### PR TITLE
sec: Harden security for Auth & Habits

### DIFF
--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -36,13 +36,14 @@ class NewPasswordController extends Controller
      */
     public function store(Request $request): RedirectResponse
     {
-        $request->validate([
+        $validated = $request->validate([
             'token' => 'required',
             'email' => 'required|email',
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'password_confirmation' => 'required',
         ]);
 
-        $status = $this->resetPassword($request);
+        $status = $this->resetPassword($validated);
 
         if ($status === Password::PASSWORD_RESET) {
             return redirect()->route('login')->with('status', __($status));
@@ -53,14 +54,17 @@ class NewPasswordController extends Controller
         ]);
     }
 
-    private function resetPassword(Request $request): string
+    /**
+     * @param  array<string, mixed>  $credentials
+     */
+    private function resetPassword(array $credentials): string
     {
         /** @var string $status */
         $status = Password::reset(
-            $request->only('email', 'password', 'password_confirmation', 'token'),
-            function (\App\Models\User $user) use ($request): void {
+            $credentials,
+            function (\App\Models\User $user) use ($credentials): void {
                 /** @var string $password */
-                $password = $request->password;
+                $password = $credentials['password'];
 
                 $user->forceFill([
                     'password' => Hash::make($password),

--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -31,16 +31,14 @@ class PasswordResetLinkController extends Controller
      */
     public function store(Request $request): RedirectResponse
     {
-        $request->validate([
+        $validated = $request->validate([
             'email' => 'required|email',
         ]);
 
         // We will send the password reset link to this user. Once we have attempted
         // to send the link, we will examine the response then see the message we
         // need to show to the user. Finally, we'll send out a proper response.
-        $status = Password::sendResetLink(
-            $request->only('email')
-        );
+        $status = Password::sendResetLink($validated);
 
         if ($status === Password::RESET_LINK_SENT) {
             return back()->with('status', __($status));

--- a/app/Http/Controllers/HabitController.php
+++ b/app/Http/Controllers/HabitController.php
@@ -74,13 +74,13 @@ class HabitController extends Controller
             abort(403);
         }
 
-        $request->validate([
+        $validated = $request->validate([
             'date' => 'required|date',
         ]);
 
-        $date = $request->date;
+        $date = $validated['date'];
 
-        $dateInput = $request->date;
+        $dateInput = $validated['date'];
         if (! is_string($dateInput)) {
             throw new \UnexpectedValueException('Date must be a string');
         }

--- a/config/database.php
+++ b/config/database.php
@@ -61,8 +61,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 
@@ -82,8 +82,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 


### PR DESCRIPTION
This PR hardens the security of the application by enforcing strict usage of validated data in `HabitController` and Auth controllers (`PasswordResetLinkController`, `NewPasswordController`). This mitigates potential mass-assignment risks and ensures data integrity.

Additionally, it fixes a `config/database.php` issue where `\Pdo\Mysql` constants caused errors in PHP 8.3 environments, replacing them with `PDO::MYSQL_ATTR_` constants.

Tests passed:
- `tests/Feature/HabitTest.php`
- `tests/Feature/Auth/PasswordResetTest.php`


---
*PR created automatically by Jules for task [14468968723116317810](https://jules.google.com/task/14468968723116317810) started by @kuasar-mknd*