### PR TITLE
feat(backend): Implement CRUD for WarmupPreference

### DIFF
--- a/app/Http/Controllers/Api/WarmupPreferenceController.php
+++ b/app/Http/Controllers/Api/WarmupPreferenceController.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Requests\Api\WarmupPreferenceStoreRequest;
+use App\Http\Requests\Api\WarmupPreferenceUpdateRequest;
+use App\Http\Resources\WarmupPreferenceResource;
+use App\Models\WarmupPreference;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class WarmupPreferenceController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): AnonymousResourceCollection
+    {
+        $this->authorize('viewAny', WarmupPreference::class);
+
+        $preferences = QueryBuilder::for(WarmupPreference::class)
+            ->where('user_id', $this->user()->id)
+            ->allowedSorts(['created_at', 'updated_at'])
+            ->get();
+
+        return WarmupPreferenceResource::collection($preferences);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(WarmupPreferenceStoreRequest $request): JsonResponse
+    {
+        $this->authorize('create', WarmupPreference::class);
+
+        $validated = $request->validated();
+        $validated['user_id'] = $this->user()->id;
+
+        $preference = WarmupPreference::create($validated);
+
+        return (new WarmupPreferenceResource($preference))
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(WarmupPreference $warmup_preference): WarmupPreferenceResource
+    {
+        $this->authorize('view', $warmup_preference);
+
+        return new WarmupPreferenceResource($warmup_preference);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(WarmupPreferenceUpdateRequest $request, WarmupPreference $warmup_preference): WarmupPreferenceResource
+    {
+        $this->authorize('update', $warmup_preference);
+
+        $warmup_preference->update($request->validated());
+
+        return new WarmupPreferenceResource($warmup_preference);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(WarmupPreference $warmup_preference): Response
+    {
+        $this->authorize('delete', $warmup_preference);
+
+        $warmup_preference->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Api/WarmupPreferenceStoreRequest.php
+++ b/app/Http/Requests/Api/WarmupPreferenceStoreRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class WarmupPreferenceStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'bar_weight' => ['required', 'numeric', 'min:0'],
+            'rounding_increment' => ['required', 'numeric', 'min:0'],
+            'steps' => ['required', 'array'],
+            'steps.*.percent' => ['required', 'numeric', 'min:0', 'max:100'],
+            'steps.*.reps' => ['required', 'integer', 'min:1'],
+            'steps.*.label' => ['nullable', 'string', 'max:50'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/WarmupPreferenceUpdateRequest.php
+++ b/app/Http/Requests/Api/WarmupPreferenceUpdateRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class WarmupPreferenceUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'bar_weight' => ['sometimes', 'numeric', 'min:0'],
+            'rounding_increment' => ['sometimes', 'numeric', 'min:0'],
+            'steps' => ['sometimes', 'array'],
+            'steps.*.percent' => ['required_with:steps', 'numeric', 'min:0', 'max:100'],
+            'steps.*.reps' => ['required_with:steps', 'integer', 'min:1'],
+            'steps.*.label' => ['nullable', 'string', 'max:50'],
+        ];
+    }
+}

--- a/app/Http/Resources/WarmupPreferenceResource.php
+++ b/app/Http/Resources/WarmupPreferenceResource.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\WarmupPreference
+ */
+class WarmupPreferenceResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'bar_weight' => $this->bar_weight,
+            'rounding_increment' => $this->rounding_increment,
+            'steps' => $this->steps,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Policies/WarmupPreferencePolicy.php
+++ b/app/Policies/WarmupPreferencePolicy.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\WarmupPreference;
+
+class WarmupPreferencePolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, WarmupPreference $warmupPreference): bool
+    {
+        return $user->id === $warmupPreference->user_id;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, WarmupPreference $warmupPreference): bool
+    {
+        return $user->id === $warmupPreference->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, WarmupPreference $warmupPreference): bool
+    {
+        return $user->id === $warmupPreference->user_id;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, WarmupPreference $warmupPreference): bool
+    {
+        return $user->id === $warmupPreference->user_id;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, WarmupPreference $warmupPreference): bool
+    {
+        return $user->id === $warmupPreference->user_id;
+    }
+}

--- a/config/database.php
+++ b/config/database.php
@@ -61,8 +61,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 
@@ -82,8 +82,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,7 @@ Route::prefix('v1')->middleware(['auth:sanctum', 'throttle:60,1'])->as('api.v1.'
     Route::apiResource('workout-templates', WorkoutTemplateController::class);
     Route::apiResource('daily-journals', \App\Http\Controllers\Api\DailyJournalController::class);
     Route::apiResource('notification-preferences', \App\Http\Controllers\Api\NotificationPreferenceController::class);
+    Route::apiResource('warmup-preferences', \App\Http\Controllers\Api\WarmupPreferenceController::class);
     Route::apiResource('plates', \App\Http\Controllers\Api\PlateController::class);
     Route::apiResource('habits', \App\Http\Controllers\Api\HabitController::class);
     Route::apiResource('habit-logs', \App\Http\Controllers\Api\HabitLogController::class);

--- a/tests/Feature/Api/WarmupPreferenceControllerTest.php
+++ b/tests/Feature/Api/WarmupPreferenceControllerTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Models\WarmupPreference;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
+use function Pest\Laravel\deleteJson;
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+use function Pest\Laravel\putJson;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+describe('Authenticated User', function (): void {
+    beforeEach(function (): void {
+        $this->user = User::factory()->create();
+        Sanctum::actingAs($this->user);
+    });
+
+    test('user can list their warmup preferences', function (): void {
+        $preference = WarmupPreference::create([
+            'user_id' => $this->user->id,
+            'bar_weight' => 20,
+            'rounding_increment' => 2.5,
+            'steps' => [['percent' => 50, 'reps' => 10, 'label' => 'Warmup']],
+        ]);
+
+        $response = getJson(route('api.v1.warmup-preferences.index'));
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonFragment([
+                'id' => $preference->id,
+                'bar_weight' => 20,
+            ]);
+    });
+
+    test('user cannot see other users warmup preferences', function (): void {
+        $otherUser = User::factory()->create();
+        WarmupPreference::create([
+            'user_id' => $otherUser->id,
+            'bar_weight' => 20,
+            'rounding_increment' => 2.5,
+            'steps' => [],
+        ]);
+
+        $response = getJson(route('api.v1.warmup-preferences.index'));
+
+        $response->assertOk()
+            ->assertJsonCount(0, 'data');
+    });
+
+    test('user can create a warmup preference', function (): void {
+        $data = [
+            'bar_weight' => 20,
+            'rounding_increment' => 2.5,
+            'steps' => [['percent' => 50, 'reps' => 10, 'label' => 'Warmup']],
+        ];
+
+        $response = postJson(route('api.v1.warmup-preferences.store'), $data);
+
+        $response->assertCreated()
+            ->assertJsonFragment([
+                'bar_weight' => 20,
+            ]);
+
+        assertDatabaseHas('warmup_preferences', [
+            'user_id' => $this->user->id,
+            'bar_weight' => 20,
+        ]);
+    });
+
+    test('user can view their own warmup preference', function (): void {
+        $preference = WarmupPreference::create([
+            'user_id' => $this->user->id,
+            'bar_weight' => 20,
+            'rounding_increment' => 2.5,
+            'steps' => [['percent' => 50, 'reps' => 10, 'label' => 'Warmup']],
+        ]);
+
+        $response = getJson(route('api.v1.warmup-preferences.show', $preference));
+
+        $response->assertOk()
+            ->assertJsonFragment([
+                'id' => $preference->id,
+                'bar_weight' => 20,
+            ]);
+    });
+
+    test('user cannot view others warmup preference', function (): void {
+        $otherUser = User::factory()->create();
+        $preference = WarmupPreference::create([
+            'user_id' => $otherUser->id,
+            'bar_weight' => 20,
+            'rounding_increment' => 2.5,
+            'steps' => [],
+        ]);
+
+        $response = getJson(route('api.v1.warmup-preferences.show', $preference));
+
+        $response->assertForbidden();
+    });
+
+    test('user can update their warmup preference', function (): void {
+        $preference = WarmupPreference::create([
+            'user_id' => $this->user->id,
+            'bar_weight' => 20,
+            'rounding_increment' => 2.5,
+            'steps' => [['percent' => 50, 'reps' => 10, 'label' => 'Warmup']],
+        ]);
+
+        $response = putJson(route('api.v1.warmup-preferences.update', $preference), [
+            'bar_weight' => 25,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonFragment([
+                'bar_weight' => 25,
+            ]);
+
+        assertDatabaseHas('warmup_preferences', [
+            'id' => $preference->id,
+            'bar_weight' => 25,
+        ]);
+    });
+
+    test('user cannot update others warmup preference', function (): void {
+        $otherUser = User::factory()->create();
+        $preference = WarmupPreference::create([
+            'user_id' => $otherUser->id,
+            'bar_weight' => 20,
+            'rounding_increment' => 2.5,
+            'steps' => [],
+        ]);
+
+        $response = putJson(route('api.v1.warmup-preferences.update', $preference), [
+            'bar_weight' => 25,
+        ]);
+
+        $response->assertForbidden();
+    });
+
+    test('user can delete their warmup preference', function (): void {
+        $preference = WarmupPreference::create([
+            'user_id' => $this->user->id,
+            'bar_weight' => 20,
+            'rounding_increment' => 2.5,
+            'steps' => [],
+        ]);
+
+        $response = deleteJson(route('api.v1.warmup-preferences.destroy', $preference));
+
+        $response->assertNoContent();
+
+        assertDatabaseMissing('warmup_preferences', ['id' => $preference->id]);
+    });
+
+    test('user cannot delete others warmup preference', function (): void {
+        $otherUser = User::factory()->create();
+        $preference = WarmupPreference::create([
+            'user_id' => $otherUser->id,
+            'bar_weight' => 20,
+            'rounding_increment' => 2.5,
+            'steps' => [],
+        ]);
+
+        $response = deleteJson(route('api.v1.warmup-preferences.destroy', $preference));
+
+        $response->assertForbidden();
+
+        assertDatabaseHas('warmup_preferences', ['id' => $preference->id]);
+    });
+});
+
+describe('Unauthenticated User', function (): void {
+    test('guest cannot list warmup preferences', function (): void {
+        $response = getJson(route('api.v1.warmup-preferences.index'));
+        $response->assertUnauthorized();
+    });
+
+    test('guest cannot create warmup preference', function (): void {
+        $response = postJson(route('api.v1.warmup-preferences.store'), []);
+        $response->assertUnauthorized();
+    });
+
+    test('guest cannot view warmup preference', function (): void {
+        $user = User::factory()->create();
+        $preference = WarmupPreference::create([
+            'user_id' => $user->id,
+            'bar_weight' => 20,
+            'rounding_increment' => 2.5,
+            'steps' => [],
+        ]);
+        $response = getJson(route('api.v1.warmup-preferences.show', $preference));
+        $response->assertUnauthorized();
+    });
+
+    test('guest cannot update warmup preference', function (): void {
+        $user = User::factory()->create();
+        $preference = WarmupPreference::create([
+            'user_id' => $user->id,
+            'bar_weight' => 20,
+            'rounding_increment' => 2.5,
+            'steps' => [],
+        ]);
+        $response = putJson(route('api.v1.warmup-preferences.update', $preference), []);
+        $response->assertUnauthorized();
+    });
+
+    test('guest cannot delete warmup preference', function (): void {
+        $user = User::factory()->create();
+        $preference = WarmupPreference::create([
+            'user_id' => $user->id,
+            'bar_weight' => 20,
+            'rounding_increment' => 2.5,
+            'steps' => [],
+        ]);
+        $response = deleteJson(route('api.v1.warmup-preferences.destroy', $preference));
+        $response->assertUnauthorized();
+    });
+});


### PR DESCRIPTION
Implemented full CRUD API for WarmupPreference model including Controller, Resource, Requests, Policy, Routes, and Tests. Also fixed database configuration for PHP 8.3.

---
*PR created automatically by Jules for task [6312386729698117162](https://jules.google.com/task/6312386729698117162) started by @kuasar-mknd*