### PR TITLE
🎨 Palette: Fix duplicate labels & add clear button to GlassInput

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-05-23 - Visual Regression with Transparent Glass Overlays
 **Learning:** Applying transparent/glassy backgrounds (`bg-white/60`) to elements positioned over borders (like dividers) causes the underlying border to show through the text, looking like a strikethrough.
 **Action:** When using glass effects on overlay elements, restructure the layout (e.g., using flexbox with side lines) to ensure the background behind the transparent element is clear, rather than relying on opacity masking.
+
+## 2026-06-15 - Duplicate Labels in Variant-Based Components
+**Learning:** Components that render different layouts based on a `variant` prop (like `GlassInput`) may accidentally render the label multiple times if the label logic is not conditional on the variant, causing confusion for screen readers.
+**Action:** When implementing variant-based components, explicitly check if the label is handled inside the variant block and suppress the default label rendering to avoid duplication.

--- a/resources/js/Components/UI/GlassInput.vue
+++ b/resources/js/Components/UI/GlassInput.vue
@@ -50,12 +50,34 @@ const sizeClasses = {
     lg: 'min-h-[56px] text-lg rounded-2xl',
     fat: 'text-[4.5rem] leading-none rounded-[2rem] p-5',
 }
+
+// Clear button logic
+const hasClearButton = computed(() => {
+    return ['text', 'search', 'email', 'url', 'tel'].includes(props.type)
+})
+
+const showClearButton = computed(() => {
+    return (
+        hasClearButton.value &&
+        props.modelValue &&
+        String(props.modelValue).length > 0 &&
+        !attrs.disabled &&
+        !attrs.readonly
+    )
+})
+
+const isRequired = computed(() => {
+    // Check for 'required' in attrs (Vue treats presence as empty string usually, or true if bound)
+    return 'required' in attrs && attrs.required !== false
+})
 </script>
 
 <template>
     <div class="w-full">
-        <label v-if="label" :for="inputId" class="font-display-label text-text-muted mb-2 block">
+        <!-- Main Label (Hidden for 'fat' variant to avoid duplication) -->
+        <label v-if="label && variant !== 'fat'" :for="inputId" class="font-display-label text-text-muted mb-2 block">
             {{ label }}
+            <span v-if="isRequired" class="ml-0.5 text-red-500" aria-hidden="true">*</span>
         </label>
 
         <!-- Fat numeric input for workout logging -->
@@ -102,7 +124,7 @@ const sizeClasses = {
         </div>
 
         <!-- Standard input -->
-        <template v-else>
+        <div v-else class="relative">
             <input
                 :id="inputId"
                 :type="type"
@@ -116,13 +138,27 @@ const sizeClasses = {
                     sizeClasses[size],
                     {
                         'border-red-500 focus:border-red-500 focus:ring-red-500/20': error,
+                        'pr-10': hasClearButton, // Add padding for clear button
                     },
                 ]"
                 v-bind="$attrs"
             />
-            <p v-if="error" :id="errorId" class="mt-2 text-sm font-medium text-red-600">
-                {{ error }}
-            </p>
-        </template>
+
+            <!-- Clear Button -->
+            <button
+                v-if="showClearButton"
+                type="button"
+                @click="$emit('update:modelValue', '')"
+                class="text-text-muted hover:text-text-main absolute top-1/2 right-3 -translate-y-1/2 rounded-full p-1 transition-colors"
+                aria-label="Effacer le texte"
+                tabindex="-1"
+            >
+                <span class="material-symbols-outlined text-lg leading-none">cancel</span>
+            </button>
+        </div>
+
+        <p v-if="error" :id="errorId" class="mt-2 text-sm font-medium text-red-600">
+            {{ error }}
+        </p>
     </div>
 </template>


### PR DESCRIPTION
💡 What:
- Fixed a bug where the label was rendered twice in the 'fat' variant of GlassInput.
- Added a "Clear" button (x) to standard text inputs when they have a value.
- Added a visual red asterisk indicator for required fields.

🎯 Why:
- Duplicate labels confuse screen readers and users.
- Clearing text on mobile is tedious without a clear button.
- Required fields should be visually distinct.

♿ Accessibility:
- Suppressed duplicate label for 'fat' variant.
- Added 'aria-label' to the clear button.
- Added 'aria-hidden="true"' to the asterisk.

---
*PR created automatically by Jules for task [10673559008171823237](https://jules.google.com/task/10673559008171823237) started by @kuasar-mknd*