### PR TITLE
🛡️ Sentinel: [Security Enhancement] Add SQL injection warnings and fix DB config

### DIFF
--- a/app/Http/Controllers/SupplementController.php
+++ b/app/Http/Controllers/SupplementController.php
@@ -118,6 +118,7 @@ class SupplementController extends Controller
         $usageHistoryRaw = SupplementLog::where('user_id', $user->id)
             ->where('consumed_at', '>=', now()->subDays($days)->startOfDay())
             ->select(
+                // SECURITY: Static DB::raw - safe. DO NOT concatenate user input here.
                 DB::raw('DATE(consumed_at) as date'),
                 DB::raw('SUM(quantity) as count')
             )

--- a/app/Services/StatsService.php
+++ b/app/Services/StatsService.php
@@ -381,6 +381,7 @@ final class StatsService
             $query->where('workouts.started_at', '>=', $start);
         }
 
+        // SECURITY: Static DB::raw - safe. DO NOT concatenate user input here.
         return (float) $query->sum(DB::raw('sets.weight * sets.reps'));
     }
 
@@ -397,6 +398,7 @@ final class StatsService
             ->where('workouts.user_id', $user->id)
             ->whereBetween('workouts.started_at', [$startOfWeek, $endOfWeek])
             ->select(
+                // SECURITY: Static DB::raw - safe. DO NOT concatenate user input here.
                 DB::raw('DATE(workouts.started_at) as date'),
                 DB::raw('COALESCE(SUM(sets.weight * sets.reps), 0) as volume')
             )
@@ -536,6 +538,7 @@ final class StatsService
                 'workouts.id',
                 'workouts.started_at',
                 'workouts.name',
+                // SECURITY: Static DB::raw - safe. DO NOT concatenate user input here.
                 DB::raw('COALESCE(SUM(sets.weight * sets.reps), 0) as volume')
             )
             ->groupBy('workouts.id', 'workouts.started_at', 'workouts.name')
@@ -557,6 +560,7 @@ final class StatsService
             ->where('workouts.user_id', $user->id)
             ->whereBetween('workouts.started_at', [$start, now()->endOfDay()])
             ->select(
+                // SECURITY: Static DB::raw - safe. DO NOT concatenate user input here.
                 DB::raw('DATE(workouts.started_at) as date'),
                 DB::raw('COALESCE(SUM(sets.weight * sets.reps), 0) as volume')
             )
@@ -580,6 +584,7 @@ final class StatsService
             ->join('exercises', 'workout_lines.exercise_id', '=', 'exercises.id')
             ->where('workouts.user_id', $user->id)
             ->where('workouts.started_at', '>=', now()->subDays($days))
+            // SECURITY: Static selectRaw - safe. DO NOT concatenate user input here.
             ->selectRaw('exercises.category, SUM(sets.weight * sets.reps) as volume')
             ->groupBy('exercises.category')
             ->get();
@@ -601,6 +606,7 @@ final class StatsService
             ->where('workouts.user_id', $user->id)
             ->where('workout_lines.exercise_id', $exerciseId)
             ->where('workouts.started_at', '>=', now()->subDays($days))
+            // SECURITY: Static selectRaw - safe. DO NOT concatenate user input here.
             ->selectRaw('workouts.started_at, MAX(sets.weight * (1 + sets.reps / 30.0)) as epley_1rm')
             ->groupBy('workouts.started_at')
             ->orderBy('workouts.started_at')

--- a/config/database.php
+++ b/config/database.php
@@ -61,8 +61,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 
@@ -82,8 +82,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "html",
+    "name": "app",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {


### PR DESCRIPTION
This PR addresses a security enhancement item from `SECURITY_PLAN.md` by adding explicit warning comments to `DB::raw` usages in `StatsService` and `SupplementController`. This serves as a guardrail for future development to prevent SQL injection vulnerabilities.

Additionally, it fixes a configuration issue in `config/database.php` where non-existent `\Pdo\Mysql` class constants were causing static analysis (PHPStan) failures in the current PHP 8.3 environment.

Verified by running `npm run lint:php`, `npm run format`, and `composer run test`.

---
*PR created automatically by Jules for task [4779474984349584394](https://jules.google.com/task/4779474984349584394) started by @kuasar-mknd*