### PR TITLE
refactor: Extract logic from SupplementController

### DIFF
--- a/app/Actions/Supplements/FetchSupplementsIndexAction.php
+++ b/app/Actions/Supplements/FetchSupplementsIndexAction.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Supplements;
+
+use App\Models\Supplement;
+use App\Models\SupplementLog;
+use App\Models\User;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class FetchSupplementsIndexAction
+{
+    /** @return array<string, mixed> */
+    public function execute(User $user): array
+    {
+        return [
+            'supplements' => $this->getSupplementsWithLatestLog($user),
+            'usageHistory' => $this->getUsageHistory($user),
+        ];
+    }
+
+    /** @return \Illuminate\Support\Collection<int, mixed> */
+    private function getSupplementsWithLatestLog(User $user): Collection
+    {
+        return Supplement::forUser($user->id)
+            ->with(['latestLog'])
+            ->get()
+            ->map(fn (Supplement $supplement): array => [
+                'id' => (int) $supplement->id,
+                'name' => (string) $supplement->name,
+                'icon' => 'heroicon-o-beaker',
+                'current_log' => (float) ($supplement->latestLog->quantity ?? 0.0),
+                'unit' => 'servings',
+                'daily_goal' => null,
+            ]);
+    }
+
+    /** @return array<int, array{date: string, count: float}> */
+    private function getUsageHistory(User $user): array
+    {
+        $days = 30;
+        /** @var \Illuminate\Support\Collection<string, float> $usageHistoryRaw */
+        $usageHistoryRaw = SupplementLog::where('user_id', $user->id)
+            ->where('consumed_at', '>=', now()->subDays($days)->startOfDay())
+            ->select(DB::raw('DATE(consumed_at) as date'), DB::raw('SUM(quantity) as count'))
+            ->groupBy('date')
+            ->get()
+            ->pluck('count', 'date');
+
+        return $this->fillUsageHistory($usageHistoryRaw, $days);
+    }
+
+    /**
+     * @param  \Illuminate\Support\Collection<string, float>  $usageHistoryRaw
+     * @return array<int, array{date: string, count: float}>
+     */
+    private function fillUsageHistory(Collection $usageHistoryRaw, int $days): array
+    {
+        $history = [];
+        for ($i = $days - 1; $i >= 0; $i--) {
+            $carbonDate = now()->subDays($i);
+            $history[] = [
+                'date' => $carbonDate->format('d/m'),
+                'count' => (float) ($usageHistoryRaw->get($carbonDate->format('Y-m-d')) ?? 0.0),
+            ];
+        }
+
+        return $history;
+    }
+}

--- a/app/Http/Controllers/SupplementController.php
+++ b/app/Http/Controllers/SupplementController.php
@@ -4,24 +4,17 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Actions\Supplements\FetchSupplementsIndexAction;
 use App\Models\Supplement;
 use App\Models\SupplementLog;
-use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 
 class SupplementController extends Controller
 {
-    public function index(): \Inertia\Response
+    public function index(FetchSupplementsIndexAction $fetchSupplements): \Inertia\Response
     {
-        /** @var User $user */
-        $user = $this->user();
-
-        return Inertia::render('Supplements/Index', [
-            'supplements' => $this->getSupplementsWithLatestLog($user),
-            'usageHistory' => $this->getUsageHistory($user),
-        ]);
+        return Inertia::render('Supplements/Index', $fetchSupplements->execute($this->user()));
     }
 
     public function store(Request $request): \Illuminate\Http\RedirectResponse
@@ -88,69 +81,5 @@ class SupplementController extends Controller
         }
 
         return redirect()->back()->with('success', 'Consommation enregistrée.');
-    }
-
-    /**
-     * @return \Illuminate\Support\Collection<int, mixed>
-     */
-    protected function getSupplementsWithLatestLog(User $user): \Illuminate\Support\Collection
-    {
-        /** @var \Illuminate\Support\Collection<int, mixed> $results */
-        $results = Supplement::forUser($user->id)
-            ->with(['latestLog'])
-            ->get()
-            ->map(fn (Supplement $supplement): array => [
-                'id' => (int) $supplement->id,
-                'name' => (string) $supplement->name,
-                'icon' => 'heroicon-o-beaker',
-                'current_log' => (float) ($supplement->latestLog->quantity ?? 0.0),
-                'unit' => 'servings',
-                'daily_goal' => null,
-            ]);
-
-        return $results;
-    }
-
-    /** @return array<int, array{date: string, count: float}> */
-    private function getUsageHistory(User $user): array
-    {
-        $days = 30;
-        $usageHistoryRaw = SupplementLog::where('user_id', $user->id)
-            ->where('consumed_at', '>=', now()->subDays($days)->startOfDay())
-            ->select(
-                DB::raw('DATE(consumed_at) as date'),
-                DB::raw('SUM(quantity) as count')
-            )
-            ->groupBy('date')
-            ->get()
-            ->pluck('count', 'date');
-
-        /** @var \Illuminate\Support\Collection<string, float> $results */
-        $results = $usageHistoryRaw;
-
-        return $this->fillUsageHistory($results, $days);
-    }
-
-    /**
-     * @param  \Illuminate\Support\Collection<string, float>  $usageHistoryRaw
-     * @return array<int, array{date: string, count: float}>
-     */
-    private function fillUsageHistory(\Illuminate\Support\Collection $usageHistoryRaw, int $days): array
-    {
-        $history = [];
-        for ($i = $days - 1; $i >= 0; $i--) {
-            $carbonDate = now()->subDays($i);
-            $dateKey = $carbonDate->format('Y-m-d');
-            $dateString = $carbonDate->format('d/m');
-
-            $rawTotal = $usageHistoryRaw[$dateKey] ?? 0.0;
-
-            $history[] = [
-                'date' => $dateString,
-                'count' => (float) $rawTotal,
-            ];
-        }
-
-        return $history;
     }
 }


### PR DESCRIPTION
Refactored `SupplementController` by extracting the `index` method's business logic into a dedicated Action class `FetchSupplementsIndexAction`. This reduces the controller's complexity and adheres to the project's strict coding standards (Skinny Controllers, max 15 lines per method). The logic for fetching supplements with their latest logs and calculating usage history is now encapsulated in the Action. The code was formatted using Pint.

---
*PR created automatically by Jules for task [8531932344720233087](https://jules.google.com/task/8531932344720233087) started by @kuasar-mknd*