### PR TITLE
test: Add Pest coverage for WaterController

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -61,8 +61,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 
@@ -82,8 +82,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 

--- a/tests/Feature/WaterTrackerTest.php
+++ b/tests/Feature/WaterTrackerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Models\User;
+use App\Models\WaterLog;
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('water tracker page is displayed', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('tools.water.index'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('Tools/WaterTracker')
+            ->has('logs')
+            ->has('todayTotal')
+            ->has('history')
+            ->has('goal')
+        );
+});
+
+test('user can log water consumption', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('tools.water.store'), [
+            'amount' => 500,
+            'consumed_at' => now()->toDateTimeString(),
+        ])
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('water_logs', [
+        'user_id' => $user->id,
+        'amount' => 500,
+    ]);
+});
+
+test('validation errors for water logging', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('tools.water.store'), [
+            'amount' => '',
+        ])
+        ->assertSessionHasErrors(['amount', 'consumed_at']);
+});
+
+test('user can delete water log', function () {
+    $user = User::factory()->create();
+    $log = WaterLog::factory()->create(['user_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->delete(route('tools.water.destroy', $log))
+        ->assertRedirect();
+
+    $this->assertDatabaseMissing('water_logs', [
+        'id' => $log->id,
+    ]);
+});
+
+test('user cannot delete others water log', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+    $log = WaterLog::factory()->create(['user_id' => $user2->id]);
+
+    $this->actingAs($user1)
+        ->delete(route('tools.water.destroy', $log))
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('water_logs', [
+        'id' => $log->id,
+    ]);
+});


### PR DESCRIPTION
Added comprehensive Pest feature tests for `WaterController`.
Covered:
- Index page rendering.
- Logging water consumption (Store).
- Validation for water logging.
- Deleting water logs.
- Authorization checks for deletion.

Also addressed a PHP 8.3 compatibility issue in `config/database.php` where `\Pdo\Mysql` (PHP 8.4+) was used.

---
*PR created automatically by Jules for task [18257340295196188024](https://jules.google.com/task/18257340295196188024) started by @kuasar-mknd*