### PR TITLE
test: Add Pest coverage for WaterController

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -61,8 +61,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 
@@ -82,8 +82,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 

--- a/tests/Feature/WaterTrackerTest.php
+++ b/tests/Feature/WaterTrackerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Models\User;
+use App\Models\WaterLog;
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('unauthenticated users are redirected to login', function () {
+    $response = $this->get(route('tools.water.index'));
+
+    $response->assertRedirect(route('login'));
+});
+
+test('authenticated users can view water tracker', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)
+        ->get(route('tools.water.index'));
+
+    $response->assertStatus(200)
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('Tools/WaterTracker')
+            ->has('logs')
+            ->has('todayTotal')
+            ->has('history')
+            ->has('goal')
+        );
+});
+
+test('users can store water log', function () {
+    $user = User::factory()->create();
+    $date = now()->format('Y-m-d H:i:s');
+
+    $response = $this->actingAs($user)
+        ->post(route('tools.water.store'), [
+            'amount' => 500,
+            'consumed_at' => $date,
+        ]);
+
+    $response->assertRedirect();
+    $this->assertDatabaseHas('water_logs', [
+        'user_id' => $user->id,
+        'amount' => 500,
+        'consumed_at' => $date,
+    ]);
+});
+
+test('store water log validation', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)
+        ->post(route('tools.water.store'), [
+            'amount' => 'not-an-integer',
+            'consumed_at' => 'not-a-date',
+        ]);
+
+    $response->assertSessionHasErrors(['amount', 'consumed_at']);
+});
+
+test('users can delete their own water log', function () {
+    $user = User::factory()->create();
+    $log = WaterLog::factory()->create(['user_id' => $user->id]);
+
+    $response = $this->actingAs($user)
+        ->delete(route('tools.water.destroy', $log));
+
+    $response->assertRedirect();
+    $this->assertDatabaseMissing('water_logs', ['id' => $log->id]);
+});
+
+test('users cannot delete others water log', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $log = WaterLog::factory()->create(['user_id' => $otherUser->id]);
+
+    $response = $this->actingAs($user)
+        ->delete(route('tools.water.destroy', $log));
+
+    $response->assertStatus(403);
+    $this->assertDatabaseHas('water_logs', ['id' => $log->id]);
+});


### PR DESCRIPTION
- Added `tests/Feature/WaterTrackerTest.php` with comprehensive test cases for the Water Tracker tool.
- Tests include:
  - Authentication redirects.
  - Page rendering and Inertia props verification.
  - Validation logic for storing logs.
  - Successful creation of logs.
  - Authorization checks for deleting logs (cannot delete others' logs).
  - Successful deletion of own logs.
- Updated `config/database.php` to replace `\Pdo\Mysql::ATTR_SSL_CA` with `PDO::MYSQL_ATTR_SSL_CA` (and similar) to fix a fatal error in PHP 8.3 environments where `Pdo\Mysql` class (PHP 8.4+) is not available.
- Reverted unintentional `composer.lock` and `package-lock.json` changes to keep the PR clean.

---
*PR created automatically by Jules for task [8546750418526033248](https://jules.google.com/task/8546750418526033248) started by @kuasar-mknd*