### PR TITLE
feat(backend): Implement CRUD for BodyPartMeasurement

### DIFF
--- a/app/Http/Controllers/Api/BodyPartMeasurementController.php
+++ b/app/Http/Controllers/Api/BodyPartMeasurementController.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Requests\BodyPartMeasurementStoreRequest;
+use App\Http\Requests\BodyPartMeasurementUpdateRequest;
+use App\Http\Resources\BodyPartMeasurementResource;
+use App\Models\BodyPartMeasurement;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class BodyPartMeasurementController extends Controller
+{
+    public function index(): \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    {
+        $measurements = QueryBuilder::for(BodyPartMeasurement::class)
+            ->allowedSorts(['measured_at', 'value', 'part', 'created_at'])
+            ->defaultSort('-measured_at')
+            ->where('user_id', $this->user()->id)
+            ->paginate();
+
+        return BodyPartMeasurementResource::collection($measurements);
+    }
+
+    public function store(BodyPartMeasurementStoreRequest $request): BodyPartMeasurementResource
+    {
+        $measurement = new BodyPartMeasurement($request->validated());
+        $measurement->user_id = $this->user()->id;
+        $measurement->save();
+
+        return new BodyPartMeasurementResource($measurement);
+    }
+
+    public function show(BodyPartMeasurement $bodyPartMeasurement): BodyPartMeasurementResource
+    {
+        if ($bodyPartMeasurement->user_id !== $this->user()->id) {
+            abort(403);
+        }
+
+        return new BodyPartMeasurementResource($bodyPartMeasurement);
+    }
+
+    public function update(BodyPartMeasurementUpdateRequest $request, BodyPartMeasurement $bodyPartMeasurement): BodyPartMeasurementResource
+    {
+        if ($bodyPartMeasurement->user_id !== $this->user()->id) {
+            abort(403);
+        }
+
+        $bodyPartMeasurement->update($request->validated());
+
+        return new BodyPartMeasurementResource($bodyPartMeasurement);
+    }
+
+    public function destroy(BodyPartMeasurement $bodyPartMeasurement): \Illuminate\Http\Response
+    {
+        if ($bodyPartMeasurement->user_id !== $this->user()->id) {
+            abort(403);
+        }
+
+        $bodyPartMeasurement->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/BodyPartMeasurementUpdateRequest.php
+++ b/app/Http/Requests/BodyPartMeasurementUpdateRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BodyPartMeasurementUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'part' => ['sometimes', 'required', 'string', 'max:50'],
+            'value' => ['sometimes', 'required', 'numeric', 'min:0', 'max:999.99'],
+            'unit' => ['sometimes', 'required', 'string', 'in:cm,in'],
+            'measured_at' => ['sometimes', 'required', 'date', 'before_or_equal:today'],
+            'notes' => ['nullable', 'string', 'max:500'],
+        ];
+    }
+}

--- a/app/Http/Resources/BodyPartMeasurementResource.php
+++ b/app/Http/Resources/BodyPartMeasurementResource.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class BodyPartMeasurementResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'part' => $this->part,
+            'value' => (float) $this->value,
+            'unit' => $this->unit,
+            'measured_at' => $this->measured_at->format('Y-m-d'),
+            'notes' => $this->notes,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/config/database.php
+++ b/config/database.php
@@ -61,8 +61,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 
@@ -82,8 +82,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,6 +29,7 @@ Route::prefix('v1')->middleware(['auth:sanctum', 'throttle:60,1'])->as('api.v1.'
     Route::apiResource('habit-logs', \App\Http\Controllers\Api\HabitLogController::class);
     Route::apiResource('supplements', \App\Http\Controllers\Api\SupplementController::class);
     Route::apiResource('water-logs', \App\Http\Controllers\Api\WaterLogController::class);
+    Route::apiResource('body-part-measurements', \App\Http\Controllers\Api\BodyPartMeasurementController::class);
 
     Route::get('/status', fn () => response()->json(['status' => 'ok']));
 });

--- a/tests/Feature/Api/V1/BodyPartMeasurementControllerTest.php
+++ b/tests/Feature/Api/V1/BodyPartMeasurementControllerTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\BodyPartMeasurement;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BodyPartMeasurementControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_list_measurements(): void
+    {
+        $user = User::factory()->create();
+        BodyPartMeasurement::factory()->count(3)->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/body-part-measurements');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(3, 'data');
+    }
+
+    public function test_user_cannot_see_others_measurements(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        BodyPartMeasurement::factory()->create(['user_id' => $otherUser->id]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/body-part-measurements');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(0, 'data');
+    }
+
+    public function test_user_can_create_measurement(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')->postJson('/api/v1/body-part-measurements', [
+            'part' => 'bicep',
+            'value' => 35.5,
+            'unit' => 'cm',
+            'measured_at' => '2023-10-25',
+            'notes' => 'Pumped',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.part', 'bicep')
+            ->assertJsonPath('data.value', 35.5)
+            ->assertJsonPath('data.unit', 'cm')
+            ->assertJsonPath('data.measured_at', '2023-10-25');
+
+        $this->assertDatabaseHas('body_part_measurements', [
+            'user_id' => $user->id,
+            'part' => 'bicep',
+            'value' => 35.5,
+        ]);
+    }
+
+    public function test_user_can_view_own_measurement(): void
+    {
+        $user = User::factory()->create();
+        $measurement = BodyPartMeasurement::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user, 'sanctum')->getJson("/api/v1/body-part-measurements/{$measurement->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.id', $measurement->id);
+    }
+
+    public function test_user_can_update_own_measurement(): void
+    {
+        $user = User::factory()->create();
+        $measurement = BodyPartMeasurement::factory()->create([
+            'user_id' => $user->id,
+            'value' => 35.0,
+            'unit' => 'cm',
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')->putJson("/api/v1/body-part-measurements/{$measurement->id}", [
+            'part' => $measurement->part,
+            'unit' => 'cm',
+            'measured_at' => $measurement->measured_at->format('Y-m-d'),
+            'value' => 36.5,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.value', 36.5);
+
+        $this->assertDatabaseHas('body_part_measurements', [
+            'id' => $measurement->id,
+            'value' => 36.5,
+        ]);
+    }
+
+    public function test_user_can_patch_update_own_measurement(): void
+    {
+        $user = User::factory()->create();
+        $measurement = BodyPartMeasurement::factory()->create([
+            'user_id' => $user->id,
+            'value' => 35.0,
+            'part' => 'bicep',
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')->patchJson("/api/v1/body-part-measurements/{$measurement->id}", [
+            'value' => 37.0,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.value', 37)
+            ->assertJsonPath('data.part', 'bicep'); // Should remain unchanged
+
+        $this->assertDatabaseHas('body_part_measurements', [
+            'id' => $measurement->id,
+            'value' => 37.0,
+            'part' => 'bicep',
+        ]);
+    }
+
+    public function test_user_cannot_update_others_measurement(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $measurement = BodyPartMeasurement::factory()->create(['user_id' => $otherUser->id]);
+
+        $response = $this->actingAs($user, 'sanctum')->putJson("/api/v1/body-part-measurements/{$measurement->id}", [
+            'part' => 'bicep',
+            'value' => 40.0,
+            'unit' => 'cm',
+            'measured_at' => '2023-10-25',
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_user_can_delete_own_measurement(): void
+    {
+        $user = User::factory()->create();
+        $measurement = BodyPartMeasurement::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user, 'sanctum')->deleteJson("/api/v1/body-part-measurements/{$measurement->id}");
+
+        $response->assertNoContent();
+        $this->assertDatabaseMissing('body_part_measurements', ['id' => $measurement->id]);
+    }
+
+    public function test_user_cannot_delete_others_measurement(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $measurement = BodyPartMeasurement::factory()->create(['user_id' => $otherUser->id]);
+
+        $response = $this->actingAs($user, 'sanctum')->deleteJson("/api/v1/body-part-measurements/{$measurement->id}");
+
+        $response->assertForbidden();
+        $this->assertDatabaseHas('body_part_measurements', ['id' => $measurement->id]);
+    }
+
+    public function test_validation_errors(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')->postJson('/api/v1/body-part-measurements', [
+            // empty
+        ]);
+
+        $response->assertJsonValidationErrors(['part', 'value', 'unit', 'measured_at']);
+    }
+}


### PR DESCRIPTION
Implemented full CRUD API for BodyPartMeasurement model.
- Includes Controller, Resource, Request, Routes, and Tests.
- Ensures strict authorization (user can only manage their own data).
- Supports PATCH updates.
- Fixes a configuration issue in `config/database.php` regarding PDO constants.

---
*PR created automatically by Jules for task [5015922546908364647](https://jules.google.com/task/5015922546908364647) started by @kuasar-mknd*