### PR TITLE
🛡️ Sentinel: [HIGH] Fix Missing Rate Limiting on Auth Routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Users could create Personal Records linked to Workouts and Sets belonging to other users because validation only checked for ID existence (`exists:workouts,id`) without verifying ownership.
 **Learning:** Standard `exists` validation confirms a record is in the database but ignores ownership. This allows linking to private resources of others, polluting data relationships.
 **Prevention:** Always scope `exists` checks to `user_id` when validating relationships to user-owned resources: `Rule::exists('table')->where('user_id', $this->user()->id)`.
+
+## 2026-06-25 - Missing Rate Limiting on Public Auth Routes
+**Vulnerability:** The `register` and `forgot-password` POST routes in `routes/auth.php` lacked rate limiting middleware, exposing the application to account creation spam and email flooding attacks.
+**Learning:** Default Laravel authentication routes (especially from starter kits like Breeze) may not enforce rate limiting on `register` or `forgot-password` by default, focusing primarily on `login`. DoS and Spam vectors are often overlooked in default configs.
+**Prevention:** Explicitly apply `middleware('throttle:6,1')` (or strict custom limiters) to ALL public `POST` authentication endpoints in `routes/auth.php`.

--- a/config/database.php
+++ b/config/database.php
@@ -61,8 +61,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => filter_var(env('DB_SSL_VERIFY', true), FILTER_VALIDATE_BOOLEAN),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 
@@ -82,8 +82,8 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => env('DB_SSL_VERIFY', true),
             ], fn ($value): bool => ! is_null($value)) : [],
         ],
 

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -17,17 +17,20 @@ Route::middleware('guest')->group(function (): void {
     Route::get('register', [RegisteredUserController::class, 'create'])
         ->name('register');
 
-    Route::post('register', [RegisteredUserController::class, 'store']);
+    Route::post('register', [RegisteredUserController::class, 'store'])
+        ->middleware('throttle:6,1');
 
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
         ->name('login');
 
-    Route::post('login', [AuthenticatedSessionController::class, 'store']);
+    Route::post('login', [AuthenticatedSessionController::class, 'store'])
+        ->middleware('throttle:6,1');
 
     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
         ->name('password.request');
 
     Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
+        ->middleware('throttle:6,1')
         ->name('password.email');
 
     Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])

--- a/tests/Feature/Security/AuthRateLimitTest.php
+++ b/tests/Feature/Security/AuthRateLimitTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuthRateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_registration_is_rate_limited(): void
+    {
+        // Hit the endpoint 6 times (allowed)
+        for ($i = 0; $i < 6; $i++) {
+            $response = $this->post('/register', [
+                'name' => 'Test User',
+                'email' => "test{$i}@example.com",
+                'password' => 'password',
+                'password_confirmation' => 'password',
+            ]);
+
+            $this->assertNotEquals(429, $response->status(), "Request $i failed with 429");
+
+            // Successful registration logs the user in. We must logout to try registering again as a guest.
+            // This also ensures we are testing the endpoint's IP rate limiting, not user-specific limits.
+            auth()->logout();
+        }
+
+        // The 7th attempt should be blocked
+        $response = $this->post('/register', [
+            'name' => 'Test User',
+            'email' => 'test_limit@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertStatus(429);
+    }
+
+    public function test_login_is_rate_limited_by_ip(): void
+    {
+        // Hit the endpoint 6 times with different emails to bypass LoginRequest's email throttling
+        // checking that route-level throttling catches it.
+        for ($i = 0; $i < 6; $i++) {
+            $response = $this->post('/login', [
+                'email' => "test{$i}@example.com",
+                'password' => 'password',
+            ]);
+
+            $this->assertNotEquals(429, $response->status(), "Request $i failed with 429");
+        }
+
+        $response = $this->post('/login', [
+            'email' => 'test_limit@example.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertStatus(429);
+    }
+
+    public function test_forgot_password_is_rate_limited(): void
+    {
+        for ($i = 0; $i < 6; $i++) {
+            $response = $this->post('/forgot-password', [
+                'email' => "test{$i}@example.com",
+            ]);
+
+            $this->assertNotEquals(429, $response->status(), "Request $i failed with 429");
+        }
+
+        $response = $this->post('/forgot-password', [
+            'email' => 'test_limit@example.com',
+        ]);
+
+        $response->assertStatus(429);
+    }
+}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Public authentication routes (`register`, `forgot-password`) lacked rate limiting, allowing brute-force, spam, and DoS attacks.
🎯 **Impact:** Potential for account creation spam, email flooding, and service degradation.
🔧 **Fix:** Added `throttle:6,1` middleware to `register`, `login`, and `forgot-password` routes in `routes/auth.php`.
✅ **Verification:** Added `Tests\Feature\Security\AuthRateLimitTest.php` verifying 429 response after 6 attempts.

**Additional Fix:**
* Corrected `config/database.php` to use `PDO::MYSQL_ATTR_` constants instead of `\Pdo\Mysql` for PHP 8.3 compatibility, which was causing tests to fail.

---
*PR created automatically by Jules for task [12642456896476462578](https://jules.google.com/task/12642456896476462578) started by @kuasar-mknd*