### PR TITLE
sec: Harden security for API Pagination

### DIFF
--- a/app/Http/Controllers/Api/DailyJournalController.php
+++ b/app/Http/Controllers/Api/DailyJournalController.php
@@ -21,8 +21,12 @@ class DailyJournalController extends Controller
     {
         $this->authorize('viewAny', DailyJournal::class);
 
+        $validated = $request->validate([
+            'per_page' => 'sometimes|integer|min:1|max:100',
+        ]);
+
         /** @var int $perPage */
-        $perPage = $request->get('per_page', 15);
+        $perPage = $validated['per_page'] ?? 15;
 
         $journals = $this->user()->dailyJournals()
             ->orderBy('date', 'desc')

--- a/app/Http/Controllers/Api/HabitController.php
+++ b/app/Http/Controllers/Api/HabitController.php
@@ -35,8 +35,12 @@ class HabitController extends Controller
             ->defaultSort('name')
             ->where('user_id', $this->user()->id);
 
+        $validated = $request->validate([
+            'per_page' => 'sometimes|integer|min:1|max:100',
+        ]);
+
         /** @var int $perPage */
-        $perPage = $request->get('per_page', 15);
+        $perPage = $validated['per_page'] ?? 15;
 
         $habits = $query->paginate($perPage);
 


### PR DESCRIPTION
This PR addresses a potential Denial of Service (DoS) vulnerability in the API where the `per_page` parameter for pagination was unvalidated. This allowed users to potentially request an unlimited number of records, leading to resource exhaustion.

Changes:
- In `app/Http/Controllers/Api/HabitController.php`, the `index` method now strictly validates that `per_page` is an integer between 1 and 100.
- In `app/Http/Controllers/Api/DailyJournalController.php`, the `index` method now strictly validates that `per_page` is an integer between 1 and 100.

This ensures that the application remains performant and secure against malicious or accidental requests for excessive data.

---
*PR created automatically by Jules for task [12252812952848795048](https://jules.google.com/task/12252812952848795048) started by @kuasar-mknd*