### PR TITLE
feat(viz): Add Bar Chart for Water Intake History

### DIFF
--- a/app/Http/Requests/StoreWaterLogRequest.php
+++ b/app/Http/Requests/StoreWaterLogRequest.php
@@ -25,7 +25,7 @@ class StoreWaterLogRequest extends FormRequest
     {
         return [
             'amount' => ['required', 'integer', 'min:1'],
-            'consumed_at' => ['required', 'date'],
+            'consumed_at' => ['nullable', 'date'],
         ];
     }
 }

--- a/resources/js/Components/Stats/WaterIntakeChart.vue
+++ b/resources/js/Components/Stats/WaterIntakeChart.vue
@@ -1,0 +1,91 @@
+<script setup>
+import { Bar } from 'vue-chartjs'
+import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale } from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+    goal: {
+        type: Number,
+        default: 2500,
+    },
+})
+
+const chartData = computed(() => {
+    return {
+        labels: props.data.map((item) => item.day_name.substring(0, 3)),
+        datasets: [
+            {
+                label: 'Water (ml)',
+                data: props.data.map((item) => item.total),
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+                    const gradient = ctx.createLinearGradient(0, chartArea.top, 0, chartArea.bottom)
+                    gradient.addColorStop(0, '#06b6d4') // Cyan-500
+                    gradient.addColorStop(1, '#3b82f6') // Blue-500
+                    return gradient
+                },
+                borderRadius: 6,
+                hoverBackgroundColor: '#60a5fa', // Blue-400
+            },
+        ],
+    }
+})
+
+const chartOptions = computed(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+        y: {
+            beginAtZero: true,
+            suggestedMax: props.goal,
+            grid: {
+                color: 'rgba(255, 255, 255, 0.05)',
+            },
+            ticks: {
+                color: '#94a3b8', // Slate-400
+                font: { size: 10, weight: 'bold' },
+            },
+        },
+        x: {
+            grid: {
+                display: false,
+            },
+            ticks: {
+                color: '#94a3b8', // Slate-400
+                font: { size: 10, weight: 'bold' },
+            },
+        },
+    },
+    plugins: {
+        legend: {
+            display: false,
+        },
+        tooltip: {
+            backgroundColor: 'rgba(30, 41, 59, 0.9)', // Slate-800
+            titleColor: '#f8fafc',
+            bodyColor: '#f8fafc',
+            padding: 12,
+            cornerRadius: 12,
+            borderWidth: 1,
+            borderColor: 'rgba(255, 255, 255, 0.1)',
+            callbacks: {
+                label: (context) => `${context.parsed.y} ml`,
+            },
+        },
+    },
+}))
+</script>
+
+<template>
+    <div class="h-[300px] w-full">
+        <Bar :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Tools/WaterTracker.vue
+++ b/resources/js/Pages/Tools/WaterTracker.vue
@@ -160,32 +160,7 @@
                 <!-- Weekly History -->
                 <GlassCard class="animate-slide-up h-full" style="animation-delay: 0.15s">
                     <h2 class="font-display text-text-main mb-4 text-lg font-black uppercase italic">Last 7 Days</h2>
-
-                    <div class="flex h-[300px] items-end justify-between gap-2 pt-4">
-                        <div
-                            v-for="day in history"
-                            :key="day.date"
-                            class="group relative flex flex-1 flex-col items-center justify-end"
-                        >
-                            <!-- Tooltip -->
-                            <div class="absolute -top-10 opacity-0 transition-opacity group-hover:opacity-100 bg-slate-800 text-white text-xs rounded px-2 py-1 mb-2 whitespace-nowrap z-10">
-                                {{ day.total }} ml
-                            </div>
-
-                            <!-- Bar -->
-                            <div
-                                class="w-full rounded-t-lg bg-slate-100 transition-all duration-500 group-hover:bg-blue-100 relative overflow-hidden"
-                                :style="{ height: `${Math.min((day.total / goal) * 100, 100)}%` }"
-                            >
-                                <div class="absolute bottom-0 left-0 right-0 top-0 bg-blue-500/20 group-hover:bg-blue-500/30 transition-colors"></div>
-                                <!-- Fill based on goal cap? Actually visual height is mostly useful relative to goal -->
-                            </div>
-
-                            <span class="text-text-muted mt-2 text-xs font-bold uppercase truncate w-full text-center">
-                                {{ day.day_name.substring(0, 3) }}
-                            </span>
-                        </div>
-                    </div>
+                    <WaterIntakeChart :data="history" :goal="goal" />
                 </GlassCard>
             </div>
         </div>
@@ -193,11 +168,13 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, defineAsyncComponent } from 'vue'
 import { Head, useForm, router } from '@inertiajs/vue3'
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
 import GlassCard from '@/Components/UI/GlassCard.vue'
 import GlassButton from '@/Components/UI/GlassButton.vue'
+
+const WaterIntakeChart = defineAsyncComponent(() => import('@/Components/Stats/WaterIntakeChart.vue'))
 
 const props = defineProps({
     logs: {


### PR DESCRIPTION
This PR introduces a proper visualization for the Water Intake History on the Water Tracker page.

Changes:
1.  **New Component**: `resources/js/Components/Stats/WaterIntakeChart.vue`.
    -   Uses `vue-chartjs` to render a Bar chart.
    -   Implements "Liquid Glass" aesthetic consistent with the rest of the application.
    -   Visualizes daily water intake against the goal.

2.  **Page Update**: `resources/js/Pages/Tools/WaterTracker.vue`.
    -   Replaced the custom HTML/CSS implementation of the weekly history with the new Chart component.
    -   Imports the chart asynchronously.

3.  **Bug Fix**: `app/Http/Requests/StoreWaterLogRequest.php`.
    -   Changed `consumed_at` validation rule from `required` to `nullable`. The frontend does not send this field when adding water via quick buttons, and the controller is designed to fill it if missing. This fix allows the "Add Water" functionality to work correctly.

This enhances the user experience by providing a more interactive and visually appealing chart for tracking hydration progress.

---
*PR created automatically by Jules for task [3930958241331679532](https://jules.google.com/task/3930958241331679532) started by @kuasar-mknd*