### PR TITLE
feat(backend): Implement CRUD for BodyPartMeasurement

### DIFF
--- a/app/Http/Controllers/Api/BodyPartMeasurementController.php
+++ b/app/Http/Controllers/Api/BodyPartMeasurementController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Requests\BodyPartMeasurementStoreRequest;
+use App\Http\Requests\BodyPartMeasurementUpdateRequest;
+use App\Http\Resources\BodyPartMeasurementResource;
+use App\Models\BodyPartMeasurement;
+use Illuminate\Http\Response;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class BodyPartMeasurementController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    {
+        $measurements = QueryBuilder::for(BodyPartMeasurement::class)
+            ->allowedSorts(['measured_at', 'value', 'created_at', 'part'])
+            ->defaultSort('-measured_at')
+            ->where('user_id', $this->user()->id)
+            ->paginate();
+
+        return BodyPartMeasurementResource::collection($measurements);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(BodyPartMeasurementStoreRequest $request): BodyPartMeasurementResource
+    {
+        $measurement = new BodyPartMeasurement($request->validated());
+        $measurement->user_id = $this->user()->id;
+        $measurement->save();
+
+        return new BodyPartMeasurementResource($measurement);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(BodyPartMeasurement $bodyPartMeasurement): BodyPartMeasurementResource
+    {
+        if ($bodyPartMeasurement->user_id !== $this->user()->id) {
+            abort(403);
+        }
+
+        return new BodyPartMeasurementResource($bodyPartMeasurement);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(BodyPartMeasurementUpdateRequest $request, BodyPartMeasurement $bodyPartMeasurement): BodyPartMeasurementResource
+    {
+        if ($bodyPartMeasurement->user_id !== $this->user()->id) {
+            abort(403);
+        }
+
+        $bodyPartMeasurement->update($request->validated());
+
+        return new BodyPartMeasurementResource($bodyPartMeasurement);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(BodyPartMeasurement $bodyPartMeasurement): Response
+    {
+        if ($bodyPartMeasurement->user_id !== $this->user()->id) {
+            abort(403);
+        }
+
+        $bodyPartMeasurement->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/BodyPartMeasurementUpdateRequest.php
+++ b/app/Http/Requests/BodyPartMeasurementUpdateRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BodyPartMeasurementUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'part' => ['sometimes', 'required', 'string', 'max:50'],
+            'value' => ['sometimes', 'required', 'numeric', 'min:0', 'max:999.99'],
+            'unit' => ['sometimes', 'required', 'string', 'in:cm,in'],
+            'measured_at' => ['sometimes', 'required', 'date', 'before_or_equal:today'],
+            'notes' => ['nullable', 'string', 'max:500'],
+        ];
+    }
+}

--- a/app/Http/Resources/BodyPartMeasurementResource.php
+++ b/app/Http/Resources/BodyPartMeasurementResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\BodyPartMeasurement */
+class BodyPartMeasurementResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'part' => $this->part,
+            'value' => $this->value,
+            'unit' => $this->unit,
+            'measured_at' => $this->measured_at->format('Y-m-d'),
+            'notes' => $this->notes,
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ Route::prefix('v1')->middleware(['auth:sanctum', 'throttle:60,1'])->as('api.v1.'
     Route::apiResource('sets', SetController::class);
     Route::apiResource('personal-records', \App\Http\Controllers\Api\PersonalRecordController::class);
     Route::apiResource('body-measurements', BodyMeasurementController::class);
+    Route::apiResource('body-part-measurements', \App\Http\Controllers\Api\BodyPartMeasurementController::class);
     Route::apiResource('goals', GoalController::class);
     Route::apiResource('workout-templates', WorkoutTemplateController::class);
     Route::apiResource('daily-journals', \App\Http\Controllers\Api\DailyJournalController::class);

--- a/tests/Feature/Api/V1/BodyPartMeasurementTest.php
+++ b/tests/Feature/Api/V1/BodyPartMeasurementTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\BodyPartMeasurement;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BodyPartMeasurementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_list_measurements(): void
+    {
+        $user = User::factory()->create();
+        BodyPartMeasurement::factory()->count(3)->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/body-part-measurements');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(3, 'data');
+    }
+
+    public function test_user_cannot_see_others_measurements(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        BodyPartMeasurement::factory()->create(['user_id' => $otherUser->id]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/body-part-measurements');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(0, 'data');
+    }
+
+    public function test_api_is_protected(): void
+    {
+        $response = $this->getJson('/api/v1/body-part-measurements');
+        $response->assertUnauthorized();
+    }
+
+    public function test_user_can_create_measurement(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')->postJson('/api/v1/body-part-measurements', [
+            'part' => 'Biceps L',
+            'value' => 35.5,
+            'unit' => 'cm',
+            'measured_at' => '2023-10-25',
+            'notes' => 'Post workout',
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.part', 'Biceps L')
+            ->assertJsonPath('data.value', '35.50')
+            ->assertJsonPath('data.unit', 'cm')
+            ->assertJsonPath('data.measured_at', '2023-10-25');
+
+        $this->assertDatabaseHas('body_part_measurements', [
+            'user_id' => $user->id,
+            'part' => 'Biceps L',
+            'value' => 35.5,
+        ]);
+    }
+
+    public function test_user_can_view_own_measurement(): void
+    {
+        $user = User::factory()->create();
+        $measurement = BodyPartMeasurement::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user, 'sanctum')->getJson("/api/v1/body-part-measurements/{$measurement->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.id', $measurement->id);
+    }
+
+    public function test_user_can_update_own_measurement(): void
+    {
+        $user = User::factory()->create();
+        $measurement = BodyPartMeasurement::factory()->create([
+            'user_id' => $user->id,
+            'value' => 30.0,
+            'part' => 'Forearm R'
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')->putJson("/api/v1/body-part-measurements/{$measurement->id}", [
+            'value' => 31.5,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.value', '31.50');
+
+        $this->assertDatabaseHas('body_part_measurements', [
+            'id' => $measurement->id,
+            'value' => 31.5,
+        ]);
+    }
+
+    public function test_user_cannot_update_others_measurement(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $measurement = BodyPartMeasurement::factory()->create(['user_id' => $otherUser->id]);
+
+        $response = $this->actingAs($user, 'sanctum')->putJson("/api/v1/body-part-measurements/{$measurement->id}", [
+            'value' => 40.0,
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_user_can_delete_own_measurement(): void
+    {
+        $user = User::factory()->create();
+        $measurement = BodyPartMeasurement::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user, 'sanctum')->deleteJson("/api/v1/body-part-measurements/{$measurement->id}");
+
+        $response->assertNoContent();
+        $this->assertDatabaseMissing('body_part_measurements', ['id' => $measurement->id]);
+    }
+
+    public function test_user_cannot_delete_others_measurement(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $measurement = BodyPartMeasurement::factory()->create(['user_id' => $otherUser->id]);
+
+        $response = $this->actingAs($user, 'sanctum')->deleteJson("/api/v1/body-part-measurements/{$measurement->id}");
+
+        $response->assertForbidden();
+        $this->assertDatabaseHas('body_part_measurements', ['id' => $measurement->id]);
+    }
+}


### PR DESCRIPTION
Implemented full API CRUD for `BodyPartMeasurement` model.
This includes:
- Controller with Index, Store, Show, Update, Destroy.
- API Resource.
- Request validation for updates (reused existing Store request logic pattern).
- Comprehensive Feature tests covering happy paths and authorization.
- Route registration.

---
*PR created automatically by Jules for task [13300209211896073401](https://jules.google.com/task/13300209211896073401) started by @kuasar-mknd*