### PR TITLE
sec: Harden security for User Mass Assignment

### DIFF
--- a/app/Actions/ResolveSocialUserAction.php
+++ b/app/Actions/ResolveSocialUserAction.php
@@ -33,14 +33,19 @@ class ResolveSocialUserAction
 
         // Create new user
         // We use create() because all fields are in $fillable in User model
-        return User::create([
+        $user = User::create([
             'name' => $socialUser->getName() ?? $socialUser->getNickname() ?? 'Utilisateur',
             'email' => $socialUser->getEmail(),
             'password' => Str::random(16), // Random password, hashed by model cast
             'provider' => $provider,
             'provider_id' => $socialUser->getId(),
             'avatar' => $socialUser->getAvatar(),
-            'email_verified_at' => now(), // Assume email is verified by provider
         ]);
+
+        $user->forceFill([
+            'email_verified_at' => now(), // Assume email is verified by provider
+        ])->save();
+
+        return $user;
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -60,7 +60,6 @@ class User extends Authenticatable implements MustVerifyEmail
         'current_streak',
         'longest_streak',
         'last_workout_at',
-        'email_verified_at',
     ];
 
     /**

--- a/tests/Feature/Security/MassAssignmentTest.php
+++ b/tests/Feature/Security/MassAssignmentTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Security;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MassAssignmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_email_verified_at_cannot_be_mass_assigned(): void
+    {
+        $userData = [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'password',
+            'email_verified_at' => now(),
+        ];
+
+        // In strict mode (dev/test), this throws an exception.
+        // In production, it would silently discard the attribute.
+        // Both outcomes prevent mass assignment.
+        $this->expectException(\Illuminate\Database\Eloquent\MassAssignmentException::class);
+
+        new User($userData);
+    }
+
+    public function test_create_method_throws_exception_on_mass_assignment_of_protected_field(): void
+    {
+        $userData = [
+            'name' => 'Test User 2',
+            'email' => 'test2@example.com',
+            'password' => 'password',
+            'email_verified_at' => now(),
+        ];
+
+        $this->expectException(\Illuminate\Database\Eloquent\MassAssignmentException::class);
+
+        User::create($userData);
+    }
+}


### PR DESCRIPTION
This PR hardens the application security by removing `email_verified_at` from the `User` model's `$fillable` attributes. This prevents potential mass-assignment vulnerabilities where an attacker could verify their email address during registration or profile update if strict input filtering wasn't in place.

Changes:
- `app/Models/User.php`: Removed `email_verified_at` from `$fillable`.
- `app/Actions/ResolveSocialUserAction.php`: Updated to use `forceFill` for setting `email_verified_at` when creating a new user from a social provider, as it is no longer mass-assignable.
- `tests/Feature/Security/MassAssignmentTest.php`: Added a new test file to verify that `email_verified_at` throws a `MassAssignmentException` in strict mode (test environment) when attempting mass assignment.

Tests passed:
- `tests/Feature/Security/MassAssignmentTest.php`
- `tests/Feature/SocialAuthTest.php`
- `tests/Feature/Auth/RegistrationTest.php`

---
*PR created automatically by Jules for task [11530436232541339405](https://jules.google.com/task/11530436232541339405) started by @kuasar-mknd*