### PR TITLE
feat(backend): Implement CRUD for Achievement

### DIFF
--- a/app/Http/Controllers/Api/AchievementController.php
+++ b/app/Http/Controllers/Api/AchievementController.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Requests\Api\StoreAchievementRequest;
+use App\Http\Requests\Api\UpdateAchievementRequest;
+use App\Http\Resources\AchievementResource;
+use App\Models\Achievement;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class AchievementController extends Controller
+{
+    use AuthorizesRequests;
+
+    #[OA\Get(
+        path: '/achievements',
+        summary: 'Get list of achievements',
+        tags: ['Achievements']
+    )]
+    #[OA\Response(response: 200, description: 'Successful operation')]
+    #[OA\Response(response: 401, description: 'Unauthenticated')]
+    public function index(Request $request): \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    {
+        $this->authorize('viewAny', Achievement::class);
+
+        $achievements = QueryBuilder::for(Achievement::class)
+            ->allowedSorts(['name', 'created_at', 'category', 'type'])
+            ->allowedFilters(['category', 'type'])
+            ->defaultSort('name')
+            ->paginate();
+
+        return AchievementResource::collection($achievements);
+    }
+
+    #[OA\Post(
+        path: '/achievements',
+        summary: 'Create a new achievement',
+        tags: ['Achievements']
+    )]
+    #[OA\Response(response: 201, description: 'Created successfully')]
+    #[OA\Response(response: 422, description: 'Validation error')]
+    public function store(StoreAchievementRequest $request): AchievementResource
+    {
+        $this->authorize('create', Achievement::class);
+
+        /** @var array<string, mixed> $validated */
+        $validated = $request->validated();
+
+        $achievement = Achievement::create($validated);
+
+        return new AchievementResource($achievement);
+    }
+
+    #[OA\Get(
+        path: '/achievements/{achievement}',
+        summary: 'Get a specific achievement',
+        tags: ['Achievements']
+    )]
+    #[OA\Response(response: 200, description: 'Successful operation')]
+    #[OA\Response(response: 404, description: 'Not found')]
+    public function show(Achievement $achievement): AchievementResource
+    {
+        $this->authorize('view', $achievement);
+
+        return new AchievementResource($achievement);
+    }
+
+    #[OA\Put(
+        path: '/achievements/{achievement}',
+        summary: 'Update an achievement',
+        tags: ['Achievements']
+    )]
+    #[OA\Response(response: 200, description: 'Updated successfully')]
+    #[OA\Response(response: 422, description: 'Validation error')]
+    public function update(UpdateAchievementRequest $request, Achievement $achievement): AchievementResource
+    {
+        $this->authorize('update', $achievement);
+
+        /** @var array<string, mixed> $validated */
+        $validated = $request->validated();
+
+        $achievement->update($validated);
+
+        return new AchievementResource($achievement);
+    }
+
+    #[OA\Delete(
+        path: '/achievements/{achievement}',
+        summary: 'Delete an achievement',
+        tags: ['Achievements']
+    )]
+    #[OA\Response(response: 204, description: 'Deleted successfully')]
+    public function destroy(Achievement $achievement): \Illuminate\Http\Response
+    {
+        $this->authorize('delete', $achievement);
+
+        $achievement->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Api/StoreAchievementRequest.php
+++ b/app/Http/Requests/Api/StoreAchievementRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreAchievementRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'slug' => ['required', 'string', 'unique:achievements,slug', 'max:255'],
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['required', 'string'],
+            'icon' => ['required', 'string', 'max:255'],
+            'type' => ['required', 'string', 'in:count,streak,weight_record,volume_total'],
+            'threshold' => ['required', 'numeric', 'min:0'],
+            'category' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/UpdateAchievementRequest.php
+++ b/app/Http/Requests/Api/UpdateAchievementRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateAchievementRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        /** @var \App\Models\Achievement $achievement */
+        $achievement = $this->route('achievement');
+
+        return [
+            'slug' => [
+                'sometimes',
+                'string',
+                Rule::unique('achievements', 'slug')->ignore($achievement->id),
+                'max:255',
+            ],
+            'name' => ['sometimes', 'string', 'max:255'],
+            'description' => ['sometimes', 'string'],
+            'icon' => ['sometimes', 'string', 'max:255'],
+            'type' => ['sometimes', 'string', 'in:count,streak,weight_record,volume_total'],
+            'threshold' => ['sometimes', 'numeric', 'min:0'],
+            'category' => ['sometimes', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Resources/AchievementResource.php
+++ b/app/Http/Resources/AchievementResource.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Achievement
+ */
+class AchievementResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'slug' => $this->slug,
+            'name' => $this->name,
+            'description' => $this->description,
+            'icon' => $this->icon,
+            'type' => $this->type,
+            'threshold' => $this->threshold,
+            'category' => $this->category,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Route;
 Route::prefix('v1')->middleware(['auth:sanctum', 'throttle:api'])->as('api.v1.')->group(function (): void {
     Route::get('/user', fn (Request $request): \App\Http\Resources\UserResource => new \App\Http\Resources\UserResource($request->user()));
 
+    Route::apiResource('achievements', \App\Http\Controllers\Api\AchievementController::class);
     Route::apiResource('exercises', ExerciseController::class);
     Route::apiResource('plates', \App\Http\Controllers\Api\PlateController::class);
     Route::apiResource('workouts', WorkoutController::class);

--- a/tests/Feature/Api/AchievementControllerTest.php
+++ b/tests/Feature/Api/AchievementControllerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Achievement;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\deleteJson;
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+use function Pest\Laravel\putJson;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+describe('Authenticated User', function (): void {
+    beforeEach(function (): void {
+        $this->user = User::factory()->create();
+        Sanctum::actingAs($this->user);
+    });
+
+    test('user can list achievements', function (): void {
+        Achievement::factory()->count(3)->create();
+
+        $response = getJson(route('api.v1.achievements.index'));
+
+        $response->assertOk()
+            ->assertJsonCount(3, 'data')
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => [
+                        'id',
+                        'slug',
+                        'name',
+                        'description',
+                        'icon',
+                        'type',
+                        'threshold',
+                        'category',
+                    ],
+                ],
+                'links',
+                'meta',
+            ]);
+    });
+
+    test('user can view a specific achievement', function (): void {
+        $achievement = Achievement::factory()->create();
+
+        $response = getJson(route('api.v1.achievements.show', $achievement));
+
+        $response->assertOk()
+            ->assertJsonFragment([
+                'id' => $achievement->id,
+                'slug' => $achievement->slug,
+            ]);
+    });
+
+    test('user cannot create achievement', function (): void {
+        $data = [
+            'slug' => 'test-achievement',
+            'name' => 'Test Achievement',
+            'description' => 'Description',
+            'icon' => '🏆',
+            'type' => 'streak',
+            'threshold' => 10,
+            'category' => 'general',
+        ];
+
+        $response = postJson(route('api.v1.achievements.store'), $data);
+
+        $response->assertForbidden();
+    });
+
+    test('user cannot update achievement', function (): void {
+        $achievement = Achievement::factory()->create();
+
+        $response = putJson(route('api.v1.achievements.update', $achievement), [
+            'name' => 'Updated Name',
+        ]);
+
+        $response->assertForbidden();
+    });
+
+    test('user cannot delete achievement', function (): void {
+        $achievement = Achievement::factory()->create();
+
+        $response = deleteJson(route('api.v1.achievements.destroy', $achievement));
+
+        $response->assertForbidden();
+    });
+});
+
+describe('Unauthenticated User', function (): void {
+    test('guest cannot list achievements', function (): void {
+        $response = getJson(route('api.v1.achievements.index'));
+        $response->assertUnauthorized();
+    });
+
+    test('guest cannot view achievement', function (): void {
+        $achievement = Achievement::factory()->create();
+        $response = getJson(route('api.v1.achievements.show', $achievement));
+        $response->assertUnauthorized();
+    });
+});


### PR DESCRIPTION
This PR implements the missing API Controller for the `Achievement` model. It includes:

1.  **Controller**: `App\Http\Controllers\Api\AchievementController` implementing standard CRUD operations using `Spatie\QueryBuilder` and `AuthorizesRequests`.
2.  **Requests**: `StoreAchievementRequest` and `UpdateAchievementRequest` for validation.
3.  **Resource**: `AchievementResource` for JSON transformation.
4.  **Routes**: API resource route registered in `routes/api.php`.
5.  **Tests**: Comprehensive feature tests covering all endpoints and policy enforcement.

Note: The `AchievementPolicy` restricts modification (create/update/delete) to users with specific permissions. Regular users are restricted to `index` and `show`, returning 403 Forbidden for write operations, which is verified by tests.

Also fixed a testing environment issue where `spatie/laravel-backup` caused failures due to missing email configuration by adding `MAIL_FROM_ADDRESS` and `BACKUP_NOTIFICATION_EMAIL` to `phpunit.xml`.

---
*PR created automatically by Jules for task [7104390104193169504](https://jules.google.com/task/7104390104193169504) started by @kuasar-mknd*