### PR TITLE
feat(backend): Implement CRUD for Achievement

### DIFF
--- a/app/Http/Controllers/Api/AchievementController.php
+++ b/app/Http/Controllers/Api/AchievementController.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\StoreAchievementRequest;
+use App\Http\Requests\Api\UpdateAchievementRequest;
+use App\Http\Resources\AchievementResource;
+use App\Models\Achievement;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+
+class AchievementController extends Controller
+{
+    public function __construct()
+    {
+        $this->authorizeResource(Achievement::class, 'achievement');
+    }
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): AnonymousResourceCollection
+    {
+        return AchievementResource::collection(Achievement::paginate());
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreAchievementRequest $request): AchievementResource
+    {
+        $achievement = Achievement::create($request->validated());
+
+        return new AchievementResource($achievement);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Achievement $achievement): AchievementResource
+    {
+        return new AchievementResource($achievement);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdateAchievementRequest $request, Achievement $achievement): AchievementResource
+    {
+        $achievement->update($request->validated());
+
+        return new AchievementResource($achievement);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Achievement $achievement): Response
+    {
+        $achievement->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Api/StoreAchievementRequest.php
+++ b/app/Http/Requests/Api/StoreAchievementRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreAchievementRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'slug' => ['required', 'string', 'max:255', Rule::unique('achievements')],
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['required', 'string'],
+            'icon' => ['required', 'string', 'max:255'],
+            'type' => ['required', 'string', 'max:255'],
+            'threshold' => ['required', 'numeric', 'min:0'],
+            'category' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/UpdateAchievementRequest.php
+++ b/app/Http/Requests/Api/UpdateAchievementRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateAchievementRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        /** @var \App\Models\Achievement $achievement */
+        $achievement = $this->route('achievement');
+
+        return [
+            'slug' => ['sometimes', 'required', 'string', 'max:255', Rule::unique('achievements')->ignore($achievement->id)],
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'description' => ['sometimes', 'required', 'string'],
+            'icon' => ['sometimes', 'required', 'string', 'max:255'],
+            'type' => ['sometimes', 'required', 'string', 'max:255'],
+            'threshold' => ['sometimes', 'required', 'numeric', 'min:0'],
+            'category' => ['sometimes', 'required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Route;
 Route::prefix('v1')->middleware(['auth:sanctum', app()->isProduction() ? 'throttle:60,1' : 'throttle:1000,1'])->as('api.v1.')->group(function (): void {
     Route::get('/user', fn (Request $request): \App\Http\Resources\UserResource => new \App\Http\Resources\UserResource($request->user()));
 
-    // Route::apiResource('achievements', \App\Http\Controllers\Api\AchievementController::class);
+    Route::apiResource('achievements', \App\Http\Controllers\Api\AchievementController::class);
     Route::apiResource('user-achievements', \App\Http\Controllers\Api\UserAchievementController::class);
     Route::apiResource('exercises', ExerciseController::class);
     Route::apiResource('plates', \App\Http\Controllers\Api\PlateController::class);


### PR DESCRIPTION
This PR implements a full CRUD REST API for the `Achievement` model as requested.

Changes:
- Added `app/Http/Controllers/Api/AchievementController.php` with `index`, `show`, `store`, `update`, `destroy` endpoints using Route Model Binding and API Resources (`AchievementResource`).
- The controller uses `$this->authorizeResource()` relying on the existing `AchievementPolicy`.
- Replaced stubbed forms with validation logic in `app/Http/Requests/Api/StoreAchievementRequest.php` and `app/Http/Requests/Api/UpdateAchievementRequest.php`.
- Enabled the route in `routes/api.php` by uncommenting it.

---
*PR created automatically by Jules for task [8654008862154350325](https://jules.google.com/task/8654008862154350325) started by @kuasar-mknd*