### PR TITLE
sec: Harden security for Social Auth

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -111,8 +111,10 @@ Route::middleware('auth')->group(function (): void {
 
 // Social Login
 Route::get('/auth/{provider}/redirect', [\App\Http\Controllers\Auth\SocialAuthController::class, 'redirect'])
+    ->middleware('guest')
     ->name('social.redirect');
 Route::get('/auth/{provider}/callback', [\App\Http\Controllers\Auth\SocialAuthController::class, 'callback'])
+    ->middleware('guest')
     ->name('social.callback');
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
This pull request addresses an issue where the social authentication routes (`/auth/{provider}/redirect` and `/auth/{provider}/callback`) were missing the `guest` middleware. Without it, authenticated users could trigger the authentication flow, which deviates from standard login practices and could lead to unexpected behavior. The fix correctly applies the `guest` middleware to these routes. Tests and static analysis pass successfully.

---
*PR created automatically by Jules for task [11723652444016135780](https://jules.google.com/task/11723652444016135780) started by @kuasar-mknd*