### PR TITLE
refactor: Extract logic from SetController

### DIFF
--- a/app/Actions/Workouts/CreateSetAction.php
+++ b/app/Actions/Workouts/CreateSetAction.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Workouts;
+
+use App\Models\Set;
+use App\Models\User;
+use App\Models\WorkoutLine;
+use App\Services\StatsService;
+
+final class CreateSetAction
+{
+    public function __construct(protected StatsService $statsService)
+    {
+    }
+
+    /**
+     * Create a new set for a workout line.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function execute(User $user, WorkoutLine $workoutLine, array $data): Set
+    {
+        $set = $workoutLine->sets()->create(
+            collect($data)->except('workout_line_id')->toArray()
+        );
+
+        $this->statsService->clearWorkoutRelatedStats($user);
+
+        return $set;
+    }
+}

--- a/app/Http/Controllers/Api/SetController.php
+++ b/app/Http/Controllers/Api/SetController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\Workouts\CreateSetAction;
 use App\Http\Requests\Api\SetStoreRequest;
 use App\Http\Requests\Api\SetUpdateRequest;
 use App\Http\Resources\SetResource;
@@ -43,7 +44,7 @@ class SetController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(SetStoreRequest $request): SetResource
+    public function store(SetStoreRequest $request, CreateSetAction $action): SetResource
     {
         $validated = $request->validated();
 
@@ -53,11 +54,7 @@ class SetController extends Controller
 
             $this->authorize('create', [Set::class, $workoutLine]);
 
-            $set = $workoutLine->sets()->create(
-                collect($validated)->except('workout_line_id')->toArray()
-            );
-
-            $this->statsService->clearWorkoutRelatedStats($this->user());
+            $set = $action->execute($this->user(), $workoutLine, $validated);
 
             return new SetResource($set);
         } catch (\Exception $e) {


### PR DESCRIPTION
Extracts set creation logic from `SetController` into a dedicated `CreateSetAction` class following SOLID principles. This simplifies the controller and reuses the action pattern present in other parts of the application.

Tested successfully with `phpstan` and `pest`.

---
*PR created automatically by Jules for task [7779316602872776038](https://jules.google.com/task/7779316602872776038) started by @kuasar-mknd*