### PR TITLE
feat(viz): Add Time of Day Distribution Chart for Workouts

### DIFF
--- a/app/Actions/Dashboard/FetchDashboardDataAction.php
+++ b/app/Actions/Dashboard/FetchDashboardDataAction.php
@@ -81,6 +81,14 @@ final class FetchDashboardDataAction
     }
 
     /**
+     * @return array<int, array{label: string, count: int}>
+     */
+    public function getTimeOfDayDistribution(User $user): array
+    {
+        return $this->statsService->getTimeOfDayDistribution($user);
+    }
+
+    /**
      * Legacy method if needed, but we will update the controller.
      *
      * @return array<string, mixed>
@@ -97,6 +105,7 @@ final class FetchDashboardDataAction
                 'weeklyVolumeTrend' => $this->getWeeklyVolumeTrend($user),
                 'volumeTrend' => $this->getVolumeTrend($user),
                 'durationDistribution' => $this->getDurationDistribution($user),
+                'timeOfDayDistribution' => $this->getTimeOfDayDistribution($user),
             ]
         );
     }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -51,6 +51,7 @@ class DashboardController extends Controller
             'weeklyVolumeTrend' => Inertia::defer(fn (): array => $fetchDashboardData->getWeeklyVolumeTrend($user)),
             'volumeTrend' => Inertia::defer(fn (): array => $fetchDashboardData->getVolumeTrend($user)),
             'durationDistribution' => Inertia::defer(fn (): array => $fetchDashboardData->getDurationDistribution($user)),
+            'timeOfDayDistribution' => Inertia::defer(fn (): array => $fetchDashboardData->getTimeOfDayDistribution($user)),
         ]);
     }
 }

--- a/app/Services/StatsService.php
+++ b/app/Services/StatsService.php
@@ -244,6 +244,18 @@ class StatsService
     }
 
     /**
+     * @return array<int, array{label: string, count: int}>
+     */
+    public function getTimeOfDayDistribution(User $user, int $days = 90): array
+    {
+        return Cache::remember(
+            "stats.time_of_day_distribution.{$user->id}.{$days}",
+            now()->addMinutes(30),
+            fn (): array => $this->calculateTimeOfDayDistribution($user, $days)
+        );
+    }
+
+    /**
      * @return array<int, array{month: string, volume: float}>
      */
     public function getMonthlyVolumeHistory(User $user, int $months = 6): array
@@ -297,6 +309,7 @@ class StatsService
         Cache::forget("stats.duration_history.{$user->id}.20");
         Cache::forget("stats.monthly_volume_history.{$user->id}.6");
         Cache::forget("stats.duration_distribution.{$user->id}.90");
+        Cache::forget("stats.time_of_day_distribution.{$user->id}.90");
 
         // Invalidate 1RM cache for all exercises (O(1))
         Cache::put("stats.1rm_version.{$user->id}", (string) time(), 86400 * 30);
@@ -666,5 +679,39 @@ class StatsService
         };
 
         $buckets[$label]++;
+    }
+
+    /**
+     * @return array<int, array{label: string, count: int}>
+     */
+    protected function calculateTimeOfDayDistribution(User $user, int $days): array
+    {
+        $workouts = $user->workouts()
+            ->where('started_at', '>=', now()->subDays($days))
+            ->get();
+
+        $buckets = [
+            'Matin (06h-12h)' => 0,
+            'Après-midi (12h-17h)' => 0,
+            'Soir (17h-22h)' => 0,
+            'Nuit (22h-06h)' => 0,
+        ];
+
+        foreach ($workouts as $workout) {
+            $hour = (int) $workout->started_at->format('G');
+
+            if ($hour >= 6 && $hour < 12) {
+                $buckets['Matin (06h-12h)']++;
+            } elseif ($hour >= 12 && $hour < 17) {
+                $buckets['Après-midi (12h-17h)']++;
+            } elseif ($hour >= 17 && $hour < 22) {
+                $buckets['Soir (17h-22h)']++;
+            } else {
+                $buckets['Nuit (22h-06h)']++;
+            }
+        }
+
+        /** @var array<int, array{label: string, count: int}> */
+        return collect($buckets)->map(fn (int $count, string $label): array => ['label' => $label, 'count' => $count])->values()->toArray();
     }
 }

--- a/resources/js/Components/Stats/TimeOfDayChart.vue
+++ b/resources/js/Components/Stats/TimeOfDayChart.vue
@@ -1,0 +1,84 @@
+<script setup>
+import { Doughnut } from 'vue-chartjs'
+import { Chart as ChartJS, Title, Tooltip, Legend, ArcElement } from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(Title, Tooltip, Legend, ArcElement)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    return {
+        labels: props.data.map((item) => item.label),
+        datasets: [
+            {
+                data: props.data.map((item) => item.count),
+                backgroundColor: [
+                    '#38BDF8', // Sky 400 (Matin)
+                    '#F59E0B', // Amber 500 (Après-midi)
+                    '#8B5CF6', // Violet 500 (Soir)
+                    '#312E81', // Indigo 900 (Nuit)
+                ],
+                hoverBackgroundColor: [
+                    '#0EA5E9', // Sky 500
+                    '#D97706', // Amber 600
+                    '#7C3AED', // Violet 600
+                    '#1E1B4B', // Indigo 950
+                ],
+                borderWidth: 2,
+                borderColor: '#ffffff',
+                hoverOffset: 4,
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    cutout: '65%',
+    plugins: {
+        legend: {
+            position: 'right',
+            labels: {
+                color: '#64748B',
+                font: { size: 11, weight: 'bold' },
+                padding: 15,
+                usePointStyle: true,
+                pointStyle: 'circle',
+            },
+        },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.95)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            padding: 12,
+            cornerRadius: 12,
+            borderWidth: 1,
+            borderColor: 'rgba(0, 0, 0, 0.05)',
+            callbacks: {
+                label: function (context) {
+                    const value = context.raw
+                    const total = context.chart._metasets[context.datasetIndex].total
+                    const percentage = Math.round((value / total) * 100)
+                    return ` ${value} séances (${percentage}%)`
+                },
+            },
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="relative h-48 w-full">
+        <Doughnut :data="chartData" :options="chartOptions" />
+        <div class="pointer-events-none absolute inset-0 -ml-[120px] flex items-center justify-center">
+            <span class="material-symbols-outlined text-text-muted/20 text-4xl">schedule</span>
+        </div>
+    </div>
+</template>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -7,6 +7,7 @@ import { defineAsyncComponent } from 'vue'
 
 const WeeklyVolumeChart = defineAsyncComponent(() => import('@/Components/Stats/WeeklyVolumeChart.vue'))
 const DurationDistributionChart = defineAsyncComponent(() => import('@/Components/Stats/DurationDistributionChart.vue'))
+const TimeOfDayChart = defineAsyncComponent(() => import('@/Components/Stats/TimeOfDayChart.vue'))
 
 /**
  * Dashboard - Command Center
@@ -27,6 +28,7 @@ const props = defineProps({
     weeklyVolumeTrend: { type: Array, default: () => [] },
     volumeTrend: { type: Array, default: () => [] },
     durationDistribution: { type: Array, default: () => [] },
+    timeOfDayDistribution: { type: Array, default: () => [] },
 })
 
 const form = useForm({})
@@ -220,6 +222,30 @@ const colorForWorkout = (index) => {
                     </div>
                 </section>
             </div>
+
+            <!-- Time of Day Distribution Chart -->
+            <section
+                class="glass-panel-light animate-slide-up relative overflow-hidden rounded-3xl p-6"
+                style="animation-delay: 0.18s"
+            >
+                <div class="relative z-10 mb-6">
+                    <h3 class="text-hot-pink mb-1 text-[10px] font-black tracking-[0.2em] uppercase">Habitudes</h3>
+                    <p class="font-display text-text-main text-2xl font-black uppercase italic dark:text-white">
+                        Horaire Favori
+                    </p>
+                </div>
+
+                <!-- Time of Day Chart -->
+                <div class="relative -mx-2 mt-2 h-48 w-auto">
+                    <TimeOfDayChart
+                        v-if="timeOfDayDistribution && timeOfDayDistribution.some((d) => d.count > 0)"
+                        :data="timeOfDayDistribution"
+                    />
+                    <div v-else class="text-text-muted flex h-full items-center justify-center">
+                        <p class="text-sm">Pas assez de données (90j)</p>
+                    </div>
+                </div>
+            </section>
 
             <!-- Recent Activity -->
             <section class="animate-slide-up" style="animation-delay: 0.2s">

--- a/tests/Unit/Services/StatsServiceCacheTest.php
+++ b/tests/Unit/Services/StatsServiceCacheTest.php
@@ -40,6 +40,7 @@ class StatsServiceCacheTest extends TestCase
         Cache::shouldReceive('forget')->once()->with("stats.volume_history.{$user->id}.20");
         Cache::shouldReceive('forget')->once()->with("stats.volume_history.{$user->id}.30");
         Cache::shouldReceive('forget')->once()->with("stats.duration_distribution.{$user->id}.90");
+        Cache::shouldReceive('forget')->once()->with("stats.time_of_day_distribution.{$user->id}.90");
         Cache::shouldReceive('forget')->once()->with("stats.monthly_volume_history.{$user->id}.6");
         Cache::shouldReceive('forget')->once()->with("stats.muscle_dist.{$user->id}.30");
         Cache::shouldReceive('forget')->once()->with("stats.muscle_dist.{$user->id}.7");
@@ -82,6 +83,7 @@ class StatsServiceCacheTest extends TestCase
         Cache::shouldReceive('forget')->once()->with("stats.volume_history.{$user->id}.20");
         Cache::shouldReceive('forget')->once()->with("stats.volume_history.{$user->id}.30");
         Cache::shouldReceive('forget')->once()->with("stats.duration_distribution.{$user->id}.90");
+        Cache::shouldReceive('forget')->once()->with("stats.time_of_day_distribution.{$user->id}.90");
         Cache::shouldReceive('forget')->once()->with("stats.monthly_volume_history.{$user->id}.6");
         Cache::shouldReceive('forget')->once()->with("stats.muscle_dist.{$user->id}.30");
         Cache::shouldReceive('forget')->once()->with("stats.muscle_dist.{$user->id}.7");


### PR DESCRIPTION
This PR introduces a new "Time of Day" workout distribution chart to the Dashboard. It calculates whether the user prefers to train in the morning, afternoon, evening, or night over the last 90 days.

The backend implementation relies on caching the computation in `StatsService` (O(1) invalidation) and passing it synchronously as a deferred property in `DashboardController` so initial render speeds are completely unaffected.

The frontend utilizes a Doughnut chart built with `vue-chartjs` combined with Liquid Glass styling parameters.

---
*PR created automatically by Jules for task [12893392653587962363](https://jules.google.com/task/12893392653587962363) started by @kuasar-mknd*