### PR TITLE
🎨 Palette: Add Empty State CTA and Loading Feedback to Dashboard

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-02 - Empty State Call to Actions & Async Buttons
+**Learning:** Found an empty state ("Aucune séance pour l'instant") that left users at a dead-end on the primary Dashboard. Additionally, a large call-to-action card executed an async form post without any visual feedback (no spinner). In Inertia/Vue apps, disabling the button isn't enough; the user needs clear visual feedback that their action is processing, especially for major actions like creating a new Workout.
+**Action:** Always provide an actionable CTA within Empty States to prevent "dead ends". Also, always ensure primary action buttons not only disable themselves but also show an explicit loading indicator (like `animate-spin` on an icon) when `form.processing` is true.

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -111,7 +111,15 @@ const colorForWorkout = (index) => {
                         <div
                             class="from-electric-orange to-hot-pink flex size-16 items-center justify-center rounded-2xl bg-linear-to-br shadow-lg shadow-orange-500/30 transition-transform duration-300 group-hover:scale-110"
                         >
-                            <span class="material-symbols-outlined text-4xl text-white">fitness_center</span>
+                            <span
+                                v-if="form.processing"
+                                class="material-symbols-outlined animate-spin text-4xl text-white"
+                                aria-hidden="true"
+                                >autorenew</span
+                            >
+                            <span v-else class="material-symbols-outlined text-4xl text-white" aria-hidden="true"
+                                >fitness_center</span
+                            >
                         </div>
                         <span
                             class="font-display text-text-main text-center text-xl leading-none font-black tracking-tight uppercase italic dark:text-white"
@@ -261,9 +269,12 @@ const colorForWorkout = (index) => {
 
                 <!-- Empty State -->
                 <div v-if="recentWorkouts.length === 0" class="glass-panel-light rounded-3xl p-8 text-center">
-                    <div class="mb-3 text-5xl">🏋️</div>
+                    <div class="mb-3 text-5xl" aria-hidden="true">🏋️</div>
                     <p class="text-text-main font-bold dark:text-white">Aucune séance pour l'instant</p>
-                    <p class="text-text-muted mt-1 text-sm">Commence ton parcours fitness !</p>
+                    <p class="text-text-muted mt-1 mb-5 text-sm">Commence ton parcours fitness !</p>
+                    <GlassButton variant="primary" @click="startWorkout" :loading="form.processing" class="mx-auto">
+                        Démarrer une séance
+                    </GlassButton>
                 </div>
 
                 <!-- Activity Cards -->


### PR DESCRIPTION
### 💡 What:
1. Added a missing "Démarrer une séance" Call-To-Action (CTA) within the "Activité Récente" Empty State.
2. Added an explicit visual loading state (spinning `autorenew` icon) to the primary "Démarrer Séance" quick action card, shown when `form.processing` is active.

### 🎯 Why:
1. **Empty State Dead-End:** Previously, new users who hadn't logged any workouts saw an empty state that read "Commence ton parcours fitness !" but lacked any actionable button, forcing them to scroll up to begin. Adding the CTA keeps the interaction smooth and intuitive.
2. **Missing Feedback:** The primary "Démarrer Séance" button posted an asynchronous form. While the button disabled itself, the lack of visual feedback left the user wondering if the system was registering the action. The loading spinner explicitly signals that the system is processing.

### ♿ Accessibility:
Added `aria-hidden="true"` to decorative emojis and icons in these updated sections to prevent redundant or confusing screen reader announcements.

---
*PR created automatically by Jules for task [14269485159190943261](https://jules.google.com/task/14269485159190943261) started by @kuasar-mknd*