### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix SQL Injection Risk by Replaying DB::raw() with selectRaw()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-02 - SQL DB::raw() Usage
+**Vulnerability:** Found `DB::raw()` being used directly within a standard `select()` method across services and actions (e.g., `StatsService.php`, `FetchSupplementsIndexAction.php`).
+**Learning:** Even though the current usage uses static strings and is technically safe, this pattern is inherently fragile and prone to SQL injection vulnerabilities if future developers naively inject or concatenate user input into these closures.
+**Prevention:** Rather than using `select(DB::raw(...))`, we should utilize `selectRaw(...)` which supports parameterized bindings and clearly separates standard select clauses from complex, raw SQL aggregates.

--- a/app/Actions/Supplements/FetchSupplementsIndexAction.php
+++ b/app/Actions/Supplements/FetchSupplementsIndexAction.php
@@ -8,7 +8,6 @@ use App\Models\Supplement;
 use App\Models\SupplementLog;
 use App\Models\User;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 
 final class FetchSupplementsIndexAction
 {
@@ -56,10 +55,7 @@ final class FetchSupplementsIndexAction
         $days = 30;
         $usageHistoryRaw = SupplementLog::where('user_id', $user->id)
             ->where('consumed_at', '>=', now()->subDays($days)->startOfDay())
-            ->select(
-                DB::raw('DATE(consumed_at) as date'),
-                DB::raw('SUM(quantity) as count')
-            )
+            ->selectRaw('DATE(consumed_at) as date, SUM(quantity) as count')
             ->groupBy('date')
             ->get()
             ->pluck('count', 'date');

--- a/app/Services/StatsService.php
+++ b/app/Services/StatsService.php
@@ -442,10 +442,7 @@ class StatsService
         return DB::table('workouts')
             ->where('user_id', $user->id)
             ->whereBetween('started_at', [$startOfWeek, $endOfWeek])
-            ->select(
-                DB::raw('DATE(started_at) as date'),
-                DB::raw('SUM(workout_volume) as total_volume')
-            )
+            ->selectRaw('DATE(started_at) as date, SUM(workout_volume) as total_volume')
             ->groupBy('date')
             ->get()->keyBy('date');
     }
@@ -520,10 +517,7 @@ class StatsService
         return DB::table('workouts')
             ->where('user_id', $user->id)
             ->whereBetween('started_at', [$start, now()->endOfDay()])
-            ->select(
-                DB::raw('DATE(started_at) as date'),
-                DB::raw('SUM(workout_volume) as daily_volume')
-            )
+            ->selectRaw('DATE(started_at) as date, SUM(workout_volume) as daily_volume')
             ->groupBy('date')
             ->pluck('daily_volume', 'date')
             ->map(fn (mixed $value): float => is_numeric($value) ? floatval($value) : 0.0);


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Found `DB::raw()` being used directly within a standard `select()` method across services and actions (e.g., `StatsService.php`, `FetchSupplementsIndexAction.php`).
🎯 **Impact:** Even though the current usage uses static strings and is technically safe, this pattern is inherently fragile and prone to SQL injection vulnerabilities if future developers naively inject or concatenate user input into these closures.
🔧 **Fix:** Replaced the use of `select(DB::raw(...))` with Laravel's built-in `selectRaw(...)`. This acts as a defensive programming enhancement by encouraging a method that directly supports parameterized bindings (`selectRaw('...', [$bindings])`), minimizing the risk of future developers mistakenly concatenating unsafe user input into `DB::raw()`.
✅ **Verification:** Verified by running all unit and feature tests (`./vendor/bin/pest`), formatting (`./vendor/bin/pint`), and static analysis (`./vendor/bin/phpstan analyse`). All checks passed and the change does not impact any functionality or responses.

---
*PR created automatically by Jules for task [12885508696099105302](https://jules.google.com/task/12885508696099105302) started by @kuasar-mknd*