### PR TITLE
🎨 Palette: Live workout duration timer

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -156,12 +156,14 @@ const showingNavigationDropdown = ref(false)
                 >
                     <span class="material-symbols-outlined" aria-hidden="true">arrow_back</span>
                 </Link>
-                <h1
-                    v-if="pageTitle"
-                    class="font-display text-text-main truncate text-2xl font-black tracking-tight uppercase italic dark:text-white"
-                >
-                    {{ pageTitle }}
-                </h1>
+                <div v-if="pageTitle" class="flex min-w-0 flex-col">
+                    <h1
+                        class="font-display text-text-main truncate text-2xl leading-none font-black tracking-tight uppercase italic dark:text-white"
+                    >
+                        {{ pageTitle }}
+                    </h1>
+                    <slot name="subtitle" />
+                </div>
             </div>
 
             <div class="flex items-center gap-2">

--- a/resources/js/Pages/Workouts/Show.vue
+++ b/resources/js/Pages/Workouts/Show.vue
@@ -20,7 +20,7 @@ import RestTimer from '@/Components/Workout/RestTimer.vue'
 import SyncService from '@/Utils/SyncService'
 import Modal from '@/Components/Modal.vue'
 import { Head, useForm, router, usePage, Link } from '@inertiajs/vue3'
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { formatToLocalISO, formatToUTC } from '@/Utils/date'
 import { triggerHaptic } from '@/composables/useHaptics'
 
@@ -554,12 +554,52 @@ const filteredExercises = computed(() => {
 const hasNoResults = computed(() => {
     return searchQuery.value && filteredExercises.value.length === 0
 })
+
+// --- Workout Duration Timer ---
+
+const workoutDuration = ref('00:00:00')
+let durationInterval = null
+
+const updateWorkoutDuration = () => {
+    const start = new Date(props.workout.started_at)
+    const end = props.workout.ended_at ? new Date(props.workout.ended_at) : new Date()
+    const diff = Math.max(0, Math.floor((end - start) / 1000))
+
+    const h = Math.floor(diff / 3600)
+    const m = Math.floor((diff % 3600) / 60)
+    const s = diff % 60
+    workoutDuration.value = [h, m, s].map((v) => v.toString().padStart(2, '0')).join(':')
+}
+
+onMounted(() => {
+    updateWorkoutDuration()
+    if (!props.workout.ended_at) {
+        durationInterval = setInterval(updateWorkoutDuration, 1000)
+        document.addEventListener('visibilitychange', updateWorkoutDuration)
+    }
+})
+
+onUnmounted(() => {
+    clearInterval(durationInterval)
+    document.removeEventListener('visibilitychange', updateWorkoutDuration)
+})
 </script>
 
 <template>
     <Head :title="workout.name || 'Séance'" />
 
     <AuthenticatedLayout :page-title="workout.name || 'Séance en cours'" show-back back-route="workouts.index">
+        <template #subtitle>
+            <div
+                class="text-electric-orange mt-1 flex items-center gap-1 font-mono text-xs font-bold sm:text-sm"
+                role="timer"
+                aria-live="off"
+            >
+                <span class="material-symbols-outlined text-[14px] sm:text-sm">timer</span>
+                {{ workoutDuration }}
+            </div>
+        </template>
+
         <template #header>
             <div class="flex items-center justify-between">
                 <div class="flex items-center gap-4">
@@ -569,9 +609,21 @@ const hasNoResults = computed(() => {
                     >
                         <span class="material-symbols-outlined">arrow_back</span>
                     </Link>
-                    <h1 class="font-display text-text-main text-2xl font-black tracking-tight uppercase italic">
-                        {{ workout.name || 'Séance' }}
-                    </h1>
+                    <div class="flex flex-col">
+                        <h1
+                            class="font-display text-text-main text-2xl leading-none font-black tracking-tight uppercase italic"
+                        >
+                            {{ workout.name || 'Séance' }}
+                        </h1>
+                        <div
+                            class="text-electric-orange mt-1 flex items-center gap-1 font-mono text-sm font-bold"
+                            role="timer"
+                            aria-live="off"
+                        >
+                            <span class="material-symbols-outlined text-sm">timer</span>
+                            {{ workoutDuration }}
+                        </div>
+                    </div>
                 </div>
 
                 <div class="flex items-center gap-2">


### PR DESCRIPTION
💡 What: Added a live workout duration timer to the active workout page.
🎯 Why: Provides immediate feedback to the user on their session length, enhancing the "active session" experience and eliminating the need to manually track time.
📸 Before/After: A live timer (HH:mm:ss) now appears under the workout title on both mobile and desktop.
♿ Accessibility: Uses `role="timer"` and `aria-live="off"` to ensure proper screen reader behavior without excessive announcements.

---
*PR created automatically by Jules for task [12852267297972886615](https://jules.google.com/task/12852267297972886615) started by @kuasar-mknd*