### PR TITLE
refactor: Extract logic from DailyJournalController

### DIFF
--- a/app/Http/Controllers/DailyJournalController.php
+++ b/app/Http/Controllers/DailyJournalController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Actions\Journal\SaveDailyJournalAction;
 use App\Http\Requests\DailyJournalStoreRequest;
 use App\Models\DailyJournal;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -33,27 +34,11 @@ class DailyJournalController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(DailyJournalStoreRequest $request): \Illuminate\Http\RedirectResponse
+    public function store(DailyJournalStoreRequest $request, SaveDailyJournalAction $action): \Illuminate\Http\RedirectResponse
     {
         $this->authorize('create', DailyJournal::class);
 
-        $validated = $request->validated();
-        $dateInput = $validated['date'];
-        if (! is_string($dateInput)) {
-            throw new \UnexpectedValueException('Date must be a string');
-        }
-        $date = \Illuminate\Support\Carbon::parse($dateInput);
-        $dateString = $date->format('Y-m-d');
-
-        $journal = $this->user()->dailyJournals()->where('date', $dateString)->first() ?? new DailyJournal();
-
-        if (! $journal->exists) {
-            $journal->user_id = $this->user()->id;
-            $journal->date = $date;
-        }
-
-        $journal->fill($validated);
-        $journal->save();
+        $action->execute($this->user(), $request->validated());
 
         return redirect()->back();
     }


### PR DESCRIPTION
Extracted the core business logic from `DailyJournalController@store` and delegated it to the existing `SaveDailyJournalAction`. This streamlines the controller, adheres to SOLID principles, and ensures proper separation of concerns.

The controller method now simply executes the action and handles the redirect response. Unused imports were removed and code was formatted using `./vendor/bin/pint`.

---
*PR created automatically by Jules for task [11378295453189827938](https://jules.google.com/task/11378295453189827938) started by @kuasar-mknd*