### PR TITLE
feat(backend): Implement CRUD for WorkoutTemplateLine

### DIFF
--- a/app/Http/Controllers/Api/WorkoutTemplateLineController.php
+++ b/app/Http/Controllers/Api/WorkoutTemplateLineController.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\WorkoutTemplateLineStoreRequest;
+use App\Http\Requests\Api\WorkoutTemplateLineUpdateRequest;
+use App\Http\Resources\WorkoutTemplateLineResource;
+use App\Models\WorkoutTemplate;
+use App\Models\WorkoutTemplateLine;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class WorkoutTemplateLineController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request): \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    {
+        $this->authorize('viewAny', WorkoutTemplateLine::class);
+
+        $lines = QueryBuilder::for(WorkoutTemplateLine::class)
+            ->allowedFilters(['workout_template_id'])
+            ->whereHas('workoutTemplate', function ($query) use ($request): void {
+                $query->where('user_id', $request->user()?->id);
+            })
+            ->paginate();
+
+        return WorkoutTemplateLineResource::collection($lines);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(WorkoutTemplateLineStoreRequest $request): WorkoutTemplateLineResource
+    {
+        /** @var array{workout_template_id: int, exercise_id: int, order?: int|null} $validated */
+        $validated = $request->validated();
+
+        /** @var \App\Models\WorkoutTemplate $workoutTemplate */
+        $workoutTemplate = WorkoutTemplate::findOrFail($validated['workout_template_id']);
+
+        $this->authorize('create', [WorkoutTemplateLine::class, $workoutTemplate]);
+
+        /** @var int|null $maxOrder */
+        $maxOrder = $workoutTemplate->workoutTemplateLines()->max('order');
+        $order = $validated['order'] ?? ($maxOrder === null ? 0 : $maxOrder + 1);
+
+        /** @var \App\Models\WorkoutTemplateLine $workoutTemplateLine */
+        $workoutTemplateLine = $workoutTemplate->workoutTemplateLines()->create(array_merge(
+            collect($validated)->except('workout_template_id')->toArray(),
+            ['order' => $order]
+        ));
+
+        return new WorkoutTemplateLineResource($workoutTemplateLine);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(WorkoutTemplateLine $workoutTemplateLine): WorkoutTemplateLineResource
+    {
+        $this->authorize('view', $workoutTemplateLine);
+
+        return new WorkoutTemplateLineResource($workoutTemplateLine);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(WorkoutTemplateLineUpdateRequest $request, WorkoutTemplateLine $workoutTemplateLine): WorkoutTemplateLineResource
+    {
+        $this->authorize('update', $workoutTemplateLine);
+
+        /** @var array{exercise_id?: int, order?: int|null} $validated */
+        $validated = $request->validated();
+
+        $workoutTemplateLine->update($validated);
+
+        return new WorkoutTemplateLineResource($workoutTemplateLine);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(WorkoutTemplateLine $workoutTemplateLine): Response
+    {
+        $this->authorize('delete', $workoutTemplateLine);
+
+        $workoutTemplateLine->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Api/WorkoutTemplateLineStoreRequest.php
+++ b/app/Http/Requests/Api/WorkoutTemplateLineStoreRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class WorkoutTemplateLineStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'workout_template_id' => [
+                'required',
+                Rule::exists('workout_templates', 'id')->where(function ($query): void {
+                    $query->where('user_id', $this->user()?->id);
+                }),
+            ],
+            'exercise_id' => [
+                'required',
+                Rule::exists('exercises', 'id')->where(function ($query): void {
+                    $query->where(function ($q): void {
+                        $q->whereNull('user_id')
+                            ->orWhere('user_id', $this->user()?->id);
+                    });
+                }),
+            ],
+            'order' => 'nullable|integer',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/WorkoutTemplateLineUpdateRequest.php
+++ b/app/Http/Requests/Api/WorkoutTemplateLineUpdateRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class WorkoutTemplateLineUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'exercise_id' => [
+                'sometimes',
+                'required',
+                Rule::exists('exercises', 'id')->where(function ($query): void {
+                    $query->where(function ($q): void {
+                        $q->whereNull('user_id')
+                            ->orWhere('user_id', $this->user()?->id);
+                    });
+                }),
+            ],
+            'order' => 'sometimes|nullable|integer',
+        ];
+    }
+}

--- a/app/Policies/WorkoutTemplateLinePolicy.php
+++ b/app/Policies/WorkoutTemplateLinePolicy.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\WorkoutTemplateLine;
+
+final class WorkoutTemplateLinePolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, WorkoutTemplateLine $workoutTemplateLine): bool
+    {
+        return $user->id === $workoutTemplateLine->workoutTemplate->user_id;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user, ?\App\Models\WorkoutTemplate $workoutTemplate = null): bool
+    {
+        if ($workoutTemplate === null) {
+            return true;
+        }
+
+        return $user->id === $workoutTemplate->user_id;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, WorkoutTemplateLine $workoutTemplateLine): bool
+    {
+        return $user->id === $workoutTemplateLine->workoutTemplate->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, WorkoutTemplateLine $workoutTemplateLine): bool
+    {
+        return $user->id === $workoutTemplateLine->workoutTemplate->user_id;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,7 @@ Route::prefix('v1')->middleware(['auth:sanctum', app()->isProduction() ? 'thrott
     Route::apiResource('body-part-measurements', BodyPartMeasurementController::class);
     Route::apiResource('goals', GoalController::class);
     Route::apiResource('workout-templates', WorkoutTemplateController::class);
+    Route::apiResource('workout-template-lines', \App\Http\Controllers\Api\WorkoutTemplateLineController::class);
     Route::apiResource('workout-lines', \App\Http\Controllers\Api\WorkoutLineController::class);
     Route::apiResource('daily-journals', \App\Http\Controllers\Api\DailyJournalController::class);
     Route::apiResource('fasts', \App\Http\Controllers\Api\FastController::class);


### PR DESCRIPTION
This PR implements full API CRUD functionality for the `WorkoutTemplateLine` model, ensuring completeness across the application's models.

**Changes:**
- Created `WorkoutTemplateLineController` with Spatie QueryBuilder integration.
- Implemented `WorkoutTemplateLineStoreRequest` and `WorkoutTemplateLineUpdateRequest` with secure validation rules checking for system or user-owned `exercise_id`s and user-owned `workout_template_id`s.
- Authored `WorkoutTemplateLinePolicy` to restrict `viewAny`, `view`, `create`, `update`, and `delete` operations to the authenticated owner of the related `WorkoutTemplate`.
- Registered `workout-template-lines` as an API Resource within `routes/api.php`.
- Ensured PHPStan compliance when calculating the max order of a template line.

---
*PR created automatically by Jules for task [6627870187560118875](https://jules.google.com/task/6627870187560118875) started by @kuasar-mknd*