### PR TITLE
feat(viz): Add Line Chart for Max Weight

### DIFF
--- a/resources/js/Components/Stats/MaxWeightChart.vue
+++ b/resources/js/Components/Stats/MaxWeightChart.vue
@@ -1,0 +1,124 @@
+<script setup>
+import { Line } from 'vue-chartjs'
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend,
+    Filler,
+} from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    return {
+        labels: props.data.map((item) => item.date),
+        datasets: [
+            {
+                label: 'Charge Max (kg)',
+                data: props.data.map((item) => item.weight),
+                fill: true,
+                tension: 0.4,
+                borderColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+                    const gradient = ctx.createLinearGradient(chartArea.left, 0, chartArea.right, 0)
+                    gradient.addColorStop(0, '#FF3366') // Hot Pink
+                    gradient.addColorStop(1, '#FF9933') // Electric Orange
+                    return gradient
+                },
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+                    const gradient = ctx.createLinearGradient(0, chartArea.top, 0, chartArea.bottom)
+                    gradient.addColorStop(0, 'rgba(255, 51, 102, 0.2)')
+                    gradient.addColorStop(1, 'rgba(255, 51, 102, 0)')
+                    return gradient
+                },
+                borderWidth: 3,
+                pointRadius: 2,
+                pointBackgroundColor: '#FF3366',
+                pointBorderColor: '#fff',
+                pointBorderWidth: 2,
+                pointHoverRadius: 6,
+                pointHoverBackgroundColor: '#fff',
+                pointHoverBorderColor: '#FF3366',
+                pointHoverBorderWidth: 3,
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: {
+            display: false,
+        },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.9)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            padding: 12,
+            cornerRadius: 12,
+            displayColors: false,
+            borderWidth: 1,
+            borderColor: 'rgba(255, 51, 102, 0.1)',
+            callbacks: {
+                label: (context) => `${context.parsed.y} kg`,
+            },
+        },
+    },
+    scales: {
+        x: {
+            display: true,
+            ticks: {
+                color: '#64748B',
+                font: { size: 10, weight: 'bold' },
+            },
+            grid: {
+                display: false,
+            },
+            border: { display: false },
+        },
+        y: {
+            display: true,
+            ticks: {
+                color: '#64748B',
+                font: { size: 10, weight: 'bold' },
+            },
+            grid: {
+                display: false,
+            },
+            border: { display: false },
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-full w-full">
+        <Line :data="chartData" :options="chartOptions" />
+    </div>
+</template>
+
+<style scoped>
+canvas {
+    filter: drop-shadow(0 4px 6px rgba(255, 51, 102, 0.2));
+}
+</style>

--- a/resources/js/Pages/Exercises/Show.vue
+++ b/resources/js/Pages/Exercises/Show.vue
@@ -8,6 +8,7 @@ const OneRepMaxChart = defineAsyncComponent(() => import('@/Components/Stats/One
 const VolumeTrendChart = defineAsyncComponent(() => import('@/Components/Stats/VolumeTrendChart.vue'))
 const WeightDistributionChart = defineAsyncComponent(() => import('@/Components/Stats/WeightDistributionChart.vue'))
 const MaxRepsChart = defineAsyncComponent(() => import('@/Components/Stats/MaxRepsChart.vue'))
+const MaxWeightChart = defineAsyncComponent(() => import('@/Components/Stats/MaxWeightChart.vue'))
 
 /**
  * Component Props
@@ -54,6 +55,14 @@ const maxRepsData = computed(() => {
     return [...props.history].reverse().map((session) => ({
         date: session.formatted_date.split('/').slice(0, 2).join('/'),
         reps: session.sets.length > 0 ? Math.max(...session.sets.map((s) => s.reps || 0)) : 0,
+    }))
+})
+
+const maxWeightData = computed(() => {
+    if (!props.history || props.history.length === 0) return []
+    return [...props.history].reverse().map((session) => ({
+        date: session.formatted_date.split('/').slice(0, 2).join('/'),
+        weight: session.sets.length > 0 ? Math.max(...session.sets.map((s) => parseFloat(s.weight) || 0)) : 0,
     }))
 })
 
@@ -165,6 +174,16 @@ const weightDistributionData = computed(() => {
                 </GlassCard>
 
                 <GlassCard>
+                    <div class="mb-4">
+                        <h3 class="font-display text-text-main text-lg font-black uppercase italic">Charge Max</h3>
+                        <p class="text-text-muted text-xs font-semibold">Charge maximale soulevée par séance (kg)</p>
+                    </div>
+                    <div class="h-64">
+                        <MaxWeightChart :data="maxWeightData" />
+                    </div>
+                </GlassCard>
+
+                <GlassCard class="md:col-span-2">
                     <div class="mb-4">
                         <h3 class="font-display text-text-main text-lg font-black uppercase italic">Max Reps</h3>
                         <p class="text-text-muted text-xs font-semibold">Maximum de répétitions par séance</p>


### PR DESCRIPTION
This PR adds a new visualization graphic `MaxWeightChart` to specifically highlight the progression of maximum load over the history of workouts for a specific exercise.

- Created `resources/js/Components/Stats/MaxWeightChart.vue`.
- Added dynamic calculation of max weight lifted within the exercise history dataset inside `Show.vue`.
- Displayed the new component alongside other analytics while restoring the layout space that `MaxRepsChart` occupies.
- Preserved complete UI design matching standard (Liquid Glass cards + dynamic gradients).

---
*PR created automatically by Jules for task [10959710063726601131](https://jules.google.com/task/10959710063726601131) started by @kuasar-mknd*