### PR TITLE
🎨 Palette: Add loading state to finish workout button

### DIFF
--- a/resources/js/Pages/Workouts/Show.vue
+++ b/resources/js/Pages/Workouts/Show.vue
@@ -117,6 +117,7 @@ const toggleSetCompletion = (set, exerciseRestTime) => {
 }
 
 const savingTemplate = ref(false)
+const finishingWorkout = ref(false)
 const saveAsTemplate = () => {
     savingTemplate.value = true
     router.post(
@@ -134,6 +135,7 @@ const finishWorkout = () => {
     showFinishModal.value = true
 }
 const confirmFinishWorkout = () => {
+    finishingWorkout.value = true
     router.patch(
         route('workouts.update', { workout: localWorkout.value.id }),
         { is_finished: true },
@@ -142,6 +144,9 @@ const confirmFinishWorkout = () => {
                 triggerHaptic('success')
                 showFinishModal.value = false
                 router.visit(route('dashboard'))
+            },
+            onFinish: () => {
+                finishingWorkout.value = false
             },
         },
     )
@@ -549,6 +554,7 @@ const filteredExercises = computed(() => {
                         variant="primary"
                         id="confirm-finish-button"
                         @click="confirmFinishWorkout"
+                        :loading="finishingWorkout"
                         class="flex-1"
                         >Confirmer</GlassButton
                     >


### PR DESCRIPTION
💡 What: Added a reactive `finishingWorkout` loading state to the "Terminer" (Finish) confirmation button on the workout session page.
🎯 Why: Previously, clicking the "Confirmer" button inside the Finish Workout modal gave no visual feedback while the `PATCH` request was being processed. Users could mistakenly think the app was frozen or their action didn't register.
📸 Before/After: Visual changes show a loading spinner on the button via the `<GlassButton>`'s existing `:loading` prop.
♿ Accessibility: The button naturally transitions its ARIA states via the existing `<GlassButton>` implementation, indicating to screen readers that it is currently processing.

---
*PR created automatically by Jules for task [9001258659440183225](https://jules.google.com/task/9001258659440183225) started by @kuasar-mknd*