### PR TITLE
refactor: Extract logic from WorkoutTemplateLineController

### DIFF
--- a/app/Actions/Workouts/CreateWorkoutTemplateLineAction.php
+++ b/app/Actions/Workouts/CreateWorkoutTemplateLineAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Workouts;
+
+use App\Models\WorkoutTemplate;
+use App\Models\WorkoutTemplateLine;
+
+final class CreateWorkoutTemplateLineAction
+{
+    /**
+     * Create a new workout template line.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function execute(WorkoutTemplate $workoutTemplate, array $data): WorkoutTemplateLine
+    {
+        /** @var int|null $maxOrder */
+        $maxOrder = $workoutTemplate->workoutTemplateLines()->max('order');
+        $order = $data['order'] ?? ($maxOrder === null ? 0 : $maxOrder + 1);
+
+        /** @var \App\Models\WorkoutTemplateLine $workoutTemplateLine */
+        $workoutTemplateLine = $workoutTemplate->workoutTemplateLines()->create(array_merge(
+            collect($data)->except('workout_template_id')->toArray(),
+            ['order' => $order]
+        ));
+
+        return $workoutTemplateLine;
+    }
+}

--- a/app/Http/Controllers/Api/WorkoutTemplateLineController.php
+++ b/app/Http/Controllers/Api/WorkoutTemplateLineController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\Workouts\CreateWorkoutTemplateLineAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\WorkoutTemplateLineStoreRequest;
 use App\Http\Requests\Api\WorkoutTemplateLineUpdateRequest;
@@ -39,7 +40,7 @@ class WorkoutTemplateLineController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(WorkoutTemplateLineStoreRequest $request): WorkoutTemplateLineResource
+    public function store(WorkoutTemplateLineStoreRequest $request, CreateWorkoutTemplateLineAction $action): WorkoutTemplateLineResource
     {
         /** @var array{workout_template_id: int, exercise_id: int, order?: int|null} $validated */
         $validated = $request->validated();
@@ -49,15 +50,7 @@ class WorkoutTemplateLineController extends Controller
 
         $this->authorize('create', [WorkoutTemplateLine::class, $workoutTemplate]);
 
-        /** @var int|null $maxOrder */
-        $maxOrder = $workoutTemplate->workoutTemplateLines()->max('order');
-        $order = $validated['order'] ?? ($maxOrder === null ? 0 : $maxOrder + 1);
-
-        /** @var \App\Models\WorkoutTemplateLine $workoutTemplateLine */
-        $workoutTemplateLine = $workoutTemplate->workoutTemplateLines()->create(array_merge(
-            collect($validated)->except('workout_template_id')->toArray(),
-            ['order' => $order]
-        ));
+        $workoutTemplateLine = $action->execute($workoutTemplate, $validated);
 
         return new WorkoutTemplateLineResource($workoutTemplateLine);
     }


### PR DESCRIPTION
Moved order calculation and workout template line creation business logic into `CreateWorkoutTemplateLineAction` to make the controller cleaner and adhere to SOLID principles.

---
*PR created automatically by Jules for task [8886615279847948549](https://jules.google.com/task/8886615279847948549) started by @kuasar-mknd*