### PR TITLE
refactor: Extract logic from HabitController

### DIFF
--- a/app/Actions/Habits/FetchApiHabitsIndexAction.php
+++ b/app/Actions/Habits/FetchApiHabitsIndexAction.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Habits;
+
+use App\Models\Habit;
+use App\Models\User;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class FetchApiHabitsIndexAction
+{
+    /**
+     * Fetch paginated list of habits for the given user, supporting includes and sorts via QueryBuilder.
+     *
+     * @param  User  $user  The authenticated user.
+     * @param  array<string, mixed>  $validated  The validated request data containing pagination options.
+     * @return LengthAwarePaginator<int, Habit> The paginated list of habits.
+     */
+    public function execute(User $user, array $validated): LengthAwarePaginator
+    {
+        /** @var \Spatie\QueryBuilder\QueryBuilder<\App\Models\Habit> $query */
+        $query = clone QueryBuilder::for(Habit::class)
+            ->allowedIncludes(['logs'])
+            ->allowedSorts(['name', 'created_at', 'goal_times_per_week'])
+            ->defaultSort('name')
+            ->where('user_id', $user->id);
+
+        /** @var int $perPage */
+        $perPage = $validated['per_page'] ?? 15;
+
+        return $query->paginate($perPage);
+    }
+}

--- a/app/Http/Controllers/Api/HabitController.php
+++ b/app/Http/Controllers/Api/HabitController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\Habits\FetchApiHabitsIndexAction;
 use App\Http\Requests\Api\StoreHabitRequest;
 use App\Http\Requests\Api\UpdateHabitRequest;
 use App\Http\Resources\HabitResource;
@@ -12,7 +13,6 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use OpenApi\Attributes as OA;
-use Spatie\QueryBuilder\QueryBuilder;
 
 class HabitController extends Controller
 {
@@ -25,24 +25,15 @@ class HabitController extends Controller
     )]
     #[OA\Response(response: 200, description: 'Successful operation')]
     #[OA\Response(response: 401, description: 'Unauthenticated')]
-    public function index(Request $request): \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    public function index(Request $request, FetchApiHabitsIndexAction $fetchApiHabitsIndexAction): \Illuminate\Http\Resources\Json\AnonymousResourceCollection
     {
         $this->authorize('viewAny', Habit::class);
-
-        $query = QueryBuilder::for(Habit::class)
-            ->allowedIncludes(['logs'])
-            ->allowedSorts(['name', 'created_at', 'goal_times_per_week'])
-            ->defaultSort('name')
-            ->where('user_id', $this->user()->id);
 
         $validated = $request->validate([
             'per_page' => 'sometimes|integer|min:1|max:100',
         ]);
 
-        /** @var int $perPage */
-        $perPage = $validated['per_page'] ?? 15;
-
-        $habits = $query->paginate($perPage);
+        $habits = $fetchApiHabitsIndexAction->execute($this->user(), $validated);
 
         return HabitResource::collection($habits);
     }


### PR DESCRIPTION
This pull request refactors the `index` method of `HabitController` by extracting the `QueryBuilder` and pagination logic into a dedicated Action class (`FetchApiHabitsIndexAction`). It reduces the length of the controller and promotes cleaner SOLID architecture by adhering to the single responsibility principle.

It also includes code formatting to adhere strictly to PSR-12 and satisfies the strictest static analysis rules (PHPStan level 9).

---
*PR created automatically by Jules for task [8053187236511395155](https://jules.google.com/task/8053187236511395155) started by @kuasar-mknd*