### PR TITLE
refactor: Extract logic from WorkoutTemplateLineController

### DIFF
--- a/app/Actions/CreateWorkoutTemplateLineAction.php
+++ b/app/Actions/CreateWorkoutTemplateLineAction.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\WorkoutTemplate;
+use App\Models\WorkoutTemplateLine;
+
+class CreateWorkoutTemplateLineAction
+{
+    /**
+     * @param  array{workout_template_id: int, exercise_id: int, order?: int|null}  $data
+     */
+    public function execute(WorkoutTemplate $workoutTemplate, array $data): WorkoutTemplateLine
+    {
+        /** @var int|null $maxOrder */
+        $maxOrder = $workoutTemplate->workoutTemplateLines()->max('order');
+        $order = $data['order'] ?? ($maxOrder === null ? 0 : $maxOrder + 1);
+
+        /** @var \App\Models\WorkoutTemplateLine $workoutTemplateLine */
+        $workoutTemplateLine = $workoutTemplate->workoutTemplateLines()->create(array_merge(
+            collect($data)->except('workout_template_id')->toArray(),
+            ['order' => $order]
+        ));
+
+        return $workoutTemplateLine;
+    }
+}

--- a/app/Http/Controllers/Api/WorkoutTemplateLineController.php
+++ b/app/Http/Controllers/Api/WorkoutTemplateLineController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\CreateWorkoutTemplateLineAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\WorkoutTemplateLineStoreRequest;
 use App\Http\Requests\Api\WorkoutTemplateLineUpdateRequest;
@@ -39,7 +40,7 @@ class WorkoutTemplateLineController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(WorkoutTemplateLineStoreRequest $request): WorkoutTemplateLineResource
+    public function store(WorkoutTemplateLineStoreRequest $request, CreateWorkoutTemplateLineAction $action): WorkoutTemplateLineResource
     {
         /** @var array{workout_template_id: int, exercise_id: int, order?: int|null} $validated */
         $validated = $request->validated();
@@ -49,15 +50,7 @@ class WorkoutTemplateLineController extends Controller
 
         $this->authorize('create', [WorkoutTemplateLine::class, $workoutTemplate]);
 
-        /** @var int|null $maxOrder */
-        $maxOrder = $workoutTemplate->workoutTemplateLines()->max('order');
-        $order = $validated['order'] ?? ($maxOrder === null ? 0 : $maxOrder + 1);
-
-        /** @var \App\Models\WorkoutTemplateLine $workoutTemplateLine */
-        $workoutTemplateLine = $workoutTemplate->workoutTemplateLines()->create(array_merge(
-            collect($validated)->except('workout_template_id')->toArray(),
-            ['order' => $order]
-        ));
+        $workoutTemplateLine = $action->execute($workoutTemplate, $validated);
 
         return new WorkoutTemplateLineResource($workoutTemplateLine);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "html",
+    "name": "app",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {


### PR DESCRIPTION
This PR refactors the `WorkoutTemplateLineController` by extracting the business logic from the `store` method into a dedicated `CreateWorkoutTemplateLineAction` class. This improves code readability and maintainability, adhering to SOLID principles.

The controller now injects the action class and calls its `execute` method, keeping the controller lean. Formatting is applied via `pint` and tests continue to pass.

---
*PR created automatically by Jules for task [9676454845702880243](https://jules.google.com/task/9676454845702880243) started by @kuasar-mknd*