### PR TITLE
design: Liquid Glass overhaul for InputLabel

### DIFF
--- a/resources/js/Components/InputLabel.vue
+++ b/resources/js/Components/InputLabel.vue
@@ -7,7 +7,7 @@ defineProps({
 </script>
 
 <template>
-    <label class="block text-sm font-medium text-gray-700">
+    <label class="mb-2 inline-flex cursor-pointer items-center rounded-2xl border border-white/20 bg-white/10 px-3 py-1.5 text-xs font-black tracking-widest text-slate-700 dark:text-white uppercase backdrop-blur-md transition-all duration-300 hover:scale-[1.02] hover:bg-white/20 active:scale-95 shadow-[0_4px_30px_rgba(0,0,0,0.1)] hover:shadow-[0_4px_30px_rgba(0,0,0,0.2)]">
         <span v-if="value">{{ value }}</span>
         <span v-else><slot /></span>
     </label>


### PR DESCRIPTION
This PR modernizes the `InputLabel.vue` component to match the requested "Liquid Glass" aesthetic by applying the necessary Tailwind CSS classes. 

Changes include:
- `bg-white/10` and `backdrop-blur-md` for the base glass effect
- `rounded-2xl` borders
- `border border-white/20` for a subtle edge
- Micro-interactions via `transition-all duration-300`, `hover:scale-[1.02]`, `hover:bg-white/20`, and `active:scale-95`
- Refactored text styling to look like a small sleek pill/badge above inputs.

---
*PR created automatically by Jules for task [7083650490244767788](https://jules.google.com/task/7083650490244767788) started by @kuasar-mknd*