### PR TITLE
feat(backend): Implement CRUD for WorkoutTemplateSet

### DIFF
--- a/app/Http/Controllers/Api/WorkoutTemplateSetController.php
+++ b/app/Http/Controllers/Api/WorkoutTemplateSetController.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\WorkoutTemplateSetStoreRequest;
+use App\Http\Requests\Api\WorkoutTemplateSetUpdateRequest;
+use App\Http\Resources\WorkoutTemplateSetResource;
+use App\Models\WorkoutTemplateLine;
+use App\Models\WorkoutTemplateSet;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class WorkoutTemplateSetController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request): \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    {
+        $this->authorize('viewAny', WorkoutTemplateSet::class);
+
+        $sets = QueryBuilder::for(WorkoutTemplateSet::class)
+            ->allowedFilters(['workout_template_line_id'])
+            ->whereHas('workoutTemplateLine.workoutTemplate', function ($query) use ($request): void {
+                $query->where('user_id', $request->user()?->id);
+            })
+            ->paginate();
+
+        return WorkoutTemplateSetResource::collection($sets);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(WorkoutTemplateSetStoreRequest $request): WorkoutTemplateSetResource
+    {
+        /** @var array{workout_template_line_id: int, reps?: int|null, weight?: float|null, is_warmup: bool, order?: int|null} $validated */
+        $validated = $request->validated();
+
+        /** @var \App\Models\WorkoutTemplateLine $workoutTemplateLine */
+        $workoutTemplateLine = WorkoutTemplateLine::findOrFail($validated['workout_template_line_id']);
+
+        $this->authorize('create', [WorkoutTemplateSet::class, $workoutTemplateLine]);
+
+        /** @var int|null $maxOrder */
+        $maxOrder = $workoutTemplateLine->workoutTemplateSets()->max('order');
+        $order = $validated['order'] ?? ($maxOrder === null ? 0 : $maxOrder + 1);
+
+        /** @var \App\Models\WorkoutTemplateSet $workoutTemplateSet */
+        $workoutTemplateSet = $workoutTemplateLine->workoutTemplateSets()->create(array_merge(
+            collect($validated)->except('workout_template_line_id')->toArray(),
+            ['order' => $order]
+        ));
+
+        return new WorkoutTemplateSetResource($workoutTemplateSet);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(WorkoutTemplateSet $workoutTemplateSet): WorkoutTemplateSetResource
+    {
+        $this->authorize('view', $workoutTemplateSet);
+
+        return new WorkoutTemplateSetResource($workoutTemplateSet);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(WorkoutTemplateSetUpdateRequest $request, WorkoutTemplateSet $workoutTemplateSet): WorkoutTemplateSetResource
+    {
+        $this->authorize('update', $workoutTemplateSet);
+
+        /** @var array{reps?: int|null, weight?: float|null, is_warmup?: bool, order?: int|null} $validated */
+        $validated = $request->validated();
+
+        $workoutTemplateSet->update($validated);
+
+        return new WorkoutTemplateSetResource($workoutTemplateSet);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(WorkoutTemplateSet $workoutTemplateSet): Response
+    {
+        $this->authorize('delete', $workoutTemplateSet);
+
+        $workoutTemplateSet->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Api/WorkoutTemplateSetStoreRequest.php
+++ b/app/Http/Requests/Api/WorkoutTemplateSetStoreRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class WorkoutTemplateSetStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'workout_template_line_id' => ['required', 'integer', 'exists:workout_template_lines,id'],
+            'reps' => ['nullable', 'integer', 'min:0'],
+            'weight' => ['nullable', 'numeric', 'min:0'],
+            'is_warmup' => ['required', 'boolean'],
+            'order' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/WorkoutTemplateSetUpdateRequest.php
+++ b/app/Http/Requests/Api/WorkoutTemplateSetUpdateRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class WorkoutTemplateSetUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'reps' => ['nullable', 'integer', 'min:0'],
+            'weight' => ['nullable', 'numeric', 'min:0'],
+            'is_warmup' => ['boolean'],
+            'order' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Http/Resources/WorkoutTemplateSetResource.php
+++ b/app/Http/Resources/WorkoutTemplateSetResource.php
@@ -19,6 +19,7 @@ class WorkoutTemplateSetResource extends JsonResource
     {
         return [
             'id' => $this->id,
+            'workout_template_line_id' => $this->workout_template_line_id,
             'reps' => $this->reps,
             'weight' => $this->weight,
             'is_warmup' => $this->is_warmup,

--- a/app/Policies/WorkoutTemplateSetPolicy.php
+++ b/app/Policies/WorkoutTemplateSetPolicy.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\WorkoutTemplateSet;
+
+final class WorkoutTemplateSetPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, WorkoutTemplateSet $workoutTemplateSet): bool
+    {
+        return $user->id === $workoutTemplateSet->workoutTemplateLine->workoutTemplate->user_id;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user, ?\App\Models\WorkoutTemplateLine $workoutTemplateLine = null): bool
+    {
+        if ($workoutTemplateLine === null) {
+            return true;
+        }
+
+        return $user->id === $workoutTemplateLine->workoutTemplate->user_id;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, WorkoutTemplateSet $workoutTemplateSet): bool
+    {
+        return $user->id === $workoutTemplateSet->workoutTemplateLine->workoutTemplate->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, WorkoutTemplateSet $workoutTemplateSet): bool
+    {
+        return $user->id === $workoutTemplateSet->workoutTemplateLine->workoutTemplate->user_id;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,6 +27,7 @@ Route::prefix('v1')->middleware(['auth:sanctum', app()->isProduction() ? 'thrott
     Route::apiResource('goals', GoalController::class);
     Route::apiResource('workout-templates', WorkoutTemplateController::class);
     Route::apiResource('workout-template-lines', \App\Http\Controllers\Api\WorkoutTemplateLineController::class);
+    Route::apiResource('workout-template-sets', \App\Http\Controllers\Api\WorkoutTemplateSetController::class);
     Route::apiResource('workout-lines', \App\Http\Controllers\Api\WorkoutLineController::class);
     Route::apiResource('daily-journals', \App\Http\Controllers\Api\DailyJournalController::class);
     Route::apiResource('fasts', \App\Http\Controllers\Api\FastController::class);


### PR DESCRIPTION
Implemented a complete API CRUD for `WorkoutTemplateSet` model:
- Created `WorkoutTemplateSetController` with `index`, `store`, `show`, `update`, and `destroy` operations.
- Added explicit FormRequests (`WorkoutTemplateSetStoreRequest`, `WorkoutTemplateSetUpdateRequest`) for secure validation.
- Created `WorkoutTemplateSetPolicy` to ensure users can only interact with template sets linked to their own workouts.
- Configured Route Model Binding and mapped outputs via `WorkoutTemplateSetResource`.
- Registered `workout-template-sets` via `Route::apiResource` in `routes/api.php`.

---
*PR created automatically by Jules for task [14890801815945440700](https://jules.google.com/task/14890801815945440700) started by @kuasar-mknd*