### PR TITLE
refactor: Extract logic from WorkoutsController

### DIFF
--- a/app/Actions/Workouts/CreateWorkoutAction.php
+++ b/app/Actions/Workouts/CreateWorkoutAction.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Workouts;
+
+use App\Models\User;
+use App\Models\Workout;
+use App\Services\StatsService;
+
+class CreateWorkoutAction
+{
+    public function __construct(protected StatsService $statsService)
+    {
+    }
+
+    public function execute(User $user): Workout
+    {
+        $workout = new Workout([
+            'started_at' => now(),
+            'name' => 'Séance du '.now()->format('d/m/Y'),
+        ]);
+        $workout->user_id = $user->id;
+        $workout->save();
+
+        $this->statsService->clearWorkoutRelatedStats($user);
+
+        return $workout;
+    }
+}

--- a/app/Http/Controllers/WorkoutsController.php
+++ b/app/Http/Controllers/WorkoutsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Actions\Workouts\CreateWorkoutAction;
 use App\Actions\Workouts\FetchWorkoutsIndexAction;
 use App\Actions\Workouts\UpdateWorkoutAction;
 use App\Http\Requests\UpdateWorkoutRequest;
@@ -93,18 +94,11 @@ class WorkoutsController extends Controller
      * @param  \Illuminate\Http\Request  $request  The HTTP request (currently unused for input but part of the signature).
      * @return \Illuminate\Http\RedirectResponse A redirect to the newly created workout.
      */
-    public function store(Request $request): \Illuminate\Http\RedirectResponse
+    public function store(Request $request, CreateWorkoutAction $createWorkout): \Illuminate\Http\RedirectResponse
     {
         $this->authorize('create', Workout::class);
 
-        $workout = new Workout([
-            'started_at' => now(),
-            'name' => 'Séance du '.now()->format('d/m/Y'),
-        ]);
-        $workout->user_id = $this->user()->id;
-        $workout->save();
-
-        $this->statsService->clearWorkoutRelatedStats($this->user());
+        $workout = $createWorkout->execute($this->user());
 
         return redirect()->route('workouts.show', $workout);
     }


### PR DESCRIPTION
- Identified `WorkoutsController::store` as a prime candidate for extracting business logic related to workout creation.
- Created `App\Actions\Workouts\CreateWorkoutAction` to handle creating the `Workout` and clearing related stats.
- Simplified `WorkoutsController@store` to inject and invoke this action.
- Ran `pint` to apply PSR-12 formatting.
- Verified functionality using Pest tests.

---
*PR created automatically by Jules for task [11941714999876595655](https://jules.google.com/task/11941714999876595655) started by @kuasar-mknd*