### PR TITLE
🎨 Palette: Add missing glass border to workout line tags

### DIFF
--- a/resources/js/Components/InputLabel.vue
+++ b/resources/js/Components/InputLabel.vue
@@ -7,7 +7,9 @@ defineProps({
 </script>
 
 <template>
-    <label class="mb-2 inline-flex cursor-pointer items-center rounded-2xl border border-white/20 bg-white/10 px-3 py-1.5 text-xs font-black tracking-widest text-slate-700 dark:text-white uppercase backdrop-blur-md transition-all duration-300 hover:scale-[1.02] hover:bg-white/20 active:scale-95 shadow-[0_4px_30px_rgba(0,0,0,0.1)] hover:shadow-[0_4px_30px_rgba(0,0,0,0.2)]">
+    <label
+        class="mb-2 inline-flex cursor-pointer items-center rounded-2xl border border-white/20 bg-white/10 px-3 py-1.5 text-xs font-black tracking-widest text-slate-700 uppercase shadow-[0_4px_30px_rgba(0,0,0,0.1)] backdrop-blur-md transition-all duration-300 hover:scale-[1.02] hover:bg-white/20 hover:shadow-[0_4px_30px_rgba(0,0,0,0.2)] active:scale-95 dark:text-white"
+    >
         <span v-if="value">{{ value }}</span>
         <span v-else><slot /></span>
     </label>

--- a/resources/js/Pages/Workouts/Index.vue
+++ b/resources/js/Pages/Workouts/Index.vue
@@ -311,7 +311,7 @@ const { isRefreshing, pullDistance } = usePullToRefresh()
                                             </span>
                                             <span
                                                 v-if="workout.workout_lines.length > 3"
-                                                class="text-text-muted/50 rounded-lg bg-white/50 px-2 py-1 text-xs"
+                                                class="text-text-muted/50 rounded-lg border border-slate-200 bg-white/50 px-2 py-1 text-xs dark:border-slate-700 dark:bg-slate-800/50"
                                             >
                                                 +{{ workout.workout_lines.length - 3 }}
                                             </span>


### PR DESCRIPTION
💡 What: Added missing glass border and dark mode background styles to the hidden exercise count tags (`+X`) on the workout history cards.
🎯 Why: It previously lacked borders, making it look flat and inconsistent with the adjacent exercise tags. It was also hard to read in dark mode. This change brings it in line with the "Liquid Glass" design system and the UX findings in `docs/ui/design_roast.md`.
📸 Before/After: Visual changes verified via Playwright screenshot in development. The `+X` badge now renders with a subtle border and matching background.
♿ Accessibility: Improves visual contrast and readability for the badge in both light and dark modes.

---
*PR created automatically by Jules for task [4196689169280781541](https://jules.google.com/task/4196689169280781541) started by @kuasar-mknd*