### PR TITLE
🎨 Palette: Fix workout delete confirmation and add haptic feedback

### DIFF
--- a/resources/js/Pages/Workouts/Show.vue
+++ b/resources/js/Pages/Workouts/Show.vue
@@ -89,7 +89,7 @@ const showCreateForm = ref(false)
 const localExercises = ref([...(props.exercises || [])].filter((e) => e && e.id))
 const showConfirmModal = ref(false)
 const confirmAction = ref(null)
-const confirmMessage = ''
+const confirmMessage = ref('')
 const showSettingsModal = ref(false)
 
 const settingsForm = useForm({
@@ -174,6 +174,10 @@ const closeModal = () => {
 }
 
 const removeLine = (lineId) => {
+    const line = localWorkout.value.workout_lines.find((l) => l.id === lineId)
+    confirmMessage.value = `Supprimer ${line?.exercise?.name || "l'exercice"} ?`
+    triggerHaptic('warning')
+
     confirmAction.value = () => {
         router.delete(route('workout-lines.destroy', { workout_line: lineId }), {
             preserveScroll: true,
@@ -186,6 +190,7 @@ const removeLine = (lineId) => {
 }
 
 const addSet = (lineId) => {
+    triggerHaptic('tap')
     const line = localWorkout.value.workout_lines.find((l) => l.id === lineId)
     const lastSet = line?.sets?.length > 0 ? line.sets[line.sets.length - 1] : null
 
@@ -221,6 +226,7 @@ const updateSet = (set, field, value) => {
 }
 
 const removeSet = (setId) => {
+    triggerHaptic('warning')
     SyncService.delete(route('api.v1.sets.destroy', { set: setId })).then(() => {
         router.reload({ preserveScroll: true, only: ['workout'] })
     })
@@ -556,9 +562,7 @@ const filteredExercises = computed(() => {
                     <GlassButton variant="secondary" @click="showConfirmModal = false" class="flex-1"
                         >Annuler</GlassButton
                     >
-                    <GlassButton variant="solid" @click="confirmAction" class="flex-1 bg-red-500 text-white"
-                        >Supprimer</GlassButton
-                    >
+                    <GlassButton variant="danger" @click="confirmAction" class="flex-1">Supprimer</GlassButton>
                 </div>
             </div>
         </Modal>


### PR DESCRIPTION
### 💡 What
Implemented a micro-UX improvement in the `Workouts/Show.vue` page. 
- Converted `confirmMessage` to a reactive `ref` and populated it with a descriptive message (e.g., "Supprimer [Exercice] ?") instead of an empty string.
- Switched the manual "Supprimer" button styling in the confirmation modal to use the `variant="danger"` from the `GlassButton` component.
- Added haptic feedback triggers for common workout actions: `triggerHaptic('tap')` when adding a set and `triggerHaptic('warning')` when deleting a set or an exercise line.

### 🎯 Why
- The previous confirmation modal was confusing as it displayed no text, just buttons.
- Using the standard `danger` variant ensures design consistency and better accessibility (proper focus/hover states).
- Haptic feedback provides immediate sensory confirmation during intense workouts, making the app feel more responsive and high-end.

### ♿ Accessibility & UX
- Better context for destructive actions (confirmation message).
- Standardized UI components (GlassButton danger variant).
- Tactile feedback for mobile users.

### ✅ Verification
- Ran `pest` tests for workout logging and lines; all passed.
- Verified visually with a Playwright script (screenshot attached in verification step).
- Checked for linting issues with `npm run lint:js`.

---
*PR created automatically by Jules for task [4320069417065550251](https://jules.google.com/task/4320069417065550251) started by @kuasar-mknd*