### PR TITLE
feat(viz): Add Bar Chart for Water Intake

### DIFF
--- a/resources/js/Components/Stats/WaterHistoryChart.vue
+++ b/resources/js/Components/Stats/WaterHistoryChart.vue
@@ -1,0 +1,94 @@
+<script setup>
+import { Bar } from 'vue-chartjs'
+import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale } from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+    goal: {
+        type: Number,
+        default: 2500,
+    },
+})
+
+const chartData = computed(() => {
+    return {
+        labels: props.data.map((item) => item.day_name.substring(0, 3)),
+        datasets: [
+            {
+                label: 'Volume (ml)',
+                data: props.data.map((item) => item.total),
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+                    const gradient = ctx.createLinearGradient(0, chartArea.top, 0, chartArea.bottom)
+                    gradient.addColorStop(0, '#3B82F6') // Blue-500
+                    gradient.addColorStop(1, '#93C5FD') // Blue-300
+                    return gradient
+                },
+                borderRadius: 6,
+                hoverBackgroundColor: '#2563EB', // Blue-600
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+        y: {
+            beginAtZero: true,
+            max: Math.max(props.goal, ...props.data.map((item) => item.total)) + 200, // Add some padding above goal
+            grid: {
+                color: 'rgba(0, 0, 0, 0.03)',
+            },
+            ticks: {
+                stepSize: 500,
+                color: '#64748B',
+                font: { size: 10, weight: 'bold' },
+            },
+        },
+        x: {
+            grid: {
+                display: false,
+            },
+            ticks: {
+                color: '#64748B',
+                font: { size: 10, weight: 'bold' },
+                textTransform: 'uppercase',
+            },
+        },
+    },
+    plugins: {
+        legend: {
+            display: false,
+        },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.9)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            padding: 12,
+            cornerRadius: 12,
+            borderWidth: 1,
+            borderColor: 'rgba(0, 0, 0, 0.05)',
+            callbacks: {
+                label: (context) => `${context.raw} ml`,
+                title: (context) => context[0].label,
+            },
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-[300px] w-full pt-4">
+        <Bar :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Tools/WaterTracker.vue
+++ b/resources/js/Pages/Tools/WaterTracker.vue
@@ -172,35 +172,7 @@
                         7 derniers jours
                     </h2>
 
-                    <div class="flex h-[300px] items-end justify-between gap-2 pt-4">
-                        <div
-                            v-for="day in history"
-                            :key="day.date"
-                            class="group relative flex flex-1 flex-col items-center justify-end"
-                        >
-                            <!-- Tooltip -->
-                            <div
-                                class="absolute -top-10 z-10 mb-2 rounded bg-slate-800 px-2 py-1 text-xs whitespace-nowrap text-white opacity-0 transition-opacity group-hover:opacity-100"
-                            >
-                                {{ day.total }} ml
-                            </div>
-
-                            <!-- Bar -->
-                            <div
-                                class="relative w-full overflow-hidden rounded-t-lg bg-slate-100 transition-all duration-500 group-hover:bg-blue-100"
-                                :style="{ height: `${Math.min((day.total / goal) * 100, 100)}%` }"
-                            >
-                                <div
-                                    class="absolute top-0 right-0 bottom-0 left-0 bg-blue-500/20 transition-colors group-hover:bg-blue-500/30"
-                                ></div>
-                                <!-- Fill based on goal cap? Actually visual height is mostly useful relative to goal -->
-                            </div>
-
-                            <span class="text-text-muted mt-2 w-full truncate text-center text-xs font-bold uppercase">
-                                {{ day.day_name.substring(0, 3) }}
-                            </span>
-                        </div>
-                    </div>
+                    <WaterHistoryChart :data="history" :goal="goal" />
                 </GlassCard>
             </div>
         </div>
@@ -208,11 +180,13 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, defineAsyncComponent } from 'vue'
 import { Head, useForm, router } from '@inertiajs/vue3'
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
 import GlassCard from '@/Components/UI/GlassCard.vue'
 import GlassButton from '@/Components/UI/GlassButton.vue'
+
+const WaterHistoryChart = defineAsyncComponent(() => import('@/Components/Stats/WaterHistoryChart.vue'))
 
 const props = defineProps({
     logs: {


### PR DESCRIPTION
Adds a new data visualization component, `WaterHistoryChart.vue`, utilizing `vue-chartjs` to display the last 7 days of water intake. Replaces the inline HTML/CSS bar implementations in the `WaterTracker.vue` tool with this new `defineAsyncComponent` imported component. This enhances UI consistency by extending the standard 'Liquid Glass' UI (glass backgrounds and custom canvas gradients) to the water tracker tool.

---
*PR created automatically by Jules for task [15634367707812098884](https://jules.google.com/task/15634367707812098884) started by @kuasar-mknd*