### PR TITLE
docs: Update documentation for PersonalRecordService

### DIFF
--- a/app/Services/PersonalRecordService.php
+++ b/app/Services/PersonalRecordService.php
@@ -12,11 +12,25 @@ use App\Traits\CalculatesOneRepMax;
 
 /**
  * Service for managing Personal Records (PRs).
+ *
+ * This service calculates and updates a user's personal records (e.g., max weight,
+ * max 1RM, max volume set) after a workout set is completed. It also handles
+ * dispatching notifications when new records are achieved.
  */
 final class PersonalRecordService
 {
     use CalculatesOneRepMax;
 
+    /**
+     * Synchronize personal records based on a completed set.
+     *
+     * Evaluates the given set against the user's existing personal records for the
+     * associated exercise. If the set establishes a new record for any tracked metric,
+     * the corresponding PersonalRecord is created or updated.
+     *
+     * @param  \App\Models\Set  $set  The workout set to evaluate for potential PRs.
+     * @param  \App\Models\User|null  $user  The user who performed the set (optional, resolved from set if null).
+     */
     public function syncSetPRs(Set $set, ?User $user = null): void
     {
         if ($this->shouldSkipSync($set)) {
@@ -42,6 +56,21 @@ final class PersonalRecordService
         $this->processUpdates($user, (int) $exerciseId, $set);
     }
 
+    /**
+     * Create or update a specific personal record type.
+     *
+     * Compares the new value against the existing record (if any). If the new value
+     * is greater, it persists the new record and optionally sends a notification
+     * to the user if they have PR notifications enabled.
+     *
+     * @param  \App\Models\User  $user  The user achieving the PR.
+     * @param  int  $exerciseId  The ID of the exercise.
+     * @param  string  $type  The type of PR (e.g., 'max_weight', 'max_1rm', 'max_volume_set').
+     * @param  float  $value  The primary value of the new record.
+     * @param  float|null  $secondary  An optional secondary value (e.g., reps associated with max weight).
+     * @param  \App\Models\Set  $set  The set that achieved this record.
+     * @param  \App\Models\PersonalRecord|null  $pr  The existing personal record, if any.
+     */
     protected function update(User $user, int $exerciseId, string $type, float $value, ?float $secondary, Set $set, ?PersonalRecord $pr): void
     {
         if ($pr && $value <= $pr->value) {
@@ -56,11 +85,30 @@ final class PersonalRecordService
         }
     }
 
+    /**
+     * Determine if a set should be excluded from PR evaluation.
+     *
+     * Warmup sets, or sets missing either weight or reps, are not considered
+     * valid for setting personal records.
+     *
+     * @param  \App\Models\Set  $set  The set to check.
+     * @return bool True if the set should be skipped, false otherwise.
+     */
     private function shouldSkipSync(Set $set): bool
     {
         return $set->is_warmup || ! $set->weight || ! $set->reps;
     }
 
+    /**
+     * Process all tracked PR metrics for a valid set.
+     *
+     * Retrieves existing PRs for the user and exercise, then evaluates the set
+     * against each tracked metric (max weight, estimated 1RM, max volume per set).
+     *
+     * @param  \App\Models\User  $user  The user who performed the set.
+     * @param  int  $exerciseId  The ID of the exercise.
+     * @param  \App\Models\Set  $set  The completed valid set.
+     */
     private function processUpdates(User $user, int $exerciseId, Set $set): void
     {
         $existingPRs = PersonalRecord::where('user_id', $user->id)


### PR DESCRIPTION
As a Lead Technical Writer, I've scanned the codebase for complex classes lacking documentation and identified `app/Services/PersonalRecordService.php` as a critical file needing explanation.

This PR adds comprehensive PHPDoc blocks to `PersonalRecordService`, including:
- A class-level description explaining the service's role in calculating and updating user personal records and dispatching notifications.
- Method-level descriptions for `syncSetPRs`, `update`, `shouldSkipSync`, and `processUpdates`.
- Detailed `@param` and `@return` tags with proper typing and descriptions.

No core logic was modified. This ensures the Gym Tracker codebase remains readable and well-documented. Static analysis (`phpstan`), formatting (`pint`), and tests (`pest`) have all been successfully run to verify the changes.

---
*PR created automatically by Jules for task [2274246223316801131](https://jules.google.com/task/2274246223316801131) started by @kuasar-mknd*