### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/resources/js/Components/Stats/BodyPartDiffChart.vue
+++ b/resources/js/Components/Stats/BodyPartDiffChart.vue
@@ -1,14 +1,6 @@
 <script setup>
 import { Bar } from 'vue-chartjs'
-import {
-    Chart as ChartJS,
-    CategoryScale,
-    LinearScale,
-    BarElement,
-    Title,
-    Tooltip,
-    Legend,
-} from 'chart.js'
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js'
 import { computed } from 'vue'
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
@@ -22,7 +14,7 @@ const props = defineProps({
 
 const chartData = computed(() => {
     // Filter out parts with no difference
-    const diffData = props.data.filter(item => item.diff !== 0)
+    const diffData = props.data.filter((item) => item.diff !== 0)
 
     return {
         labels: diffData.map((item) => item.part),
@@ -76,7 +68,7 @@ const chartOptions = {
                     const value = context.parsed.x
                     const sign = value > 0 ? '+' : ''
                     // Find the unit for this part
-                    const partData = props.data.find(d => d.part === context.label)
+                    const partData = props.data.find((d) => d.part === context.label)
                     const unit = partData ? partData.unit : ''
                     return `${sign}${value} ${unit}`
                 },

--- a/resources/js/Pages/Habits/Index.vue
+++ b/resources/js/Pages/Habits/Index.vue
@@ -298,10 +298,18 @@ const getProgressPercent = (habit) => {
 
                             <!-- Actions (Absolute) -->
                             <div class="absolute top-2 right-2 flex opacity-0 transition group-hover:opacity-100">
-                                <button @click="editHabit(habit)" class="text-text-muted hover:text-text-main p-1">
+                                <button
+                                    @click="editHabit(habit)"
+                                    class="text-text-muted hover:text-text-main p-1"
+                                    aria-label="Modifier l'habitude"
+                                >
                                     <span class="material-symbols-outlined text-sm">edit</span>
                                 </button>
-                                <button @click="deleteHabit(habit)" class="text-text-muted p-1 hover:text-red-500">
+                                <button
+                                    @click="deleteHabit(habit)"
+                                    class="text-text-muted p-1 hover:text-red-500"
+                                    aria-label="Supprimer l'habitude"
+                                >
                                     <span class="material-symbols-outlined text-sm">delete</span>
                                 </button>
                             </div>
@@ -339,7 +347,11 @@ const getProgressPercent = (habit) => {
                     <h3 class="text-text-main text-xl font-bold">
                         {{ editingHabit ? 'Modifier' : 'Nouvelle Habitude' }}
                     </h3>
-                    <button @click="showAddForm = false" class="text-text-muted hover:text-text-main">
+                    <button
+                        @click="showAddForm = false"
+                        class="text-text-muted hover:text-text-main"
+                        aria-label="Fermer le formulaire"
+                    >
                         <span class="material-symbols-outlined">close</span>
                     </button>
                 </div>

--- a/resources/js/Pages/Journal/Index.vue
+++ b/resources/js/Pages/Journal/Index.vue
@@ -199,7 +199,13 @@ const formatDate = (dateStr) => {
                     <h3 class="text-text-main font-semibold">
                         {{ editingJournal ? "Modifier l'entrée" : 'Nouvelle entrée' }}
                     </h3>
-                    <button @click="showAddForm = false" class="text-text-muted hover:text-text-main">✕</button>
+                    <button
+                        @click="showAddForm = false"
+                        class="text-text-muted hover:text-text-main"
+                        aria-label="Fermer le formulaire"
+                    >
+                        ✕
+                    </button>
                 </div>
 
                 <form @submit.prevent="submit" class="space-y-4">
@@ -420,6 +426,7 @@ const formatDate = (dateStr) => {
                                             <button
                                                 @click="editJournal(journal)"
                                                 class="text-text-muted/50 hover:text-text-main rounded p-1 hover:bg-slate-100/50"
+                                                aria-label="Modifier l'entrée"
                                             >
                                                 <svg
                                                     class="h-4 w-4"
@@ -438,6 +445,7 @@ const formatDate = (dateStr) => {
                                             <button
                                                 @click="deleteJournal(journal.id)"
                                                 class="text-text-muted/50 rounded p-1 hover:bg-slate-100/50 hover:text-red-400"
+                                                aria-label="Supprimer l'entrée"
                                             >
                                                 <svg
                                                     class="h-4 w-4"

--- a/resources/js/Pages/Measurements/Parts/Index.vue
+++ b/resources/js/Pages/Measurements/Parts/Index.vue
@@ -127,13 +127,18 @@ const selectCommonPart = (part) => {
             </GlassCard>
 
             <!-- Chart -->
-            <GlassCard v-if="latestMeasurements.some(m => m.diff !== 0)" class="animate-slide-up">
-                <h3 class="font-display mb-4 text-xs font-black tracking-[0.2em] text-emerald-500 uppercase">Évolution Récente</h3>
+            <GlassCard v-if="latestMeasurements.some((m) => m.diff !== 0)" class="animate-slide-up">
+                <h3 class="font-display mb-4 text-xs font-black tracking-[0.2em] text-emerald-500 uppercase">
+                    Évolution Récente
+                </h3>
                 <BodyPartDiffChart :data="latestMeasurements" />
             </GlassCard>
 
             <!-- Grid -->
-            <div class="animate-slide-up grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" style="animation-delay: 0.1s">
+            <div
+                class="animate-slide-up grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+                style="animation-delay: 0.1s"
+            >
                 <Link
                     v-for="item in latestMeasurements"
                     :key="item.part"


### PR DESCRIPTION
💡 **What:**
Added `aria-label` attributes to various icon-only buttons in `Habits/Index.vue` and `Journal/Index.vue` (e.g., Edit, Delete, Close Form buttons).

🎯 **Why:**
Users relying on screen readers or keyboard navigation lacked context for these actions, as the buttons only contained an icon (SVG/Material Symbol) without accessible text. This improves accessibility.

♿ **Accessibility:**
- `Habits/Index.vue`: Added `aria-label="Modifier l'habitude"`, `aria-label="Supprimer l'habitude"`, `aria-label="Fermer le formulaire"`.
- `Journal/Index.vue`: Added `aria-label="Modifier l'entrée"`, `aria-label="Supprimer l'entrée"`, `aria-label="Fermer le formulaire"`.

---
*PR created automatically by Jules for task [18395124477102379431](https://jules.google.com/task/18395124477102379431) started by @kuasar-mknd*