### PR TITLE
refactor: Extract logic from WorkoutTemplateSetController

### DIFF
--- a/app/Actions/WorkoutTemplates/CreateWorkoutTemplateSetAction.php
+++ b/app/Actions/WorkoutTemplates/CreateWorkoutTemplateSetAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\WorkoutTemplates;
+
+use App\Models\WorkoutTemplateLine;
+use App\Models\WorkoutTemplateSet;
+
+class CreateWorkoutTemplateSetAction
+{
+    /**
+     * Create a new workout template set for a workout template line.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function execute(WorkoutTemplateLine $workoutTemplateLine, array $data): WorkoutTemplateSet
+    {
+        /** @var int|null $maxOrder */
+        $maxOrder = $workoutTemplateLine->workoutTemplateSets()->max('order');
+        $order = $data['order'] ?? ($maxOrder === null ? 0 : $maxOrder + 1);
+
+        /** @var \App\Models\WorkoutTemplateSet $workoutTemplateSet */
+        $workoutTemplateSet = $workoutTemplateLine->workoutTemplateSets()->create(array_merge(
+            collect($data)->except('workout_template_line_id')->toArray(),
+            ['order' => $order]
+        ));
+
+        return $workoutTemplateSet;
+    }
+}

--- a/app/Http/Controllers/Api/WorkoutTemplateSetController.php
+++ b/app/Http/Controllers/Api/WorkoutTemplateSetController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\WorkoutTemplates\CreateWorkoutTemplateSetAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\WorkoutTemplateSetStoreRequest;
 use App\Http\Requests\Api\WorkoutTemplateSetUpdateRequest;
@@ -39,7 +40,7 @@ class WorkoutTemplateSetController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(WorkoutTemplateSetStoreRequest $request): WorkoutTemplateSetResource
+    public function store(WorkoutTemplateSetStoreRequest $request, CreateWorkoutTemplateSetAction $action): WorkoutTemplateSetResource
     {
         /** @var array{workout_template_line_id: int, reps?: int|null, weight?: float|null, is_warmup: bool, order?: int|null} $validated */
         $validated = $request->validated();
@@ -49,15 +50,7 @@ class WorkoutTemplateSetController extends Controller
 
         $this->authorize('create', [WorkoutTemplateSet::class, $workoutTemplateLine]);
 
-        /** @var int|null $maxOrder */
-        $maxOrder = $workoutTemplateLine->workoutTemplateSets()->max('order');
-        $order = $validated['order'] ?? ($maxOrder === null ? 0 : $maxOrder + 1);
-
-        /** @var \App\Models\WorkoutTemplateSet $workoutTemplateSet */
-        $workoutTemplateSet = $workoutTemplateLine->workoutTemplateSets()->create(array_merge(
-            collect($validated)->except('workout_template_line_id')->toArray(),
-            ['order' => $order]
-        ));
+        $workoutTemplateSet = $action->execute($workoutTemplateLine, $validated);
 
         return new WorkoutTemplateSetResource($workoutTemplateSet);
     }


### PR DESCRIPTION
Extracts the business logic out of `WorkoutTemplateSetController::store` into a dedicated `CreateWorkoutTemplateSetAction` class and refactors the controller to just call this Action, ensuring a cleaner controller and alignment with SOLID principles. Formatted using Laravel Pint. Tests and Static Analysis complete.

---
*PR created automatically by Jules for task [4699980948224625752](https://jules.google.com/task/4699980948224625752) started by @kuasar-mknd*