### PR TITLE
feat(viz): Add Average Weight Chart for Exercise History

### DIFF
--- a/resources/js/Components/Stats/AverageWeightChart.vue
+++ b/resources/js/Components/Stats/AverageWeightChart.vue
@@ -1,0 +1,105 @@
+<script setup>
+import { Line } from 'vue-chartjs'
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend,
+    Filler,
+} from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    return {
+        labels: props.data.map((item) => item.date),
+        datasets: [
+            {
+                label: 'Charge Moyenne (kg)',
+                data: props.data.map((item) => item.weight),
+                fill: true,
+                tension: 0.4,
+                borderColor: '#6366f1', // Indigo
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+                    const gradient = ctx.createLinearGradient(0, chartArea.top, 0, chartArea.bottom)
+                    gradient.addColorStop(0, 'rgba(99, 102, 241, 0.2)') // Indigo with opacity
+                    gradient.addColorStop(1, 'rgba(99, 102, 241, 0)') // Transparent
+                    return gradient
+                },
+                borderWidth: 3,
+                pointRadius: 3,
+                pointBackgroundColor: '#fff',
+                pointBorderColor: '#6366f1',
+                pointBorderWidth: 2,
+                pointHoverRadius: 6,
+                pointHoverBackgroundColor: '#6366f1',
+                pointHoverBorderColor: '#fff',
+                pointHoverBorderWidth: 2,
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: {
+            display: false,
+        },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.9)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            padding: 12,
+            cornerRadius: 12,
+            borderWidth: 1,
+            borderColor: 'rgba(99, 102, 241, 0.1)',
+            callbacks: {
+                label: (context) => `${context.parsed.y} kg`,
+            },
+        },
+    },
+    scales: {
+        x: {
+            grid: {
+                display: false,
+            },
+            ticks: {
+                color: '#64748B',
+                font: { size: 10, weight: 'bold' },
+            },
+        },
+        y: {
+            grid: {
+                color: 'rgba(0, 0, 0, 0.03)',
+            },
+            ticks: {
+                color: '#64748B',
+                font: { size: 10, weight: 'bold' },
+            },
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-full w-full">
+        <Line :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Exercises/Show.vue
+++ b/resources/js/Pages/Exercises/Show.vue
@@ -9,6 +9,7 @@ const VolumeTrendChart = defineAsyncComponent(() => import('@/Components/Stats/V
 const WeightDistributionChart = defineAsyncComponent(() => import('@/Components/Stats/WeightDistributionChart.vue'))
 const MaxRepsChart = defineAsyncComponent(() => import('@/Components/Stats/MaxRepsChart.vue'))
 const MaxWeightChart = defineAsyncComponent(() => import('@/Components/Stats/MaxWeightChart.vue'))
+const AverageWeightChart = defineAsyncComponent(() => import('@/Components/Stats/AverageWeightChart.vue'))
 
 /**
  * Component Props
@@ -64,6 +65,19 @@ const maxWeightData = computed(() => {
         date: session.formatted_date.split('/').slice(0, 2).join('/'),
         weight: session.sets.length > 0 ? Math.max(...session.sets.map((s) => parseFloat(s.weight) || 0)) : 0,
     }))
+})
+
+const averageWeightData = computed(() => {
+    if (!props.history || props.history.length === 0) return []
+    return [...props.history].reverse().map((session) => {
+        const setsWithWeight = session.sets.filter((s) => parseFloat(s.weight) > 0)
+        const totalWeight = setsWithWeight.reduce((sum, s) => sum + parseFloat(s.weight), 0)
+        const average = setsWithWeight.length > 0 ? (totalWeight / setsWithWeight.length).toFixed(1) : 0
+        return {
+            date: session.formatted_date.split('/').slice(0, 2).join('/'),
+            weight: average,
+        }
+    })
 })
 
 const weightDistributionData = computed(() => {
@@ -180,6 +194,16 @@ const weightDistributionData = computed(() => {
                     </div>
                     <div class="h-64">
                         <MaxWeightChart :data="maxWeightData" />
+                    </div>
+                </GlassCard>
+
+                <GlassCard>
+                    <div class="mb-4">
+                        <h3 class="font-display text-text-main text-lg font-black uppercase italic">Charge Moyenne</h3>
+                        <p class="text-text-muted text-xs font-semibold">Poids moyen par série (kg)</p>
+                    </div>
+                    <div class="h-64">
+                        <AverageWeightChart :data="averageWeightData" />
                     </div>
                 </GlassCard>
             </div>


### PR DESCRIPTION
This PR introduces a new visualization to the Exercise Detail view.

It addresses the lack of visual insight into the "Average Weight" lifted per session over time, which was previously only available as raw set data within the session history list.

**Changes:**
1. Created `resources/js/Components/Stats/AverageWeightChart.vue` - A `vue-chartjs` Line chart tailored with an indigo gradient that matches the application's design system.
2. Updated `resources/js/Pages/Exercises/Show.vue`:
    - Imported the new chart component.
    - Added a computed property `averageWeightData` that maps over the `history` array to calculate the average weight for each session.
    - Integrated the chart into the "Analytics Grid" using the `<GlassCard>` component to fulfill the "Liquid Glass" aesthetic requirement.

---
*PR created automatically by Jules for task [1720616400317544874](https://jules.google.com/task/1720616400317544874) started by @kuasar-mknd*