### PR TITLE
refactor: Extract logic from FastingController

### DIFF
--- a/app/Actions/Fasting/FetchFastingIndexAction.php
+++ b/app/Actions/Fasting/FetchFastingIndexAction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Fasting;
+
+use App\Models\User;
+
+class FetchFastingIndexAction
+{
+    /**
+     * Execute the action.
+     *
+     * @return array<string, mixed>
+     */
+    public function execute(User $user): array
+    {
+        $activeFast = $user->fasts()
+            ->where('status', 'active')
+            ->latest()
+            ->first();
+
+        $history = $user->fasts()
+            ->where('status', '!=', 'active')
+            ->latest()
+            ->paginate(10)
+            ->withQueryString();
+
+        return [
+            'activeFast' => $activeFast,
+            'history' => $history,
+        ];
+    }
+}

--- a/app/Http/Controllers/FastingController.php
+++ b/app/Http/Controllers/FastingController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Actions\Fasting\FetchFastingIndexAction;
 use App\Http\Requests\Api\StoreFastRequest;
 use App\Http\Requests\Api\UpdateFastRequest;
 use App\Models\Fast;
@@ -13,27 +14,13 @@ use Inertia\Response;
 
 class FastingController extends Controller
 {
-    public function index(): Response
+    public function index(FetchFastingIndexAction $fetchFastingIndexAction): Response
     {
         $this->authorize('viewAny', Fast::class);
 
-        $user = $this->user();
+        $data = $fetchFastingIndexAction->execute($this->user());
 
-        $activeFast = $user->fasts()
-            ->where('status', 'active')
-            ->latest()
-            ->first();
-
-        $history = $user->fasts()
-            ->where('status', '!=', 'active')
-            ->latest()
-            ->paginate(10)
-            ->withQueryString();
-
-        return Inertia::render('Tools/Fasting/Index', [
-            'activeFast' => $activeFast,
-            'history' => $history,
-        ]);
+        return Inertia::render('Tools/Fasting/Index', $data);
     }
 
     public function store(StoreFastRequest $request): RedirectResponse


### PR DESCRIPTION
Extracts the business logic out of the `FastingController::index` method into a dedicated `FetchFastingIndexAction` class to follow SOLID principles and improve code readability and maintainability.

- Tested with PHPStan level 5 and Pest tests pass.
- Used Laravel Pint to ensure code follows PSR-12.

---
*PR created automatically by Jules for task [1905320991584778580](https://jules.google.com/task/1905320991584778580) started by @kuasar-mknd*