### PR TITLE
docs: Update documentation for app/Http/Controllers/StatsController.php

### DIFF
--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -10,14 +10,32 @@ use App\Services\StatsService;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 
+/**
+ * Controller for displaying user statistics dashboards.
+ *
+ * This controller aggregates and formats data related to user workouts,
+ * volume, and body measurements to be presented on the frontend.
+ */
 class StatsController extends Controller
 {
+    /**
+     * Create a new StatsController instance.
+     *
+     * @param  \App\Services\StatsService  $statsService  Service for retrieving stats data.
+     */
     public function __construct(protected StatsService $statsService)
     {
     }
 
     /**
      * Display the main statistics dashboard with Deferred Loading (Inertia 2.0).
+     *
+     * Retrieves immediate data for fast initial rendering and uses Inertia's
+     * deferred loading for heavier analytical queries (like trends and distributions).
+     *
+     * @param  \Illuminate\Http\Request  $request  The incoming HTTP request.
+     * @param  \App\Actions\Stats\FetchStatsOverviewAction  $fetchStatsOverview  Action to fetch overview stats.
+     * @return \Inertia\Response The Inertia response rendering the 'Stats/Index' page.
      */
     public function index(Request $request, FetchStatsOverviewAction $fetchStatsOverview): \Inertia\Response
     {
@@ -41,7 +59,10 @@ class StatsController extends Controller
     }
 
     /**
-     * Get 1RM progress for a specific exercise as JSON.
+     * Get 1RM (One Rep Max) progress for a specific exercise as JSON.
+     *
+     * @param  \App\Models\Exercise  $exercise  The exercise to get progress for.
+     * @return \Illuminate\Http\JsonResponse JSON response containing the progress data.
      */
     public function exercise(Exercise $exercise): \Illuminate\Http\JsonResponse
     {


### PR DESCRIPTION
This PR adds missing PHPDoc comments to `app/Http/Controllers/StatsController.php` to improve codebase readability and documentation.

The logic within the controller remains completely untouched.

Changes:
- Added class-level docblock explaining the controller's purpose.
- Added parameter documentation for the constructor.
- Added detailed docblocks for `index` and `exercise` methods, defining parameters and return types, and highlighting the use of Inertia Deferred Loading.

---
*PR created automatically by Jules for task [11800049151989673091](https://jules.google.com/task/11800049151989673091) started by @kuasar-mknd*