### PR TITLE
🛡️ Sentinel: Fix mass assignment of denormalized statistics

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Found `AdminPolicy` returning `true` for all methods, allowing regular users to list, view, create, update, and delete administrative accounts via the API.
 **Learning:** Defaulting policies to `true` for administrative resources is extremely dangerous, particularly when the application's default authentication guard resolves to a regular `User` model.
 **Prevention:** Always default policy methods to `false` and implement a strict "deny-by-default" posture for administrative resources.
+
+## 2026-03-09 - Mass Assignment of Denormalized Statistics
+**Vulnerability:** Found `total_volume` in `User` and `workout_volume` in `Workout` models were included in the `$fillable` array and `UpdateUserRequest`.
+**Learning:** Denormalized fields used for performance (like aggregates) should never be mass-assignable. Even if they are not explicitly exposed in the UI, they can be manipulated via direct API calls if not protected at the model level.
+**Prevention:** Strictly exclude denormalized and calculated fields from `$fillable` properties and FormRequest validation rules. Use explicit `increment()`/`decrement()` or dedicated service methods for these updates.

--- a/app/Http/Requests/Api/StoreUserRequest.php
+++ b/app/Http/Requests/Api/StoreUserRequest.php
@@ -31,7 +31,6 @@ class StoreUserRequest extends FormRequest
             'provider_id' => ['nullable', 'string', 'max:255'],
             'avatar' => ['nullable', 'string', 'max:255'],
             'default_rest_time' => ['nullable', 'integer', 'min:0'],
-            'total_volume' => ['nullable', 'numeric', 'min:0'],
         ];
     }
 }

--- a/app/Http/Requests/Api/UpdateUserRequest.php
+++ b/app/Http/Requests/Api/UpdateUserRequest.php
@@ -38,7 +38,6 @@ class UpdateUserRequest extends FormRequest
             'provider_id' => ['nullable', 'string', 'max:255'],
             'avatar' => ['nullable', 'string', 'max:255'],
             'default_rest_time' => ['nullable', 'integer', 'min:0'],
-            'total_volume' => ['nullable', 'numeric', 'min:0'],
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -56,7 +56,6 @@ final class User extends Authenticatable implements MustVerifyEmail
         'provider_id',
         'avatar',
         'default_rest_time',
-        'total_volume',
     ];
 
     /**

--- a/app/Models/Workout.php
+++ b/app/Models/Workout.php
@@ -27,7 +27,6 @@ class Workout extends Model
 
     protected $fillable = [
         'name',
-        'workout_volume',
         'started_at',
         'ended_at',
         'notes',


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Denormalized statistic fields (total_volume and workout_volume) were mass-assignable.
🎯 Impact: Users could potentially manipulate their total volume or workout volume statistics by sending these fields in an API request, bypassing the actual workout data.
🔧 Fix: Removed these fields from the $fillable property in User and Workout models, and from the StoreUserRequest and UpdateUserRequest validation rules.
✅ Verification: Created a test that attempts to update total_volume via the API (with policy bypass) and verified that the value does not change. Verified that existing tests for set/workout volume calculations still pass as they use increment().

---
*PR created automatically by Jules for task [5891702764266251708](https://jules.google.com/task/5891702764266251708) started by @kuasar-mknd*