### PR TITLE
feat(viz): Add Bar Chart for Volume

### DIFF
--- a/resources/js/Components/Stats/RecentWorkoutsChart.vue
+++ b/resources/js/Components/Stats/RecentWorkoutsChart.vue
@@ -1,0 +1,95 @@
+<script setup>
+import { Bar } from 'vue-chartjs'
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    // Reverse the data so it reads chronologically from left to right
+    const reversedData = [...props.data].reverse()
+
+    const labels = reversedData.map((d) => {
+        const date = new Date(d.started_at)
+        return date.toLocaleDateString('fr-FR', {
+            day: 'numeric',
+            month: 'short',
+        })
+    })
+
+    const volumes = reversedData.map((d) => d.workout_volume || 0)
+
+    return {
+        labels,
+        datasets: [
+            {
+                label: 'Volume (kg)',
+                data: volumes,
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+
+                    const gradient = ctx.createLinearGradient(0, chartArea.bottom, 0, chartArea.top)
+                    gradient.addColorStop(0, '#FF5500') // electric-orange
+                    gradient.addColorStop(1, '#FF0080') // hot-pink
+
+                    return gradient
+                },
+                borderRadius: 8,
+                barPercentage: 0.6,
+                borderWidth: 0,
+                hoverBackgroundColor: '#8800FF', // vivid-violet
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: { display: false },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.95)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            borderColor: 'rgba(255, 85, 0, 0.2)',
+            borderWidth: 1,
+            padding: 10,
+            cornerRadius: 12,
+            displayColors: false,
+            callbacks: {
+                label: (context) => `${context.parsed.y} kg`,
+            },
+        },
+    },
+    scales: {
+        x: {
+            grid: { display: false },
+            ticks: {
+                color: '#94a3b8',
+                font: { size: 10, weight: 'bold', family: 'sans-serif' },
+            },
+            border: { display: false },
+        },
+        y: {
+            display: false,
+            beginAtZero: true,
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-48 w-full">
+        <Bar :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -8,6 +8,7 @@ import { defineAsyncComponent } from 'vue'
 const WeeklyVolumeChart = defineAsyncComponent(() => import('@/Components/Stats/WeeklyVolumeChart.vue'))
 const DurationDistributionChart = defineAsyncComponent(() => import('@/Components/Stats/DurationDistributionChart.vue'))
 const TimeOfDayChart = defineAsyncComponent(() => import('@/Components/Stats/TimeOfDayChart.vue'))
+const RecentWorkoutsChart = defineAsyncComponent(() => import('@/Components/Stats/RecentWorkoutsChart.vue'))
 
 /**
  * Dashboard - Command Center
@@ -257,6 +258,32 @@ const colorForWorkout = (index) => {
                     />
                     <div v-else class="text-text-muted flex h-full items-center justify-center">
                         <p class="text-sm">Pas assez de données (90j)</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Recent Workouts Volume Chart -->
+            <section
+                class="glass-panel-light animate-slide-up relative overflow-hidden rounded-3xl p-6"
+                style="animation-delay: 0.19s"
+            >
+                <div class="relative z-10 mb-6">
+                    <h3 class="text-electric-orange mb-1 text-[10px] font-black tracking-[0.2em] uppercase">
+                        Progression
+                    </h3>
+                    <p class="font-display text-text-main text-2xl font-black uppercase italic dark:text-white">
+                        Volume Récent
+                    </p>
+                </div>
+
+                <!-- Recent Workouts Bar Chart -->
+                <div class="relative -mx-2 mt-2 h-48 w-auto">
+                    <RecentWorkoutsChart
+                        v-if="recentWorkouts && recentWorkouts.some((w) => w.workout_volume > 0)"
+                        :data="recentWorkouts"
+                    />
+                    <div v-else class="text-text-muted flex h-full items-center justify-center">
+                        <p class="text-sm">Pas assez de données de volume</p>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
Added a new `RecentWorkoutsChart.vue` component to visually display recent workout volume progression. It utilizes `vue-chartjs` with the application's Liquid Glass gradient styling. The chart has been integrated into the `Dashboard.vue` page, right above the "Activité Récente" section, taking advantage of the pre-existing `recentWorkouts` array and deferred loading. All styling formats, tests, and frontend verifications successfully passed.

---
*PR created automatically by Jules for task [1049007698182133243](https://jules.google.com/task/1049007698182133243) started by @kuasar-mknd*