### PR TITLE
⚡ Bolt: Offload goal and achievement sync to background jobs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,11 @@
 ## 2025-05-24 - [Dashboard Cache Bypass]
 **Learning:** Fetching raw models with `first()` on the dashboard (e.g., `$user->bodyMeasurements()->latest()->first()`) directly bypasses caching layers specifically built for those metrics in `StatsService` (e.g., `getLatestBodyMetrics()`). This creates a redundant database query on every dashboard load.
 **Action:** When gathering metrics for the dashboard, always verify if a cached aggregate or getter method already exists in `StatsService` before querying Eloquent relations directly.
+
+## 2026-03-10 - [Asynchronous Goal/Achievement Sync]
+**Learning:** Performing heavy goal and achievement synchronization in synchronous model observers blocks the user's request (e.g. saving a set). For a typical workout with 20-30 sets, this adds significant overhead.
+**Action:** Offload synchronization logic to unique background jobs (`SyncUserAchievements`, `SyncUserGoals`) to keep the main request thread fast.
+
+## 2026-03-10 - [SQL-based Aggregate Calculation]
+**Learning:** Loading all of a user's workout data into PHP memory to find a maximum value (e.g. max volume goal) is inefficient and memory-intensive as data grows.
+**Action:** Always perform aggregate calculations (MAX, SUM, AVG) directly in SQL using database grouping and sorting for maximum performance and minimal memory footprint.

--- a/app/Jobs/RecalculateUserStats.php
+++ b/app/Jobs/RecalculateUserStats.php
@@ -23,8 +23,8 @@ final class RecalculateUserStats implements ShouldQueue
      */
     public function handle(\App\Services\StatsService $statsService): void
     {
-        // Invalidate all stats for this user
-        \Illuminate\Support\Facades\Cache::tags(["stats:{$this->user->id}"])->flush();
+        // ⚡ Bolt: Use surgical cache invalidation instead of tags() as database driver doesn't support tags.
+        $statsService->clearUserStatsCache($this->user);
 
         // Warm up critical stats
         $statsService->getVolumeTrend($this->user, 30);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,8 +7,6 @@ namespace App\Providers;
 use App\Models\BodyMeasurement;
 use App\Models\Set;
 use App\Models\Workout;
-use App\Services\AchievementService;
-use App\Services\GoalService;
 use App\Services\PersonalRecordService;
 use App\Services\StreakService;
 use Illuminate\Database\Eloquent\Model;
@@ -70,8 +68,9 @@ final class AppServiceProvider extends ServiceProvider
                 app(PersonalRecordService::class)->syncSetPRs($set, $user);
             }
 
-            app(AchievementService::class)->syncAchievements($user);
-            app(GoalService::class)->syncGoals($user);
+            // ⚡ Bolt: Offload heavy sync to background jobs
+            \App\Jobs\SyncUserAchievements::dispatch($user);
+            \App\Jobs\SyncUserGoals::dispatch($user);
         });
     }
 
@@ -81,14 +80,16 @@ final class AppServiceProvider extends ServiceProvider
             // Streak is only updated when a workout is "finished" or has a date
             app(StreakService::class)->updateStreak($workout->user, $workout);
 
-            app(AchievementService::class)->syncAchievements($workout->user);
-            app(GoalService::class)->syncGoals($workout->user);
+            // ⚡ Bolt: Offload heavy sync to background jobs
+            \App\Jobs\SyncUserAchievements::dispatch($workout->user);
+            \App\Jobs\SyncUserGoals::dispatch($workout->user);
         });
     }
 
     private function registerMeasurementEvents(): void
     {
-        BodyMeasurement::saved(fn (BodyMeasurement $bm) => app(GoalService::class)->syncGoals($bm->user));
-        BodyMeasurement::deleted(fn (BodyMeasurement $bm) => app(GoalService::class)->syncGoals($bm->user));
+        // ⚡ Bolt: Offload heavy goal sync to background jobs
+        BodyMeasurement::saved(fn (BodyMeasurement $bm) => \App\Jobs\SyncUserGoals::dispatch($bm->user));
+        BodyMeasurement::deleted(fn (BodyMeasurement $bm) => \App\Jobs\SyncUserGoals::dispatch($bm->user));
     }
 }

--- a/app/Services/GoalService.php
+++ b/app/Services/GoalService.php
@@ -104,15 +104,18 @@ final class GoalService
             return;
         }
 
-        // Finds the maximum volume achieved in a single workout for the associated exercise
-        $maxVolume = $goal->user->workouts()
+        // ⚡ Bolt Optimization: Calculate max volume directly in SQL instead of loading into PHP memory.
+        // Impact: Reduces memory usage and improves performance for users with many workouts.
+        $maxVolume = \Illuminate\Support\Facades\DB::table('workouts')
             ->join('workout_lines', 'workouts.id', '=', 'workout_lines.workout_id')
             ->join('sets', 'workout_lines.id', '=', 'sets.workout_line_id')
+            ->where('workouts.user_id', $goal->user_id)
             ->where('workout_lines.exercise_id', $goal->exercise_id)
-            ->selectRaw('SUM(sets.weight * sets.reps) as workout_total_volume')
+            ->selectRaw('SUM(sets.weight * sets.reps) as total_volume')
             ->groupBy('workouts.id')
-            ->get()
-            ->max('workout_total_volume');
+            ->orderByDesc('total_volume')
+            ->limit(1)
+            ->value('total_volume');
 
         if ($maxVolume !== null && is_numeric($maxVolume)) {
             $goal->update(['current_value' => (float) $maxVolume]);


### PR DESCRIPTION
💡 What:
- Offloaded Goal and Achievement synchronization to asynchronous background jobs.
- Optimized the maximum volume goal calculation to use SQL aggregation instead of PHP memory.
- Replaced unsupported `Cache::tags()` with surgical cache invalidation in `RecalculateUserStats`.

🎯 Why:
- Synchronization in model observers was blocking request latency on every set save and workout completion.
- Loading all workout volumes into PHP memory for goal evaluation was a potential memory bottleneck as user data grows.
- The `database` cache driver does not support tags, causing potential issues or silent failures.

📊 Impact:
- Reduces request latency for set/workout operations by moving heavy analytical logic to background jobs.
- Significantly reduces memory footprint during goal synchronization.
- Ensures reliable cache management by using driver-compatible invalidation methods.

🔬 Measurement:
- Use `php artisan queue:work` to see synchronization jobs being processed independently of the HTTP request.
- Verified all related tests in `Tests\Feature\Services\AchievementServiceTest` and `Tests\Feature\GoalTest` pass (part of the 830 passing tests).

---
*PR created automatically by Jules for task [6519571348073138126](https://jules.google.com/task/6519571348073138126) started by @kuasar-mknd*