### PR TITLE
refactor: Extract logic from HabitController

### DIFF
--- a/app/Actions/Habits/CreateHabitAction.php
+++ b/app/Actions/Habits/CreateHabitAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Habits;
+
+use App\Models\Habit;
+use App\Models\User;
+
+final class CreateHabitAction
+{
+    /**
+     * Create a new habit for the user.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function execute(User $user, array $data): Habit
+    {
+        if (! ($data['color'] ?? null)) {
+            $data['color'] = 'bg-slate-500';
+        }
+        if (! ($data['icon'] ?? null)) {
+            $data['icon'] = 'check_circle';
+        }
+
+        /** @var Habit $habit */
+        $habit = $user->habits()->create($data);
+
+        return $habit;
+    }
+}

--- a/app/Http/Controllers/Api/HabitController.php
+++ b/app/Http/Controllers/Api/HabitController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api;
 
+use App\Actions\Habits\CreateHabitAction;
 use App\Http\Requests\Api\StoreHabitRequest;
 use App\Http\Requests\Api\UpdateHabitRequest;
 use App\Http\Resources\HabitResource;
@@ -54,22 +55,13 @@ class HabitController extends Controller
     )]
     #[OA\Response(response: 201, description: 'Created successfully')]
     #[OA\Response(response: 422, description: 'Validation error')]
-    public function store(StoreHabitRequest $request): \Illuminate\Http\JsonResponse
+    public function store(StoreHabitRequest $request, CreateHabitAction $createHabitAction): \Illuminate\Http\JsonResponse
     {
         $this->authorize('create', Habit::class);
 
         $validated = $request->validated();
 
-        if (($validated['color'] ?? null) === null) {
-            $validated['color'] = 'bg-slate-500';
-        }
-        if (($validated['icon'] ?? null) === null) {
-            $validated['icon'] = 'check_circle';
-        }
-
-        $habit = new Habit($validated);
-        $habit->user_id = $this->user()->id;
-        $habit->save();
+        $habit = $createHabitAction->execute($this->user(), $validated);
 
         return (new HabitResource($habit))
             ->response()

--- a/app/Http/Controllers/HabitController.php
+++ b/app/Http/Controllers/HabitController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Actions\Habits\CreateHabitAction;
 use App\Actions\Habits\FetchHabitsIndexAction;
 use App\Actions\Habits\ToggleHabitAction;
 use App\Http\Requests\HabitStoreRequest;
@@ -48,19 +49,12 @@ class HabitController extends Controller
      * @param  \App\Http\Requests\HabitStoreRequest  $request  The validated request containing habit details.
      * @return \Illuminate\Http\RedirectResponse Redirects back with a success message.
      */
-    public function store(HabitStoreRequest $request): \Illuminate\Http\RedirectResponse
+    public function store(HabitStoreRequest $request, CreateHabitAction $createHabitAction): \Illuminate\Http\RedirectResponse
     {
         $this->authorize('create', Habit::class);
 
         $data = $request->validated();
-        if (! ($data['color'] ?? null)) {
-            $data['color'] = 'bg-slate-500';
-        }
-        if (! ($data['icon'] ?? null)) {
-            $data['icon'] = 'check_circle';
-        }
-
-        $this->user()->habits()->create($data);
+        $createHabitAction->execute($this->user(), $data);
 
         return redirect()->back()->with('success', 'Habitude créée.');
     }


### PR DESCRIPTION
This PR extracts the business logic for creating habits into a dedicated Action class, `App\Actions\Habits\CreateHabitAction`. 

Previously, the logic to set default `color` and `icon` values, as well as associating the newly created habit with the authenticated user, was duplicated across both the `HabitController@store` (Web) and `Api\HabitController@store` (API) methods.

This change adheres to SOLID principles by ensuring the Controllers are primarily responsible for handling the HTTP request/response cycle and authorization, while the actual business rules for habit creation are encapsulated within the `CreateHabitAction`.

Tests pass and code has been formatted to PSR-12 standards using `pint`.

---
*PR created automatically by Jules for task [16835442147860113987](https://jules.google.com/task/16835442147860113987) started by @kuasar-mknd*