### PR TITLE
docs: Update documentation for GoalController

### DIFF
--- a/app/Http/Controllers/GoalController.php
+++ b/app/Http/Controllers/GoalController.php
@@ -11,14 +11,35 @@ use App\Services\GoalService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Inertia\Inertia;
 
+/**
+ * Controller for managing user goals.
+ *
+ * This controller handles the creation, retrieval, updating, and deletion
+ * of user fitness and measurement goals. It interfaces with the GoalService
+ * to recalculate goal progress whenever a goal is updated.
+ */
 class GoalController extends Controller
 {
     use AuthorizesRequests;
 
+    /**
+     * Create a new GoalController instance.
+     *
+     * @param  \App\Services\GoalService  $goalService  The service responsible for updating goal progress.
+     */
     public function __construct(protected GoalService $goalService)
     {
     }
 
+    /**
+     * Display a listing of the user's goals.
+     *
+     * Retrieves all goals for the authenticated user, along with available
+     * exercises and predefined measurement types for the creation form.
+     * Eager loads the associated exercise for each goal.
+     *
+     * @return \Inertia\Response The Inertia response rendering the 'Goals/Index' page.
+     */
     public function index(): \Inertia\Response
     {
         return Inertia::render('Goals/Index', [
@@ -38,6 +59,17 @@ class GoalController extends Controller
         ]);
     }
 
+    /**
+     * Store a newly created goal in storage.
+     *
+     * Validates the request data, sets a default start value if none is provided,
+     * creates the goal, and immediately calculates its initial progress.
+     *
+     * @param  \App\Http\Requests\GoalStoreRequest  $request  The validated request containing goal details.
+     * @return \Illuminate\Http\RedirectResponse A redirect back to the goals index.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to create a goal.
+     */
     public function store(GoalStoreRequest $request): \Illuminate\Http\RedirectResponse
     {
         $this->authorize('create', Goal::class);
@@ -57,6 +89,18 @@ class GoalController extends Controller
         return redirect()->route('goals.index')->with('success', 'Objectif créé avec succès.');
     }
 
+    /**
+     * Update the specified goal in storage.
+     *
+     * Validates the incoming data, updates the goal's attributes, and recalculates
+     * its progress to reflect the new target or criteria.
+     *
+     * @param  \App\Http\Requests\GoalStoreRequest  $request  The validated request containing updated goal details.
+     * @param  \App\Models\Goal  $goal  The goal instance to update.
+     * @return \Illuminate\Http\RedirectResponse A redirect back to the goals index.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to update the goal.
+     */
     public function update(GoalStoreRequest $request, Goal $goal): \Illuminate\Http\RedirectResponse
     {
         $this->authorize('update', $goal);
@@ -67,6 +111,16 @@ class GoalController extends Controller
         return redirect()->route('goals.index')->with('success', 'Objectif mis à jour.');
     }
 
+    /**
+     * Remove the specified goal from storage.
+     *
+     * Permanently deletes the given goal from the database.
+     *
+     * @param  \App\Models\Goal  $goal  The goal instance to delete.
+     * @return \Illuminate\Http\RedirectResponse A redirect back to the goals index.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to delete the goal.
+     */
     public function destroy(Goal $goal): \Illuminate\Http\RedirectResponse
     {
         $this->authorize('delete', $goal);


### PR DESCRIPTION
Added missing PHPDoc blocks to `app/Http/Controllers/GoalController.php` to improve codebase readability and conform to documentation standards.

Changes include:
- Class-level docblock explaining the controller's purpose.
- Method-level docblocks for `__construct`, `index`, `store`, `update`, and `destroy`.
- Specified parameters, return types, and exceptions (e.g. `AuthorizationException`).

Logic remains unchanged. Tests have been run and passed.

---
*PR created automatically by Jules for task [1996337730374832081](https://jules.google.com/task/1996337730374832081) started by @kuasar-mknd*