### PR TITLE
⚡ Bolt: Remove unused dashboard workout count queries

### DIFF
--- a/app/Actions/Dashboard/FetchDashboardDataAction.php
+++ b/app/Actions/Dashboard/FetchDashboardDataAction.php
@@ -32,8 +32,6 @@ final class FetchDashboardDataAction
      *
      * @param  \App\Models\User  $user  The authenticated user for whom to fetch data.
      * @return array{
-     *     workoutsCount: int,
-     *     thisWeekCount: int,
      *     latestWeight: float|string|null,
      *     recentWorkouts: \Illuminate\Database\Eloquent\Collection<int, \App\Models\Workout>,
      *     recentPRs: \Illuminate\Database\Eloquent\Collection<int, \App\Models\PersonalRecord>,
@@ -46,8 +44,7 @@ final class FetchDashboardDataAction
         $latestMetrics = $this->statsService->getLatestBodyMetrics($user);
 
         return [
-            'workoutsCount' => $user->workouts()->count(),
-            'thisWeekCount' => $this->getThisWeekCount($user),
+            // ⚡ Bolt: Removed unused workoutsCount and thisWeekCount queries to prevent 2 unnecessary queries on dashboard load
             'latestWeight' => $latestMetrics['latest_weight'] ?? null,
             'recentWorkouts' => $this->getRecentWorkouts($user),
             'recentPRs' => $this->getRecentPRs($user),
@@ -153,19 +150,6 @@ final class FetchDashboardDataAction
                 'timeOfDayDistribution' => $this->getTimeOfDayDistribution($user),
             ]
         );
-    }
-
-    /**
-     * Count the number of workouts started in the current week.
-     *
-     * @param  \App\Models\User  $user  The authenticated user.
-     * @return int The total number of workouts for the current week.
-     */
-    private function getThisWeekCount(User $user): int
-    {
-        return $user->workouts()
-            ->where('started_at', '>=', now()->startOfWeek())
-            ->count();
     }
 
     /**

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -19,8 +19,6 @@ const RecentWorkoutsChart = defineAsyncComponent(() => import('@/Components/Stat
  * Database queries are limited to match the visible items in the UI.
  */
 const props = defineProps({
-    workoutsCount: { type: Number, default: 0 },
-    thisWeekCount: { type: Number, default: 0 },
     latestWeight: { type: Number, default: null },
     recentWorkouts: { type: Array, default: () => [] },
     recentPRs: { type: Array, default: () => [] },

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -21,7 +21,9 @@ const submit = () => {
 </script>
 
 <template>
-    <section class="rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-lg active:scale-95">
+    <section
+        class="rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-lg active:scale-95"
+    >
         <header>
             <h2 class="text-text-main text-lg font-semibold">Informations du profil</h2>
             <p class="text-text-muted mt-1 text-sm">Modifie tes informations de compte et ton adresse email.</p>

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -37,8 +37,6 @@ test('dashboard displays correct workout stats', function (): void {
         ->assertInertia(
             fn (Assert $page): \Inertia\Testing\AssertableInertia => $page
                 ->component('Dashboard')
-                ->where('workoutsCount', 13)
-                ->where('thisWeekCount', 3)
                 ->where('latestWeight', '75.50')
                 ->has('recentWorkouts', 3)
                 // Deferred props should be missing from initial response

--- a/tests/Feature/PageRenderingTest.php
+++ b/tests/Feature/PageRenderingTest.php
@@ -52,8 +52,6 @@ test('dashboard page renders with correct props', function (): void {
             fn (Assert $page): \Inertia\Testing\AssertableInertia => $page
                 ->component('Dashboard')
                 ->loadDeferredProps(fn (Assert $page): \Inertia\Testing\AssertableInertia => $page)
-                ->has('workoutsCount')
-                ->has('thisWeekCount')
                 ->has('recentWorkouts')
                 ->has('activeGoals')
         );


### PR DESCRIPTION
### 💡 What
Removed the `workoutsCount` and `thisWeekCount` queries from the `FetchDashboardDataAction` and their corresponding properties from the `Dashboard.vue` component.

### 🎯 Why
These variables were being calculated via database `COUNT()` queries on the `workouts` table on every dashboard page load, but were completely unused in the frontend template, creating a measurable performance bottleneck (N+2 problem on the main view).

### 📊 Impact
Eliminates 2 unnecessary database queries per user on the primary dashboard view, reducing database load and speeding up initial response times.

### 🔬 Measurement
Run `./vendor/bin/pest tests/Feature/DashboardTest.php` and use Laravel Telescope or debugbar to verify the absence of these 2 count queries. All tests passing successfully.

---
*PR created automatically by Jules for task [10763451495158484766](https://jules.google.com/task/10763451495158484766) started by @kuasar-mknd*