### PR TITLE
🎨 Palette: Add aria-hidden to decorative Material Symbols

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-02 - Empty State Call to Actions & Async Buttons
 **Learning:** Found an empty state ("Aucune séance pour l'instant") that left users at a dead-end on the primary Dashboard. Additionally, a large call-to-action card executed an async form post without any visual feedback (no spinner). In Inertia/Vue apps, disabling the button isn't enough; the user needs clear visual feedback that their action is processing, especially for major actions like creating a new Workout.
 **Action:** Always provide an actionable CTA within Empty States to prevent "dead ends". Also, always ensure primary action buttons not only disable themselves but also show an explicit loading indicator (like `animate-spin` on an icon) when `form.processing` is true.
+
+## 2025-03-12 - Decorative Material Symbols Accessibility
+**Learning:** Found multiple instances where ligature-based `material-symbols-outlined` icons (e.g., `<span class="material-symbols-outlined">cancel</span>`) were missing `aria-hidden="true"`. Without this attribute, screen readers will announce the raw ligature text (like "cancel", "error", or "schedule") which clutters the audio interface and provides confusing or redundant context to users relying on assistive technologies.
+**Action:** Always add `aria-hidden="true"` to ligature-based icon elements when they are decorative or when their meaning is already conveyed through adjacent text or an `aria-label` on the parent button.

--- a/resources/js/Components/InputError.vue
+++ b/resources/js/Components/InputError.vue
@@ -11,7 +11,9 @@ defineProps({
         v-show="message"
         class="animate-fade-in mt-2 flex w-full cursor-default items-start gap-2 rounded-2xl border border-red-500/20 bg-red-500/10 px-4 py-3 backdrop-blur-md transition-all duration-300 hover:bg-red-500/20"
     >
-        <span class="material-symbols-outlined mt-0.5 text-lg text-red-500 dark:text-red-400">error</span>
+        <span class="material-symbols-outlined mt-0.5 text-lg text-red-500 dark:text-red-400" aria-hidden="true"
+            >error</span
+        >
         <p class="text-sm font-bold text-red-500 dark:text-red-400">
             {{ message }}
         </p>

--- a/resources/js/Components/Navigation/BottomNav.vue
+++ b/resources/js/Components/Navigation/BottomNav.vue
@@ -33,7 +33,9 @@ const isActiveRoute = (itemRoute) => {
             <!-- Center FAB -->
             <div v-if="item.isFab" class="relative">
                 <button @click="createWorkout" class="glass-nav-fab" :aria-label="item.name">
-                    <span class="material-symbols-outlined text-4xl font-black">{{ item.icon }}</span>
+                    <span class="material-symbols-outlined text-4xl font-black" aria-hidden="true">{{
+                        item.icon
+                    }}</span>
                 </button>
             </div>
 
@@ -50,6 +52,7 @@ const isActiveRoute = (itemRoute) => {
                 <span
                     class="material-symbols-outlined text-[28px] transition-all group-hover:drop-shadow-[0_0_8px_rgba(255,85,0,0.5)]"
                     :style="{ fontVariationSettings: isActiveRoute(item.route) ? `'FILL' 1` : `'FILL' 0` }"
+                    aria-hidden="true"
                 >
                     {{ item.icon }}
                 </span>

--- a/resources/js/Components/Navigation/PageHeader.vue
+++ b/resources/js/Components/Navigation/PageHeader.vue
@@ -25,8 +25,9 @@ defineProps({
                     v-if="showBack && backRoute"
                     :href="backRoute.startsWith('http') || backRoute.startsWith('/') ? backRoute : route(backRoute)"
                     class="text-text-muted hover:text-electric-orange flex h-10 w-10 items-center justify-center rounded-2xl border border-white/20 bg-white/10 shadow-sm backdrop-blur-md transition-all hover:bg-white/20 hover:shadow-lg active:scale-95"
+                    aria-label="Retour"
                 >
-                    <span class="material-symbols-outlined">arrow_back</span>
+                    <span class="material-symbols-outlined" aria-hidden="true">arrow_back</span>
                 </Link>
                 <h1 class="font-display text-text-main text-xl font-black tracking-tight uppercase italic">
                     {{ title }}

--- a/resources/js/Components/Stats/TimeOfDayChart.vue
+++ b/resources/js/Components/Stats/TimeOfDayChart.vue
@@ -78,7 +78,7 @@ const chartOptions = {
     <div class="relative h-48 w-full">
         <Doughnut :data="chartData" :options="chartOptions" />
         <div class="pointer-events-none absolute inset-0 -ml-[120px] flex items-center justify-center">
-            <span class="material-symbols-outlined text-text-muted/20 text-4xl">schedule</span>
+            <span class="material-symbols-outlined text-text-muted/20 text-4xl" aria-hidden="true">schedule</span>
         </div>
     </div>
 </template>

--- a/resources/js/Components/UI/GlassEmptyState.vue
+++ b/resources/js/Components/UI/GlassEmptyState.vue
@@ -68,6 +68,7 @@ const shadowColors = {
                     v-else-if="icon"
                     class="material-symbols-outlined text-4xl"
                     :class="`text-${color === 'orange' ? 'electric-orange' : color === 'violet' ? 'vivid-violet' : color === 'pink' ? 'hot-pink' : color === 'green' ? 'neon-green' : 'cyan-pure'}`"
+                    aria-hidden="true"
                 >
                     {{ icon }}
                 </span>

--- a/resources/js/Components/UI/GlassInput.vue
+++ b/resources/js/Components/UI/GlassInput.vue
@@ -158,7 +158,7 @@ const isRequired = computed(() => {
                 aria-label="Effacer le texte"
                 tabindex="-1"
             >
-                <span class="material-symbols-outlined text-lg leading-none">cancel</span>
+                <span class="material-symbols-outlined text-lg leading-none" aria-hidden="true">cancel</span>
             </button>
         </div>
 

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.vue
@@ -21,7 +21,9 @@ const submit = () => {
 </script>
 
 <template>
-    <section class="rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-lg active:scale-95">
+    <section
+        class="rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-lg active:scale-95"
+    >
         <header>
             <h2 class="text-text-main text-lg font-semibold">Informations du profil</h2>
             <p class="text-text-muted mt-1 text-sm">Modifie tes informations de compte et ton adresse email.</p>


### PR DESCRIPTION
💡 **What:** Added `aria-hidden="true"` to multiple instances of `<span class="material-symbols-outlined">...</span>` across the application (specifically `GlassInput`, `GlassEmptyState`, `InputError`, `TimeOfDayChart`, `BottomNav`, and `PageHeader`). Also added a missing `aria-label="Retour"` to the back button link in `PageHeader.vue`.

🎯 **Why:** Material Symbols are ligature-based fonts. Without `aria-hidden="true"`, screen readers announce the literal text of the ligature (e.g., "cancel", "schedule", "arrow_back"). This creates a confusing and cluttered experience for users relying on assistive technology, as the meaning is either redundant or nonsensical in context.

♿ **Accessibility:**
- Decorative icons are now hidden from the accessibility tree, preventing screen readers from announcing confusing ligatures.
- Interactive elements (like the back button in `PageHeader`) now have proper `aria-label` attributes to provide clear, actionable context to screen reader users instead of relying on the icon's ligature text.

---
*PR created automatically by Jules for task [15388209419272607488](https://jules.google.com/task/15388209419272607488) started by @kuasar-mknd*