### PR TITLE
feat(viz): Add Bar Chart for 1RM Percentages

### DIFF
--- a/resources/js/Components/Stats/OneRepMaxPercentagesChart.vue
+++ b/resources/js/Components/Stats/OneRepMaxPercentagesChart.vue
@@ -1,0 +1,93 @@
+<script setup>
+import { Bar } from 'vue-chartjs'
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    // We want the chart to go from 50% up to 100%
+    const sortedData = [...props.data].sort((a, b) => a.percent - b.percent)
+
+    const labels = sortedData.map((d) => `${d.percent}%`)
+    const weights = sortedData.map((d) => d.value)
+
+    return {
+        labels,
+        datasets: [
+            {
+                label: 'Poids Estimé (kg)',
+                data: weights,
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+
+                    const gradient = ctx.createLinearGradient(0, chartArea.bottom, 0, chartArea.top)
+                    gradient.addColorStop(0, '#FF5500') // electric-orange
+                    gradient.addColorStop(1, '#FF0080') // hot-pink
+
+                    return gradient
+                },
+                borderRadius: 8,
+                barPercentage: 0.6,
+                borderWidth: 0,
+                hoverBackgroundColor: '#8800FF', // vivid-violet
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: { display: false },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.95)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            borderColor: 'rgba(255, 85, 0, 0.2)',
+            borderWidth: 1,
+            padding: 10,
+            cornerRadius: 12,
+            displayColors: false,
+            callbacks: {
+                label: (context) => {
+                    // Try to find the est reps for this data point
+                    const dataPoint = [...props.data].find((d) => `${d.percent}%` === context.label)
+                    const repsText = dataPoint && dataPoint.reps !== '-' ? ` (${dataPoint.reps} reps)` : ''
+                    return `${context.parsed.y.toFixed(1)} kg${repsText}`
+                },
+            },
+        },
+    },
+    scales: {
+        x: {
+            grid: { display: false },
+            ticks: {
+                color: '#94a3b8',
+                font: { size: 10, weight: 'bold', family: 'sans-serif' },
+            },
+            border: { display: false },
+        },
+        y: {
+            display: false,
+            beginAtZero: true,
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-48 w-full">
+        <Bar :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Tools/OneRepMax.vue
+++ b/resources/js/Pages/Tools/OneRepMax.vue
@@ -100,6 +100,12 @@
                             <h2 class="font-display text-text-main mb-4 text-lg font-black uppercase italic">
                                 Pourcentages d'Entraînement
                             </h2>
+
+                            <!-- Chart Component -->
+                            <div class="mb-6 h-48 w-full">
+                                <OneRepMaxPercentagesChart :data="percentages" />
+                            </div>
+
                             <div
                                 class="overflow-hidden rounded-3xl border border-white/20 bg-white/10 shadow-inner backdrop-blur-md"
                             >
@@ -142,12 +148,14 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, defineAsyncComponent } from 'vue'
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
 import PageHeader from '@/Components/Navigation/PageHeader.vue'
 import GlassCard from '@/Components/UI/GlassCard.vue'
 import GlassInput from '@/Components/UI/GlassInput.vue'
 import InputLabel from '@/Components/InputLabel.vue'
+
+const OneRepMaxPercentagesChart = defineAsyncComponent(() => import('@/Components/Stats/OneRepMaxPercentagesChart.vue'))
 
 const weight = ref('')
 const reps = ref('')


### PR DESCRIPTION
This PR implements a new visual chart component for the 1RM Calculator tool. Previously, the predicted weights for different percentages of a user's 1RM were only displayed in a static HTML table. 

This update adds a dynamic Bar chart (`OneRepMaxPercentagesChart.vue`) that visualizes the curve of estimated weights from 50% to 100% of their 1RM. 
- Built with `vue-chartjs`.
- Features an electric orange to hot pink gradient matching the app's Liquid Glass aesthetic.
- Includes a custom tooltip that displays the exact weight and estimated repetitions for each data point.
- The chart component is loaded lazily via `defineAsyncComponent` so it does not block the initial render.

---
*PR created automatically by Jules for task [7512399178942455096](https://jules.google.com/task/7512399178942455096) started by @kuasar-mknd*