### PR TITLE
feat(viz): Add Bar Chart for Total Reps

### DIFF
--- a/resources/js/Components/Dashboard/StreakCounter.vue
+++ b/resources/js/Components/Dashboard/StreakCounter.vue
@@ -8,7 +8,9 @@ defineProps({
 </script>
 
 <template>
-    <div class="group relative overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-4 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl active:scale-95">
+    <div
+        class="group relative overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-4 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl active:scale-95"
+    >
         <div class="flex items-center gap-3">
             <!-- Icon with Glow -->
             <div class="relative shrink-0">

--- a/resources/js/Components/Stats/TotalRepsChart.vue
+++ b/resources/js/Components/Stats/TotalRepsChart.vue
@@ -1,0 +1,80 @@
+<script setup>
+import { Bar } from 'vue-chartjs'
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    return {
+        labels: props.data.map((d) => d.date),
+        datasets: [
+            {
+                label: 'Volume (Reps)',
+                data: props.data.map((d) => d.reps),
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+                    const gradient = ctx.createLinearGradient(0, chartArea.bottom, 0, chartArea.top)
+                    gradient.addColorStop(0, '#00d2ff')
+                    gradient.addColorStop(1, '#3a7bd5')
+                    return gradient
+                },
+                borderRadius: 4,
+                barPercentage: 0.5,
+                borderWidth: 0,
+                hoverBackgroundColor: '#8800FF',
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: { display: false },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.95)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            borderColor: 'rgba(58, 123, 213, 0.2)',
+            borderWidth: 1,
+            padding: 10,
+            cornerRadius: 12,
+            displayColors: false,
+            callbacks: {
+                label: (context) => `${context.parsed.y} reps`,
+            },
+        },
+    },
+    scales: {
+        x: {
+            grid: { display: false },
+            ticks: {
+                color: '#94a3b8',
+                font: { size: 10, weight: 'bold', family: 'sans-serif' },
+            },
+            border: { display: false },
+        },
+        y: {
+            display: false,
+            beginAtZero: true,
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-full w-full">
+        <Bar :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Exercises/Show.vue
+++ b/resources/js/Pages/Exercises/Show.vue
@@ -10,6 +10,7 @@ const WeightDistributionChart = defineAsyncComponent(() => import('@/Components/
 const MaxRepsChart = defineAsyncComponent(() => import('@/Components/Stats/MaxRepsChart.vue'))
 const MaxWeightChart = defineAsyncComponent(() => import('@/Components/Stats/MaxWeightChart.vue'))
 const AverageWeightChart = defineAsyncComponent(() => import('@/Components/Stats/AverageWeightChart.vue'))
+const TotalRepsChart = defineAsyncComponent(() => import('@/Components/Stats/TotalRepsChart.vue'))
 
 /**
  * Component Props
@@ -56,6 +57,14 @@ const maxRepsData = computed(() => {
     return [...props.history].reverse().map((session) => ({
         date: session.formatted_date.split('/').slice(0, 2).join('/'),
         reps: session.sets.length > 0 ? Math.max(...session.sets.map((s) => s.reps || 0)) : 0,
+    }))
+})
+
+const totalRepsData = computed(() => {
+    if (!props.history || props.history.length === 0) return []
+    return [...props.history].reverse().map((session) => ({
+        date: session.formatted_date.split('/').slice(0, 2).join('/'),
+        reps: session.sets.reduce((sum, s) => sum + (parseInt(s.reps) || 0), 0),
     }))
 })
 
@@ -174,6 +183,16 @@ const weightDistributionData = computed(() => {
                     </div>
                     <div class="h-64">
                         <MaxRepsChart :data="maxRepsData" />
+                    </div>
+                </GlassCard>
+
+                <GlassCard class="rounded-3xl border border-white/20 bg-white/10 backdrop-blur-md">
+                    <div class="mb-4">
+                        <h3 class="font-display text-text-main text-lg font-black uppercase italic">Volume (Reps)</h3>
+                        <p class="text-text-muted text-xs font-semibold">Total des répétitions par séance</p>
+                    </div>
+                    <div class="h-64">
+                        <TotalRepsChart :data="totalRepsData" />
                     </div>
                 </GlassCard>
 


### PR DESCRIPTION
This PR introduces a new visualization component `TotalRepsChart` to the Exercise Detail page.

**Changes:**
- Created `resources/js/Components/Stats/TotalRepsChart.vue`, a new Bar Chart component using `vue-chartjs`. It displays the total number of reps achieved per session.
- Added a `totalRepsData` computed property in `resources/js/Pages/Exercises/Show.vue` to calculate the total reps from the `history` dataset by aggregating sets per session.
- Integrated the `<TotalRepsChart>` into the Exercise Show template, wrapped in a `<GlassCard>` with explicit Liquid Glass styling (`bg-white/10 backdrop-blur-md border border-white/20 rounded-3xl`).
- Asynchronously imported the new chart component for optimal performance.

This gives users a better visual representation of their endurance and volume progression over time for individual exercises.

---
*PR created automatically by Jules for task [3363897918143309248](https://jules.google.com/task/3363897918143309248) started by @kuasar-mknd*