### PR TITLE
docs: Update documentation for BodyMeasurementController

### DIFF
--- a/app/Http/Controllers/BodyMeasurementController.php
+++ b/app/Http/Controllers/BodyMeasurementController.php
@@ -9,14 +9,38 @@ use App\Models\BodyMeasurement;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Inertia\Inertia;
 
+/**
+ * Controller for managing user body measurements.
+ *
+ * This controller handles the CRUD operations for overall body measurements
+ * like weight and body fat percentage. It integrates with Inertia.js for
+ * frontend rendering and manages the clearing of related statistics caches
+ * upon updates or deletions.
+ */
 class BodyMeasurementController extends Controller
 {
     use AuthorizesRequests;
 
+    /**
+     * Create a new BodyMeasurementController instance.
+     *
+     * @param  \App\Services\StatsService  $statsService  Service for fetching and clearing user measurement statistics.
+     */
     public function __construct(protected \App\Services\StatsService $statsService)
     {
     }
 
+    /**
+     * Display a listing of the user's body measurements.
+     *
+     * Retrieves the most recent measurements for the authenticated user
+     * and fetches their historical weight data spanning the past year to
+     * populate the frontend graphs and list view.
+     *
+     * @return \Inertia\Response The Inertia response rendering the 'Measurements/Index' page.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to view measurements.
+     */
     public function index(): \Inertia\Response
     {
         $this->authorize('viewAny', BodyMeasurement::class);
@@ -34,6 +58,18 @@ class BodyMeasurementController extends Controller
         ]);
     }
 
+    /**
+     * Store a newly created body measurement in storage.
+     *
+     * Creates a new body measurement record for the authenticated user based
+     * on the validated incoming request. After creation, clears the
+     * related body measurement stats cache to ensure fresh data.
+     *
+     * @param  \App\Http\Requests\BodyMeasurementStoreRequest  $request  The validated request containing measurement data.
+     * @return \Illuminate\Http\RedirectResponse Redirects back to the previous page.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to create a measurement.
+     */
     public function store(BodyMeasurementStoreRequest $request): \Illuminate\Http\RedirectResponse
     {
         $this->authorize('create', BodyMeasurement::class);
@@ -45,6 +81,18 @@ class BodyMeasurementController extends Controller
         return redirect()->back();
     }
 
+    /**
+     * Remove the specified body measurement from storage.
+     *
+     * Deletes the given body measurement record, provided the authenticated
+     * user is authorized to do so (i.e., they own the measurement).
+     * Afterward, clears the relevant body measurement stats cache.
+     *
+     * @param  \App\Models\BodyMeasurement  $bodyMeasurement  The body measurement model instance to delete.
+     * @return \Illuminate\Http\RedirectResponse Redirects back to the previous page.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to delete the measurement.
+     */
     public function destroy(BodyMeasurement $bodyMeasurement): \Illuminate\Http\RedirectResponse
     {
         $this->authorize('delete', $bodyMeasurement);


### PR DESCRIPTION
This PR adds comprehensive PHPDoc blocks to `app/Http/Controllers/BodyMeasurementController.php` to improve codebase readability.

**Changes:**
- Added class-level documentation explaining the controller's purpose.
- Added method-level documentation for `__construct`, `index`, `store`, and `destroy`.
- Specified parameters, return types, and potential exceptions (like `AuthorizationException`).
- No application logic was altered.

---
*PR created automatically by Jules for task [8370929927966734703](https://jules.google.com/task/8370929927966734703) started by @kuasar-mknd*