### PR TITLE
🎨 Palette: Improve accessibility of Calendar navigation buttons

### DIFF
--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -134,16 +134,16 @@ const formatDateFull = (dateStr) => {
         <div class="space-y-6">
             <!-- Calendar Navigation -->
             <div class="flex items-center justify-between">
-                <GlassButton @click="changeMonth(-1)" class="px-3!">
-                    <span class="material-symbols-outlined">chevron_left</span>
+                <GlassButton @click="changeMonth(-1)" class="px-3!" aria-label="Mois précédent">
+                    <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
                 </GlassButton>
 
                 <h2 class="text-text-main text-xl font-black tracking-tighter uppercase italic">
                     {{ currentMonthName }} <span class="text-electric-orange">{{ currentYear }}</span>
                 </h2>
 
-                <GlassButton @click="changeMonth(1)" class="px-3!">
-                    <span class="material-symbols-outlined">chevron_right</span>
+                <GlassButton @click="changeMonth(1)" class="px-3!" aria-label="Mois suivant">
+                    <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
                 </GlassButton>
             </div>
 


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `aria-hidden="true"` attributes to the month navigation buttons on the Calendar page.
🎯 **Why:** The `chevron_left` and `chevron_right` icons were missing `aria-hidden="true"`, meaning screen readers would read out "chevron left" instead of explaining the button's action. The buttons themselves were also missing descriptive `aria-label`s. This makes the calendar navigation much more accessible for screen reader users.
📸 **Before/After:** Visuals remain completely unchanged, but the underlying HTML is now accessible.
♿ **Accessibility:** Added proper context ("Mois précédent", "Mois suivant") and hid decorative ligatures from assistive technologies.

---
*PR created automatically by Jules for task [18271770776917517384](https://jules.google.com/task/18271770776917517384) started by @kuasar-mknd*