### PR TITLE
feat(viz): Add Bar Chart for Sets Per Session

### DIFF
--- a/resources/js/Components/Stats/SetsPerSessionChart.vue
+++ b/resources/js/Components/Stats/SetsPerSessionChart.vue
@@ -1,0 +1,80 @@
+<script setup>
+import { Bar } from 'vue-chartjs'
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    return {
+        labels: props.data.map((d) => d.date),
+        datasets: [
+            {
+                label: 'Séries (Sets)',
+                data: props.data.map((d) => d.sets),
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+                    const gradient = ctx.createLinearGradient(0, chartArea.bottom, 0, chartArea.top)
+                    gradient.addColorStop(0, '#ff4b2b') // Electric orange shade
+                    gradient.addColorStop(1, '#ff416c') // Hot pink shade
+                    return gradient
+                },
+                borderRadius: 4,
+                barPercentage: 0.5,
+                borderWidth: 0,
+                hoverBackgroundColor: '#8800FF',
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: { display: false },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.95)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            borderColor: 'rgba(255, 65, 108, 0.2)',
+            borderWidth: 1,
+            padding: 10,
+            cornerRadius: 12,
+            displayColors: false,
+            callbacks: {
+                label: (context) => `${context.parsed.y} séries`,
+            },
+        },
+    },
+    scales: {
+        x: {
+            grid: { display: false },
+            ticks: {
+                color: '#94a3b8',
+                font: { size: 10, weight: 'bold', family: 'sans-serif' },
+            },
+            border: { display: false },
+        },
+        y: {
+            display: false,
+            beginAtZero: true,
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-full w-full">
+        <Bar :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Exercises/Show.vue
+++ b/resources/js/Pages/Exercises/Show.vue
@@ -11,6 +11,7 @@ const MaxRepsChart = defineAsyncComponent(() => import('@/Components/Stats/MaxRe
 const MaxWeightChart = defineAsyncComponent(() => import('@/Components/Stats/MaxWeightChart.vue'))
 const AverageWeightChart = defineAsyncComponent(() => import('@/Components/Stats/AverageWeightChart.vue'))
 const TotalRepsChart = defineAsyncComponent(() => import('@/Components/Stats/TotalRepsChart.vue'))
+const SetsPerSessionChart = defineAsyncComponent(() => import('@/Components/Stats/SetsPerSessionChart.vue'))
 
 /**
  * Component Props
@@ -65,6 +66,14 @@ const totalRepsData = computed(() => {
     return [...props.history].reverse().map((session) => ({
         date: session.formatted_date.split('/').slice(0, 2).join('/'),
         reps: session.sets.reduce((sum, s) => sum + (parseInt(s.reps) || 0), 0),
+    }))
+})
+
+const setsPerSessionData = computed(() => {
+    if (!props.history || props.history.length === 0) return []
+    return [...props.history].reverse().map((session) => ({
+        date: session.formatted_date.split('/').slice(0, 2).join('/'),
+        sets: session.sets.length,
     }))
 })
 
@@ -223,6 +232,16 @@ const weightDistributionData = computed(() => {
                     </div>
                     <div class="h-64">
                         <AverageWeightChart :data="averageWeightData" />
+                    </div>
+                </GlassCard>
+
+                <GlassCard class="rounded-3xl border border-white/20 bg-white/10 backdrop-blur-md">
+                    <div class="mb-4">
+                        <h3 class="font-display text-text-main text-lg font-black uppercase italic">Séries</h3>
+                        <p class="text-text-muted text-xs font-semibold">Nombre de séries par séance</p>
+                    </div>
+                    <div class="h-64">
+                        <SetsPerSessionChart :data="setsPerSessionData" />
                     </div>
                 </GlassCard>
             </div>


### PR DESCRIPTION
This PR introduces a new "Séries" (Sets Per Session) bar chart for the Exercise Detail view.

**Changes made:**
- **New Component:** Added `resources/js/Components/Stats/SetsPerSessionChart.vue` to display a bar chart using Chart.js.
- **Data Integration:** Extracted the dataset from the existing `history` prop in `Show.vue` (mapping the `history[].sets.length` to the `date`).
- **Aesthetic:** Applied the 'Liquid Glass' aesthetic via Tailwind classes to the new `GlassCard` wrapper within the Analytics Grid (`bg-white/10`, `backdrop-blur-md`, `border border-white/20`, `rounded-3xl`).

All frontend (`pnpm run lint`) and backend tests (`./vendor/bin/pest`) passed. The UI successfully displays the chart as verified via Playwright screenshot.

---
*PR created automatically by Jules for task [2424723938689726993](https://jules.google.com/task/2424723938689726993) started by @kuasar-mknd*