### PR TITLE
docs: Update documentation for Fasting Module

### DIFF
--- a/app/Http/Controllers/FastingController.php
+++ b/app/Http/Controllers/FastingController.php
@@ -12,8 +12,26 @@ use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 use Inertia\Response;
 
+/**
+ * Controller for managing User Fasts.
+ *
+ * This controller handles the creation, retrieval, updating, and deletion
+ * of fasting records. It provides the data for the fasting tracker frontend
+ * and ensures proper authorization for all operations.
+ */
 class FastingController extends Controller
 {
+    /**
+     * Display a listing of the user's fasts.
+     *
+     * Retrieves the fasting history and any currently active fast for
+     * the authenticated user to render the fasting index page.
+     *
+     * @param  \App\Actions\Fasting\FetchFastingIndexAction  $fetchFastingIndexAction  The action to fetch fasting data.
+     * @return \Inertia\Response The Inertia response rendering the 'Tools/Fasting/Index' page.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to view fasts.
+     */
     public function index(FetchFastingIndexAction $fetchFastingIndexAction): Response
     {
         $this->authorize('viewAny', Fast::class);
@@ -23,6 +41,17 @@ class FastingController extends Controller
         return Inertia::render('Tools/Fasting/Index', $data);
     }
 
+    /**
+     * Store a newly created fast in storage.
+     *
+     * Validates the request data and starts a new fast for the user.
+     * Prevents starting a new fast if one is already currently active.
+     *
+     * @param  \App\Http\Requests\Api\StoreFastRequest  $request  The validated request containing fast details.
+     * @return \Illuminate\Http\RedirectResponse Redirects back with a success message or an error if a fast is already active.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to create a fast.
+     */
     public function store(StoreFastRequest $request): RedirectResponse
     {
         $this->authorize('create', Fast::class);
@@ -42,6 +71,18 @@ class FastingController extends Controller
         return back()->with('success', 'Fast started successfully.');
     }
 
+    /**
+     * Update the specified fast in storage.
+     *
+     * Validates the request and updates the details of an existing fast,
+     * such as ending it or modifying its duration/type.
+     *
+     * @param  \App\Http\Requests\Api\UpdateFastRequest  $request  The validated request with updated fast details.
+     * @param  \App\Models\Fast  $fast  The fast record to update.
+     * @return \Illuminate\Http\RedirectResponse Redirects back with a success message.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to update the fast.
+     */
     public function update(UpdateFastRequest $request, Fast $fast): RedirectResponse
     {
         $this->authorize('update', $fast);
@@ -51,6 +92,16 @@ class FastingController extends Controller
         return back()->with('success', 'Fast updated successfully.');
     }
 
+    /**
+     * Remove the specified fast from storage.
+     *
+     * Permanently deletes a fasting record from the database.
+     *
+     * @param  \App\Models\Fast  $fast  The fast record to delete.
+     * @return \Illuminate\Http\RedirectResponse Redirects back with a success message.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to delete the fast.
+     */
     public function destroy(Fast $fast): RedirectResponse
     {
         $this->authorize('delete', $fast);

--- a/resources/js/Pages/Tools/Fasting/Index.vue
+++ b/resources/js/Pages/Tools/Fasting/Index.vue
@@ -1,4 +1,21 @@
 <script setup>
+/**
+ * Fasting Tracker Component.
+ *
+ * This component provides an interface for users to track their intermittent fasting.
+ * It displays the currently active fast with a live progress timer, allows starting
+ * new fasts by selecting different duration types (e.g., 16:8, 20:4), and shows a
+ * history of past completed fasts.
+ *
+ * Props:
+ * @prop {Object} activeFast - The currently ongoing fast object, if any. Null otherwise.
+ *                             Expected shape: { id, type, start_time, target_duration_minutes, ... }
+ * @prop {Object} history - Paginated object containing historical fasting records.
+ *
+ * Emits:
+ * None directly. Uses Inertia forms for POST/PATCH/DELETE requests.
+ */
+
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
 import { Head, Link, useForm, router } from '@inertiajs/vue3'
 import GlassCard from '@/Components/UI/GlassCard.vue'


### PR DESCRIPTION
Added comprehensive PHPDoc comments to `FastingController.php` (covering classes, methods, parameters, and return types) and a detailed comment block to `Index.vue` Fasting page (covering props, emits, and purpose) to improve code readability and maintainability without altering any underlying logic.

---
*PR created automatically by Jules for task [14442960523719696490](https://jules.google.com/task/14442960523719696490) started by @kuasar-mknd*