### PR TITLE
🧹 Remove unused Link import in Notifications

### DIFF
--- a/resources/js/Pages/Notifications/Index.vue
+++ b/resources/js/Pages/Notifications/Index.vue
@@ -2,7 +2,7 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
 import GlassCard from '@/Components/UI/GlassCard.vue'
 import GlassButton from '@/Components/UI/GlassButton.vue'
-import { Head, Link, router } from '@inertiajs/vue3'
+import { Head, router } from '@inertiajs/vue3'
 
 const props = defineProps({
     notifications: Object,


### PR DESCRIPTION
🎯 What: Removed the unused `Link` import from `@inertiajs/vue3` in `resources/js/Pages/Notifications/Index.vue`.
💡 Why: This import was dead code. Removing it improves code maintainability and readability by ensuring only necessary dependencies are listed.
✅ Verification: Ran `pnpm lint`, `pnpm run format`, and `./vendor/bin/pest` to verify the application functionality is entirely unaffected.
✨ Result: The code is slightly cleaner and has less visual noise.

---
*PR created automatically by Jules for task [18243273826043284069](https://jules.google.com/task/18243273826043284069) started by @kuasar-mknd*