### PR TITLE
🧹 Remove unused PageHeader import in Tools Index

### DIFF
--- a/resources/js/Pages/Tools/Index.vue
+++ b/resources/js/Pages/Tools/Index.vue
@@ -211,6 +211,6 @@
 <script setup>
 import { Link } from '@inertiajs/vue3'
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
-import PageHeader from '@/Components/Navigation/PageHeader.vue'
+
 import GlassCard from '@/Components/UI/GlassCard.vue'
 </script>


### PR DESCRIPTION
🎯 **What:** Removed the unused `PageHeader` import from `resources/js/Pages/Tools/Index.vue`.
💡 **Why:** Cleans up dead code, reducing unnecessary dependencies and improving the overall code health and maintainability of the project.
✅ **Verification:** Ran `pnpm lint` and `pnpm build && ./vendor/bin/pest` to verify that code formatting and all tests still pass successfully. Verified visually using Playwright that the `/tools` page renders flawlessly.
✨ **Result:** A cleaner component with no unused imports.

---
*PR created automatically by Jules for task [468836265384724075](https://jules.google.com/task/468836265384724075) started by @kuasar-mknd*