### PR TITLE
🧪 test: Add Pest coverage for CreateUserAction

### DIFF
--- a/tests/Feature/Actions/CreateUserActionTest.php
+++ b/tests/Feature/Actions/CreateUserActionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateUserAction;
+use App\Models\User;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Hash;
+
+it('creates a new user and dispatches a registered event', function (): void {
+    Event::fake();
+
+    $action = app(CreateUserAction::class);
+
+    $input = [
+        'name' => 'John Doe',
+        'email' => 'john@example.com',
+        'password' => 'password123',
+    ];
+
+    $user = $action->execute($input);
+
+    expect($user)->toBeInstanceOf(User::class);
+    expect($user->name)->toBe('John Doe');
+    expect($user->email)->toBe('john@example.com');
+    expect(Hash::check('password123', $user->password))->toBeTrue();
+
+    $this->assertDatabaseHas('users', [
+        'id' => $user->id,
+        'email' => 'john@example.com',
+    ]);
+
+    Event::assertDispatched(Registered::class, function (Registered $event) use ($user): bool {
+        return $event->user->id === $user->id;
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing test coverage for `CreateUserAction`. The action previously had no tests, despite being a core piece of the user registration flow.

📊 **Coverage:** What scenarios are now tested
The new Pest feature test (`CreateUserActionTest`) covers the happy path scenario for user creation. It verifies that:
- The action returns a `User` instance.
- The user's name and email match the input data.
- The password is correctly hashed.
- The user is persisted to the database.
- A `Registered` event is dispatched with the newly created user.

✨ **Result:** The improvement in test coverage
Test coverage for the `CreateUserAction` is now established, ensuring the action correctly creates users and triggers the necessary events. This provides a safety net against regressions in the user registration logic.

---
*PR created automatically by Jules for task [6218184988213740454](https://jules.google.com/task/6218184988213740454) started by @kuasar-mknd*