### PR TITLE
🧪 Add test coverage for ToggleHabitAction

### DIFF
--- a/tests/Unit/Actions/Habits/ToggleHabitActionTest.php
+++ b/tests/Unit/Actions/Habits/ToggleHabitActionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Habits\ToggleHabitAction;
+use App\Models\Habit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+test('it creates a new log if one does not exist for the given date', function (): void {
+    // Arrange
+    $action = new ToggleHabitAction();
+    $habit = Habit::factory()->create();
+    $date = '2023-10-25';
+
+    // Act
+    $action->execute($habit, $date);
+
+    // Assert
+    $this->assertDatabaseHas('habit_logs', [
+        'habit_id' => $habit->id,
+        'date' => clone Carbon::parse($date)->startOfDay(),
+    ]);
+});
+
+test('it deletes the log if one already exists for the given date', function (): void {
+    // Arrange
+    $action = new ToggleHabitAction();
+    $habit = Habit::factory()->create();
+    $date = '2023-10-25';
+
+    // Create an initial log
+    $habit->logs()->create([
+        'date' => clone Carbon::parse($date)->startOfDay(),
+    ]);
+
+    // Ensure it exists before acting
+    $this->assertDatabaseHas('habit_logs', [
+        'habit_id' => $habit->id,
+        'date' => clone Carbon::parse($date)->startOfDay(),
+    ]);
+
+    // Act
+    $action->execute($habit, $date);
+
+    // Assert
+    $this->assertDatabaseMissing('habit_logs', [
+        'habit_id' => $habit->id,
+        'date' => clone Carbon::parse($date)->startOfDay(),
+    ]);
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds test coverage for `app/Actions/Habits/ToggleHabitAction.php` which previously had no tests. The logic within this action allows for a habit to be toggled for a specific date.

📊 **Coverage:** What scenarios are now tested
- Tested the case where a log is missing for the given date, ensuring the system creates it correctly.
- Tested the case where a log already exists for the given date, ensuring the system deletes it correctly.

✨ **Result:** The improvement in test coverage
Both paths (`if` / `else`) within the action are tested. The unit test uses pest format to test these scenarios securely and directly on the database. Tests pass smoothly in the execution pipeline.

---
*PR created automatically by Jules for task [5730035147400160836](https://jules.google.com/task/5730035147400160836) started by @kuasar-mknd*