### PR TITLE
🧪 Add Pest coverage for CreateWorkoutLineAction

### DIFF
--- a/tests/Feature/Actions/CreateWorkoutLineActionTest.php
+++ b/tests/Feature/Actions/CreateWorkoutLineActionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Workouts\CreateWorkoutLineAction;
+use App\Models\Exercise;
+use App\Models\Workout;
+use App\Models\WorkoutLine;
+
+it('sets order to 0 when no workout lines exist and order is not provided', function (): void {
+    $workout = Workout::factory()->create();
+    $exercise = Exercise::factory()->create();
+
+    $action = app(CreateWorkoutLineAction::class);
+    $workoutLine = $action->execute($workout, [
+        'exercise_id' => $exercise->id,
+    ]);
+
+    expect($workoutLine->order)->toBe(0)
+        ->and($workoutLine->workout_id)->toBe($workout->id)
+        ->and($workoutLine->exercise_id)->toBe($exercise->id);
+});
+
+it('auto-increments order based on max order when order is not provided', function (): void {
+    $workout = Workout::factory()->create();
+    $exercise = Exercise::factory()->create();
+
+    WorkoutLine::factory()->create([
+        'workout_id' => $workout->id,
+        'exercise_id' => $exercise->id,
+        'order' => 2,
+    ]);
+
+    WorkoutLine::factory()->create([
+        'workout_id' => $workout->id,
+        'exercise_id' => $exercise->id,
+        'order' => 4,
+    ]);
+
+    $action = app(CreateWorkoutLineAction::class);
+    $workoutLine = $action->execute($workout, [
+        'exercise_id' => $exercise->id,
+    ]);
+
+    expect($workoutLine->order)->toBe(5);
+});
+
+it('respects explicitly provided order', function (): void {
+    $workout = Workout::factory()->create();
+    $exercise = Exercise::factory()->create();
+
+    WorkoutLine::factory()->create([
+        'workout_id' => $workout->id,
+        'exercise_id' => $exercise->id,
+        'order' => 2,
+    ]);
+
+    $action = app(CreateWorkoutLineAction::class);
+    $workoutLine = $action->execute($workout, [
+        'exercise_id' => $exercise->id,
+        'order' => 10,
+    ]);
+
+    expect($workoutLine->order)->toBe(10);
+});


### PR DESCRIPTION
🎯 What: The testing gap for `CreateWorkoutLineAction` auto-incrementing order logic when no order is provided.
📊 Coverage: Tested scenarios: auto-incrementing from 0 (when no lines exist), auto-incrementing from the `max('order')`, and respecting the explicit order if provided.
✨ Result: The `order` calculation in `CreateWorkoutLineAction` is now completely covered by unit tests, ensuring reliability when creating lines without specifying order.

---
*PR created automatically by Jules for task [10433405700543912015](https://jules.google.com/task/10433405700543912015) started by @kuasar-mknd*