### PR TITLE
🛡️ Sentinel: [HIGH] Prevent mass assignment of OAuth provider IDs

### DIFF
--- a/app/Actions/ResolveSocialUserAction.php
+++ b/app/Actions/ResolveSocialUserAction.php
@@ -21,9 +21,10 @@ final class ResolveSocialUserAction
         if ($existingUser) {
             // Update provider info if not set (linking account)
             if (! $existingUser->provider_id) {
-                $existingUser->update([
+                $existingUser->forceFill([
                     'provider' => $provider,
                     'provider_id' => $socialUser->getId(),
+                ])->update([
                     'avatar' => $socialUser->getAvatar(),
                 ]);
             }
@@ -32,17 +33,16 @@ final class ResolveSocialUserAction
         }
 
         // Create new user
-        // We use create() because all fields are in $fillable in User model
         $user = User::create([
             'name' => $socialUser->getName() ?? $socialUser->getNickname() ?? 'Utilisateur',
             'email' => $socialUser->getEmail(),
             'password' => bcrypt(Str::random(16)), // Random password since auth is handled by provider
-            'provider' => $provider,
-            'provider_id' => $socialUser->getId(),
             'avatar' => $socialUser->getAvatar(),
         ]);
 
         $user->forceFill([
+            'provider' => $provider,
+            'provider_id' => $socialUser->getId(),
             'email_verified_at' => now(), // Assume email is verified by provider
         ])->save();
 

--- a/app/Http/Requests/Api/StoreUserRequest.php
+++ b/app/Http/Requests/Api/StoreUserRequest.php
@@ -28,8 +28,6 @@ class StoreUserRequest extends FormRequest
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => ['required', 'string', Password::defaults()],
-            'provider' => ['nullable', 'string', 'max:255'],
-            'provider_id' => ['nullable', 'string', 'max:255'],
             'avatar' => ['nullable', 'string', 'max:255'],
             'default_rest_time' => ['nullable', 'integer', 'min:0'],
         ];

--- a/app/Http/Requests/Api/UpdateUserRequest.php
+++ b/app/Http/Requests/Api/UpdateUserRequest.php
@@ -35,8 +35,6 @@ class UpdateUserRequest extends FormRequest
                 Rule::unique('users')->ignore($this->route('user')),
             ],
             'password' => ['sometimes', 'string', Password::defaults()],
-            'provider' => ['nullable', 'string', 'max:255'],
-            'provider_id' => ['nullable', 'string', 'max:255'],
             'avatar' => ['nullable', 'string', 'max:255'],
             'default_rest_time' => ['nullable', 'integer', 'min:0'],
         ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -52,8 +52,6 @@ final class User extends Authenticatable implements MustVerifyEmail
         'name',
         'email',
         'password',
-        'provider',
-        'provider_id',
         'avatar',
         'default_rest_time',
     ];


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Removed `provider` and `provider_id` from the User model's `$fillable` array and from API validation requests (`StoreUserRequest`, `UpdateUserRequest`). Updated `ResolveSocialUserAction` to securely use `forceFill` when assigning these fields during OAuth callbacks.

⚠️ **Risk:** The potential impact if left unfixed
By leaving OAuth identifiers in `$fillable` and allowing them via API endpoints, an attacker could potentially execute a mass assignment attack to link their account to a victim's OAuth profile or manipulate account creation flows. This could theoretically allow an attacker to hijack a victim's social login, leading to a complete account takeover.

🛡️ **Solution:** How the fix addresses the vulnerability
Explicitly excluded OAuth provider identifiers from standard mass assignment flows (e.g. `User::create([...])` or `$user->update([...])`). They are now strictly and securely handled using `$user->forceFill([...])` during the internal OAuth resolution process. The related FormRequests were also stripped of these fields, ensuring users cannot manipulate them via API inputs.

---
*PR created automatically by Jules for task [18180896894087561519](https://jules.google.com/task/18180896894087561519) started by @kuasar-mknd*