### PR TITLE
🧪 Add test coverage for SaveDailyJournalAction error paths

### DIFF
--- a/tests/Feature/Actions/Journal/SaveDailyJournalActionTest.php
+++ b/tests/Feature/Actions/Journal/SaveDailyJournalActionTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Journal\SaveDailyJournalAction;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+it('creates a new daily journal entry', function (): void {
+    $user = User::factory()->create();
+    $action = app(SaveDailyJournalAction::class);
+
+    $date = Carbon::now()->format('Y-m-d');
+    $data = [
+        'date' => $date,
+        'content' => 'This is a test journal entry.',
+    ];
+
+    $journal = $action->execute($user, $data);
+
+    expect($journal->user_id)->toBe($user->id)
+        ->and($journal->date->format('Y-m-d'))->toBe($date)
+        ->and($journal->content)->toBe('This is a test journal entry.');
+});
+
+it('updates an existing daily journal entry', function (): void {
+    $user = User::factory()->create();
+    $action = app(SaveDailyJournalAction::class);
+
+    $date = Carbon::now()->format('Y-m-d');
+
+    // First save
+    $data1 = [
+        'date' => $date,
+        'content' => 'Initial content',
+    ];
+    $action->execute($user, $data1);
+
+    // Update
+    $data2 = [
+        'date' => $date,
+        'content' => 'Updated content',
+    ];
+    $journal = $action->execute($user, $data2);
+
+    expect($journal->user_id)->toBe($user->id)
+        ->and($journal->date->format('Y-m-d'))->toBe($date)
+        ->and($journal->content)->toBe('Updated content');
+
+    expect($user->dailyJournals()->count())->toBe(1);
+});
+
+it('throws exception if date is missing', function (): void {
+    $user = User::factory()->create();
+    $action = app(SaveDailyJournalAction::class);
+
+    $data = [
+        'content' => 'Missing date',
+    ];
+
+    expect(fn () => $action->execute($user, $data))
+        ->toThrow(UnexpectedValueException::class, 'Date must be a string');
+});
+
+it('throws exception if date is not a string', function (): void {
+    $user = User::factory()->create();
+    $action = app(SaveDailyJournalAction::class);
+
+    $data = [
+        'date' => 12345,
+        'content' => 'Integer date',
+    ];
+
+    expect(fn () => $action->execute($user, $data))
+        ->toThrow(UnexpectedValueException::class, 'Date must be a string');
+});
+
+it('throws exception if date is null', function (): void {
+    $user = User::factory()->create();
+    $action = app(SaveDailyJournalAction::class);
+
+    $data = [
+        'date' => null,
+        'content' => 'Null date',
+    ];
+
+    expect(fn () => $action->execute($user, $data))
+        ->toThrow(UnexpectedValueException::class, 'Date must be a string');
+});


### PR DESCRIPTION
🎯 **What:** 
Added missing test coverage for `SaveDailyJournalAction`. Specifically tested the error paths for missing, null, or incorrectly typed `date` inputs to ensure the action reliably throws an `UnexpectedValueException`.

📊 **Coverage:**
- `UnexpectedValueException` when date is missing.
- `UnexpectedValueException` when date is not a string (e.g., integer).
- `UnexpectedValueException` when date is null.
- Saving a valid daily journal entry successfully (Happy Path).
- Updating an existing daily journal entry successfully (Happy Path).

✨ **Result:** 
`SaveDailyJournalAction` is now fully covered with functional tests using Pest, ensuring robust handling of date validation and successful CRUD operations without regressions.

---
*PR created automatically by Jules for task [17779808035937766265](https://jules.google.com/task/17779808035937766265) started by @kuasar-mknd*