### PR TITLE
chore: Clean up resolved fix comment in migration

### DIFF
--- a/database/migrations/2026_01_29_200116_add_missing_performance_indexes.php
+++ b/database/migrations/2026_01_29_200116_add_missing_performance_indexes.php
@@ -13,7 +13,7 @@ return new class() extends Migration
      */
     public function up(): void
     {
-        // Fix: Check if table exists before adding index to avoid errors in tests/CI
+        // Check if table exists before adding index to avoid errors in tests/CI
         if (Schema::hasTable('water_logs')) {
             Schema::table('water_logs', function (Blueprint $table) {
                 if (! Schema::hasIndex('water_logs', 'water_logs_user_id_consumed_at_index')) {


### PR DESCRIPTION
Removed the `Fix:` prefix from a comment in the `2026_01_29_200116_add_missing_performance_indexes.php` migration file since the fix (checking if the table exists before adding the index) was already implemented in the code right beneath it.

---
*PR created automatically by Jules for task [9971011770386594520](https://jules.google.com/task/9971011770386594520) started by @kuasar-mknd*