### PR TITLE
🧪 Add test coverage for CalculatesMacros edge case

### DIFF
--- a/tests/Unit/Actions/Tools/CalculatesMacrosTest.php
+++ b/tests/Unit/Actions/Tools/CalculatesMacrosTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Tools\Concerns\CalculatesMacros;
+
+test('calculates macros correctly when remaining calories are less than zero', function (): void {
+    $calculator = new class()
+    {
+        use CalculatesMacros;
+
+        /**
+         * @return array<string, float|int>
+         */
+        public function testCalculateMacros(float $targetCalories, float $weight): array
+        {
+            return $this->calculateMacros($targetCalories, $weight);
+        }
+    };
+
+    $result = $calculator->testCalculateMacros(1200, 120);
+
+    // Using loosely checking or specific types
+    expect($result['protein'])->toEqual(240);
+    expect($result['fat'])->toEqual(30);
+    expect($result['carbs'])->toEqual(0);
+});
+
+test('calculates macros correctly when remaining calories are positive', function (): void {
+    $calculator = new class()
+    {
+        use CalculatesMacros;
+
+        /**
+         * @return array<string, float|int>
+         */
+        public function testCalculateMacros(float $targetCalories, float $weight): array
+        {
+            return $this->calculateMacros($targetCalories, $weight);
+        }
+    };
+
+    $result = $calculator->testCalculateMacros(2500, 80);
+
+    expect($result['protein'])->toEqual(160);
+    expect($result['fat'])->toEqual(72);
+    expect($result['carbs'])->toEqual(303);
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed in `CalculatesMacros` when the remaining calculated calories drop below zero.
📊 **Coverage:** Test covers the happy path (positive remaining calories) and the specific edge case where the low target calories and high body weight combination cause an initially negative remaining calories, forcing a recalculation logic branch.
✨ **Result:** Improved test coverage on edge cases for the calculator actions.

---
*PR created automatically by Jules for task [6225111189783803085](https://jules.google.com/task/6225111189783803085) started by @kuasar-mknd*