### PR TITLE
🧹 Clean up unused Request parameters in IntervalTimerController

### DIFF
--- a/app/Http/Controllers/IntervalTimerController.php
+++ b/app/Http/Controllers/IntervalTimerController.php
@@ -8,7 +8,6 @@ use App\Http\Requests\StoreIntervalTimerRequest;
 use App\Http\Requests\UpdateIntervalTimerRequest;
 use App\Models\IntervalTimer;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -17,7 +16,7 @@ class IntervalTimerController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index(Request $request): Response
+    public function index(): Response
     {
         return Inertia::render('Tools/IntervalTimer', [
             'timers' => $this->user()->intervalTimers()->latest()->limit(50)->get(),
@@ -53,7 +52,7 @@ class IntervalTimerController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Request $request, IntervalTimer $intervalTimer): RedirectResponse
+    public function destroy(IntervalTimer $intervalTimer): RedirectResponse
     {
         $this->authorize('delete', $intervalTimer);
 


### PR DESCRIPTION
## 🧹 Code Health Improvement: Clean up unused parameters

🎯 **What:** Removed unused `Request $request` parameters from the `index` and `destroy` methods in `app/Http/Controllers/IntervalTimerController.php`, along with the unused import.
💡 **Why:** The request object was not being used in these methods. In Laravel, removing unused parameters is completely safe due to dependency injection via the Service Container. This declutters the controller and prevents static analysis warnings about unused variables, improving code readability.
✅ **Verification:** Ran backend static analysis (rector, pint) and the full PHP/Pest test suite (`./vendor/bin/pest`) successfully. Also executed specific interval timer tests ensuring routing and execution remain flawless.
✨ **Result:** A cleaner controller class without dead parameters or imports, retaining the exact same functional behavior.

---
*PR created automatically by Jules for task [631451312845090318](https://jules.google.com/task/631451312845090318) started by @kuasar-mknd*