### PR TITLE
🎨 Palette: Improve GlassButton accessibility and focus visibility

### DIFF
--- a/resources/js/Components/UI/GlassButton.vue
+++ b/resources/js/Components/UI/GlassButton.vue
@@ -24,6 +24,10 @@ defineProps({
         type: String,
         default: null,
     },
+    ariaLabel: {
+        type: String,
+        default: null,
+    },
 })
 
 const sizeClasses = {
@@ -40,8 +44,10 @@ const sizeClasses = {
         :type="type"
         :disabled="disabled || loading"
         :aria-busy="loading"
+        :aria-label="ariaLabel || $attrs['aria-label']"
+        :title="ariaLabel"
         :class="[
-            'glass-button transition-all',
+            'glass-button focus-visible:ring-electric-orange transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
             sizeClasses[size],
             {
                 'glass-button-primary shadow-glow-orange': variant === 'primary',


### PR DESCRIPTION
💡 What: Added an `ariaLabel` prop to `GlassButton.vue` to dynamically set `aria-label` and `title` attributes. Also added `focus-visible` Tailwind utilities to the component's root button.
🎯 Why: Icon-only buttons (like those using `material-symbols-outlined`) were lacking accessible labels for screen readers and tooltips for sighted users. Additionally, there were no focus rings, making keyboard navigation difficult or impossible to track.
📸 Before/After: Before, `GlassButton` without text had no `title` or `aria-label` by default, and tabbing through the UI showed no focus indicator. After, passing `aria-label` properly applies it and `title`, and tabbing produces a clear orange focus ring (`focus-visible:ring-electric-orange`).
♿ Accessibility:
- Adds accessible names for screen readers (`aria-label`).
- Adds standard tooltips for mouse users (`title`).
- Improves WCAG compliance for focus visibility (Criterion 2.4.7 Focus Visible).

---
*PR created automatically by Jules for task [2825377200246520126](https://jules.google.com/task/2825377200246520126) started by @kuasar-mknd*