### PR TITLE
feat(viz): Add Estimated 1RM History Chart for Best 1RM

### DIFF
--- a/resources/js/Components/Stats/Estimated1RMHistoryChart.vue
+++ b/resources/js/Components/Stats/Estimated1RMHistoryChart.vue
@@ -1,0 +1,105 @@
+<script setup>
+import { Line } from 'vue-chartjs'
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend,
+    Filler,
+} from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    return {
+        labels: props.data.map((item) => item.date),
+        datasets: [
+            {
+                label: '1RM Estimé (kg)',
+                data: props.data.map((item) => item.weight),
+                fill: true,
+                tension: 0.4,
+                borderColor: '#ec4899', // Pink-500
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+                    const gradient = ctx.createLinearGradient(0, chartArea.top, 0, chartArea.bottom)
+                    gradient.addColorStop(0, 'rgba(236, 72, 153, 0.2)') // Pink with opacity
+                    gradient.addColorStop(1, 'rgba(236, 72, 153, 0)') // Transparent
+                    return gradient
+                },
+                borderWidth: 3,
+                pointRadius: 3,
+                pointBackgroundColor: '#fff',
+                pointBorderColor: '#ec4899',
+                pointBorderWidth: 2,
+                pointHoverRadius: 6,
+                pointHoverBackgroundColor: '#ec4899',
+                pointHoverBorderColor: '#fff',
+                pointHoverBorderWidth: 2,
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: {
+            display: false,
+        },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.9)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            padding: 12,
+            cornerRadius: 12,
+            borderWidth: 1,
+            borderColor: 'rgba(236, 72, 153, 0.1)',
+            callbacks: {
+                label: (context) => `${context.parsed.y} kg`,
+            },
+        },
+    },
+    scales: {
+        x: {
+            grid: {
+                display: false,
+            },
+            ticks: {
+                color: '#64748B',
+                font: { size: 10, weight: 'bold' },
+            },
+        },
+        y: {
+            grid: {
+                color: 'rgba(0, 0, 0, 0.03)',
+            },
+            ticks: {
+                color: '#64748B',
+                font: { size: 10, weight: 'bold' },
+            },
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-full w-full">
+        <Line :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Exercises/Show.vue
+++ b/resources/js/Pages/Exercises/Show.vue
@@ -14,6 +14,7 @@ const TotalRepsChart = defineAsyncComponent(() => import('@/Components/Stats/Tot
 const SetsPerSessionChart = defineAsyncComponent(() => import('@/Components/Stats/SetsPerSessionChart.vue'))
 const WeightRepsScatterChart = defineAsyncComponent(() => import('@/Components/Stats/WeightRepsScatterChart.vue'))
 const SetWeightProgressionChart = defineAsyncComponent(() => import('@/Components/Stats/SetWeightProgressionChart.vue'))
+const Estimated1RMHistoryChart = defineAsyncComponent(() => import('@/Components/Stats/Estimated1RMHistoryChart.vue'))
 
 /**
  * Component Props
@@ -98,6 +99,14 @@ const averageWeightData = computed(() => {
             weight: average,
         }
     })
+})
+
+const estimated1rmData = computed(() => {
+    if (!props.history || props.history.length === 0) return []
+    return [...props.history].reverse().map((session) => ({
+        date: session.formatted_date.split('/').slice(0, 2).join('/'),
+        weight: session.best_1rm || 0,
+    }))
 })
 
 const weightDistributionData = computed(() => {
@@ -235,6 +244,16 @@ const scatterData = computed(() => {
                     </div>
                     <div class="h-64">
                         <MaxWeightChart :data="maxWeightData" />
+                    </div>
+                </GlassCard>
+
+                <GlassCard class="rounded-3xl border border-white/20 bg-white/10 backdrop-blur-md">
+                    <div class="mb-4">
+                        <h3 class="font-display text-text-main text-lg font-black uppercase italic">1RM Estimé</h3>
+                        <p class="text-text-muted text-xs font-semibold">Meilleur 1RM estimé par séance</p>
+                    </div>
+                    <div class="h-64">
+                        <Estimated1RMHistoryChart :data="estimated1rmData" />
                     </div>
                 </GlassCard>
 


### PR DESCRIPTION
### 💡 What
Added a new `Estimated1RMHistoryChart` to visually track the user's best Estimated 1 Rep Max over time for each exercise, integrating it directly into the `Exercises/Show.vue` detail view.

### 🎯 Why
Previously, the user's "Best 1RM" per session was only available as text within a list/table format inside the History list of the Exercise detail page. This new chart component extracts that data and visualizes it as an intuitive line graph, providing users with immediate insights into their training progress and strength gains over time.

### 📸 Details
- **Component**: `Estimated1RMHistoryChart.vue` (Chart.js / vue-chartjs)
- **Aesthetic**: Liquid Glass (matches `AverageWeightChart.vue`) using a smooth gradient fill and backdrop-blur cards.
- **Integration**: Inserted securely into the Analytics Grid on the Exercise detail page.

### ♿ Accessibility
The chart leverages existing accessible structure and utilizes a clean UI approach. Fallback textual information continues to reside in the History list view beneath the charts for screen-reader users or users who prefer data tables.

---
*(Successfully built frontend assets and verified styling using Playwright headless execution, tests pass locally).*

---
*PR created automatically by Jules for task [6253120585158854432](https://jules.google.com/task/6253120585158854432) started by @kuasar-mknd*