### PR TITLE
🎨 Palette: Improve Tools index interactions and accessibility

### DIFF
--- a/resources/js/Pages/Tools/Index.vue
+++ b/resources/js/Pages/Tools/Index.vue
@@ -4,7 +4,9 @@
             <div class="flex items-center gap-4">
                 <Link
                     :href="route('profile.index')"
-                    class="text-text-muted hover:text-electric-orange flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white shadow-sm transition-colors"
+                    class="text-text-muted hover:text-electric-orange focus-visible:ring-electric-orange flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                    aria-label="Retour au profil"
+                    v-press
                 >
                     <span class="material-symbols-outlined">arrow_back</span>
                 </Link>
@@ -14,9 +16,9 @@
 
         <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
             <!-- Plate Calculator -->
-            <Link :href="route('plates.index')" class="group block">
+            <Link :href="route('plates.index')" class="group block" v-press>
                 <GlassCard
-                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl active:scale-95 dark:bg-black/40"
+                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl dark:bg-black/40"
                 >
                     <div class="flex flex-col items-center space-y-4 text-center">
                         <div class="bg-accent-primary/20 text-accent-primary rounded-full p-4">
@@ -45,9 +47,9 @@
             </Link>
 
             <!-- 1RM Calculator -->
-            <Link :href="route('tools.1rm')" class="group block">
+            <Link :href="route('tools.1rm')" class="group block" v-press>
                 <GlassCard
-                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl active:scale-95 dark:bg-black/40"
+                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl dark:bg-black/40"
                 >
                     <div class="flex flex-col items-center space-y-4 text-center">
                         <div class="bg-accent-secondary/20 text-accent-secondary rounded-full p-4">
@@ -76,9 +78,9 @@
             </Link>
 
             <!-- Wilks Calculator -->
-            <Link :href="route('tools.wilks')" class="group block">
+            <Link :href="route('tools.wilks')" class="group block" v-press>
                 <GlassCard
-                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl active:scale-95 dark:bg-black/40"
+                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl dark:bg-black/40"
                 >
                     <div class="flex flex-col items-center space-y-4 text-center">
                         <div class="bg-electric-orange/20 text-electric-orange rounded-full p-4">
@@ -107,9 +109,9 @@
             </Link>
 
             <!-- Macro Calculator -->
-            <Link :href="route('tools.macro-calculator')" class="group block">
+            <Link :href="route('tools.macro-calculator')" class="group block" v-press>
                 <GlassCard
-                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl active:scale-95 dark:bg-black/40"
+                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl dark:bg-black/40"
                 >
                     <div class="flex flex-col items-center space-y-4 text-center">
                         <div class="rounded-full bg-emerald-500/20 p-4 text-emerald-500">
@@ -126,9 +128,9 @@
             </Link>
 
             <!-- Warmup Calculator -->
-            <Link :href="route('tools.warmup')" class="group block">
+            <Link :href="route('tools.warmup')" class="group block" v-press>
                 <GlassCard
-                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl active:scale-95 dark:bg-black/40"
+                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl dark:bg-black/40"
                 >
                     <div class="flex flex-col items-center space-y-4 text-center">
                         <div class="rounded-full bg-blue-500/20 p-4 text-blue-500">
@@ -157,9 +159,9 @@
             </Link>
 
             <!-- Water Tracker -->
-            <Link :href="route('tools.water.index')" class="group block">
+            <Link :href="route('tools.water.index')" class="group block" v-press>
                 <GlassCard
-                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl active:scale-95 dark:bg-black/40"
+                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl dark:bg-black/40"
                 >
                     <div class="flex flex-col items-center space-y-4 text-center">
                         <div class="rounded-full bg-cyan-500/20 p-4 text-cyan-500">
@@ -172,9 +174,9 @@
             </Link>
 
             <!-- Interval Timer -->
-            <Link :href="route('tools.interval-timer.index')" class="group block">
+            <Link :href="route('tools.interval-timer.index')" class="group block" v-press>
                 <GlassCard
-                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl active:scale-95 dark:bg-black/40"
+                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl dark:bg-black/40"
                 >
                     <div class="flex flex-col items-center space-y-4 text-center">
                         <div class="rounded-full bg-purple-500/20 p-4 text-purple-500">
@@ -189,9 +191,9 @@
             </Link>
 
             <!-- Fasting Tracker -->
-            <Link :href="route('tools.fasting.index')" class="group block">
+            <Link :href="route('tools.fasting.index')" class="group block" v-press>
                 <GlassCard
-                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl active:scale-95 dark:bg-black/40"
+                    class="relative h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl dark:bg-black/40"
                 >
                     <div class="flex flex-col items-center space-y-4 text-center">
                         <div class="rounded-full bg-violet-500/20 p-4 text-violet-500">


### PR DESCRIPTION
💡 **What**: 
- Added a localized French `aria-label` ("Retour au profil") to the icon-only Back button on the Tools Index page.
- Added appropriate keyboard focus states to the back button via existing `focus-visible` utility classes.
- Swapped out hardcoded redundant `active:scale-95` Tailwind classes on all 8 `<GlassCard>` components for the global `v-press` directive on their wrapping `<Link>` elements.

🎯 **Why**: 
Screen readers require explicit ARIA labels on icon-only buttons to navigate the app efficiently. Providing an `aria-label` in the user's localized language (French) makes the application accessible. Additionally, consolidating interaction feedback down to the `v-press` directive aligns the elements with the standardized UX codebase interactions and removes CSS inconsistencies. 

📸 **Before/After**: Visually identical, but the `active` push state has been improved with haptic feedback capabilities when used via `v-press`, and keyboard navigation visually highlights the back button correctly now.

♿ **Accessibility**: 
- Added screen reader support to the back `<Link>` button.
- Added visible outline for keyboard users navigating to the back button via tab order.

---
*PR created automatically by Jules for task [12687777493366776582](https://jules.google.com/task/12687777493366776582) started by @kuasar-mknd*