### PR TITLE
⚡ Bolt: Remove unused volumeTrend prop from dashboard

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -45,10 +45,10 @@ class DashboardController extends Controller
 
         return Inertia::render('Dashboard', [
             ...$data,
+            // ⚡ Bolt: Removed unused volumeTrend prop to eliminate 1 unnecessary async request and 1 DB query per dashboard load.
             // Defer heavy chart data
             'weeklyVolumeStats' => Inertia::defer(fn (): array => $fetchDashboardData->getWeeklyVolumeStats($user)),
             'weeklyVolumeTrend' => Inertia::defer(fn (): array => $fetchDashboardData->getWeeklyVolumeTrend($user)),
-            'volumeTrend' => Inertia::defer(fn (): array => $fetchDashboardData->getVolumeTrend($user)),
             'durationDistribution' => Inertia::defer(fn (): array => $fetchDashboardData->getDurationDistribution($user)),
             'timeOfDayDistribution' => Inertia::defer(fn (): array => $fetchDashboardData->getTimeOfDayDistribution($user)),
         ]);

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -25,7 +25,6 @@ const props = defineProps({
     activeGoals: { type: Array, default: () => [] },
     weeklyVolumeStats: { type: Object, default: () => ({ current_week_volume: 0, percentage: 0 }) },
     weeklyVolumeTrend: { type: Array, default: () => [] },
-    volumeTrend: { type: Array, default: () => [] },
     durationDistribution: { type: Array, default: () => [] },
     timeOfDayDistribution: { type: Array, default: () => [] },
 })


### PR DESCRIPTION
💡 What: Removed the unused `volumeTrend` prop from `DashboardController` and `Dashboard.vue`.

🎯 Why: This prop was triggering an unnecessary asynchronous request (via `Inertia::defer`) and a database query on every dashboard load, despite not being used in the frontend UI (the dashboard utilizes `weeklyVolumeTrend` for its visualizations).

📊 Impact: Reduces the number of asynchronous requests by 1 and eliminates 1 database query per dashboard visit, improving overall efficiency and perceived performance.

🔬 Measurement: Verified that the dashboard UI remains intact and all relevant charts (Weekly Volume, Duration Distribution, etc.) continue to function correctly. Network inspection confirms one fewer XHR request is made during the deferred loading phase.

---
*PR created automatically by Jules for task [3306096917617733696](https://jules.google.com/task/3306096917617733696) started by @kuasar-mknd*