### PR TITLE
feat(viz): Add Mixed Chart for Session Performance

### DIFF
--- a/resources/js/Components/Stats/SessionPerformanceChart.vue
+++ b/resources/js/Components/Stats/SessionPerformanceChart.vue
@@ -1,0 +1,165 @@
+<script setup>
+import { computed } from 'vue'
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, LineElement, PointElement, Title, Tooltip, Legend } from 'chart.js'
+import { Bar } from 'vue-chartjs'
+import { commonTooltipOptions } from './chartConfig'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, LineElement, PointElement, Title, Tooltip, Legend)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    // History is desc, so reverse for chart
+    const chronologicalData = [...props.data].reverse()
+
+    const labels = chronologicalData.map((session) => session.formatted_date.split('/').slice(0, 2).join('/'))
+
+    const volumeData = chronologicalData.map((session) =>
+        session.sets.reduce((sum, set) => sum + (set.weight || 0) * (set.reps || 0), 0)
+    )
+
+    const oneRmData = chronologicalData.map((session) => session.best_1rm || 0)
+
+    return {
+        labels,
+        datasets: [
+            {
+                type: 'line',
+                label: 'Meilleur 1RM (kg)',
+                data: oneRmData,
+                borderColor: '#8b5cf6', // violet
+                backgroundColor: '#8b5cf6',
+                borderWidth: 3,
+                tension: 0.4,
+                pointBackgroundColor: '#ffffff',
+                pointBorderColor: '#8b5cf6',
+                pointBorderWidth: 2,
+                pointRadius: 4,
+                yAxisID: 'y1',
+                order: 1, // Draw line on top of bars
+            },
+            {
+                type: 'bar',
+                label: 'Volume Total (kg)',
+                data: volumeData,
+                backgroundColor: 'rgba(249, 115, 22, 0.2)', // orange with opacity
+                borderColor: '#f97316',
+                borderWidth: { top: 2, right: 0, bottom: 0, left: 0 },
+                borderRadius: { topLeft: 6, topRight: 6 },
+                yAxisID: 'y',
+                order: 2,
+            }
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: {
+        mode: 'index',
+        intersect: false,
+    },
+    plugins: {
+        legend: {
+            display: true,
+            position: 'top',
+            labels: {
+                usePointStyle: true,
+                padding: 20,
+                font: {
+                    family: "'Nunito', sans-serif",
+                    weight: 'bold',
+                },
+                color: '#64748b', // slate-500
+            }
+        },
+        tooltip: {
+            ...commonTooltipOptions,
+            callbacks: {
+                label: function (context) {
+                    let label = context.dataset.label || ''
+                    if (label) {
+                        label += ': '
+                    }
+                    if (context.parsed.y !== null) {
+                        label += context.parsed.y.toLocaleString()
+                    }
+                    return label
+                },
+            },
+        },
+    },
+    scales: {
+        x: {
+            grid: {
+                display: false,
+                drawBorder: false,
+            },
+            ticks: {
+                font: {
+                    family: "'Nunito', sans-serif",
+                    weight: 'bold',
+                },
+                color: '#94a3b8',
+            },
+        },
+        y: {
+            type: 'linear',
+            display: true,
+            position: 'left',
+            grid: {
+                color: 'rgba(241, 245, 249, 0.5)',
+                drawBorder: false,
+            },
+            ticks: {
+                font: {
+                    family: "'Nunito', sans-serif",
+                    weight: 'bold',
+                },
+                color: '#94a3b8',
+                callback: function(value) {
+                    if (value >= 1000) {
+                        return (value / 1000).toFixed(1) + 'k'
+                    }
+                    return value
+                }
+            },
+            title: {
+                display: false,
+                text: 'Volume'
+            }
+        },
+        y1: {
+            type: 'linear',
+            display: true,
+            position: 'right',
+            grid: {
+                drawOnChartArea: false, // only want the grid lines for one axis to show up
+            },
+            ticks: {
+                font: {
+                    family: "'Nunito', sans-serif",
+                    weight: 'bold',
+                },
+                color: '#94a3b8',
+            },
+            title: {
+                display: false,
+                text: '1RM'
+            }
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-full w-full">
+        <Bar :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Exercises/Show.vue
+++ b/resources/js/Pages/Exercises/Show.vue
@@ -15,6 +15,7 @@ const SetsPerSessionChart = defineAsyncComponent(() => import('@/Components/Stat
 const WeightRepsScatterChart = defineAsyncComponent(() => import('@/Components/Stats/WeightRepsScatterChart.vue'))
 const SetWeightProgressionChart = defineAsyncComponent(() => import('@/Components/Stats/SetWeightProgressionChart.vue'))
 const Estimated1RMHistoryChart = defineAsyncComponent(() => import('@/Components/Stats/Estimated1RMHistoryChart.vue'))
+const SessionPerformanceChart = defineAsyncComponent(() => import('@/Components/Stats/SessionPerformanceChart.vue'))
 
 /**
  * Component Props
@@ -305,6 +306,23 @@ const scatterData = computed(() => {
                     <p class="text-text-muted text-sm">Pas assez de données pour afficher les statistiques</p>
                 </div>
             </GlassCard>
+
+            <!-- Session Performance Chart -->
+            <div class="animate-slide-up" style="animation-delay: 0.15s">
+                <GlassCard class="rounded-3xl border border-white/20 bg-white/10 backdrop-blur-md">
+                    <div class="mb-4">
+                        <h3 class="font-display text-text-main text-lg font-black uppercase italic">Performance Historique</h3>
+                        <p class="text-text-muted text-xs font-semibold">Volume et 1RM au fil du temps</p>
+                    </div>
+                    <div v-if="history.length > 0" class="h-64">
+                        <SessionPerformanceChart :data="history" />
+                    </div>
+                    <div v-else class="flex h-64 flex-col items-center justify-center text-center">
+                        <span class="material-symbols-outlined text-text-muted/30 mb-2 text-5xl">bar_chart</span>
+                        <p class="text-text-muted text-sm">Pas assez de données pour afficher le graphique</p>
+                    </div>
+                </GlassCard>
+            </div>
 
             <!-- History List -->
             <div class="animate-slide-up" style="animation-delay: 0.2s">


### PR DESCRIPTION
This pull request adds a new data visualization component to provide users with insights into their training progression for specific exercises.

**🎯 What:**
- Created `SessionPerformanceChart.vue`, a new "Stats" component utilizing Chart.js.
- Implemented a mixed Bar/Line chart to visualize Total Volume per session alongside Estimated 1RM progress.
- Integrated this chart into the Exercise Detail view (`resources/js/Pages/Exercises/Show.vue`), directly above the existing history list.
- Leveraged the 'Liquid Glass' aesthetic via `GlassCard` and Tailwind translucency utility classes to fit into the design system seamlessly.

**💡 Why:**
- Previously, training history was only visible as a raw text list. A visual chart allows users to immediately recognize trends in volume overload and strength progress.

**📸 Verification:**
- Created the Vue component and processed properties safely.
- All frontend and backend checks passed (`pnpm run build`, `pest`, `pint`, `rector`, `phpstan`).
- Visually verified via Playwright screenshot capturing the new Glass UI mixed chart.

---
*PR created automatically by Jules for task [8137063729385376310](https://jules.google.com/task/8137063729385376310) started by @kuasar-mknd*