### PR TITLE
docs: Update documentation for app/Http/Controllers/WorkoutLinesController.php

### DIFF
--- a/app/Http/Controllers/WorkoutLinesController.php
+++ b/app/Http/Controllers/WorkoutLinesController.php
@@ -8,10 +8,28 @@ use App\Models\Workout;
 use App\Models\WorkoutLine;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
+/**
+ * Controller for managing Workout Lines.
+ *
+ * This controller handles adding exercises (lines) to an existing workout
+ * and removing them. It ensures proper authorization for these actions.
+ */
 class WorkoutLinesController extends Controller
 {
     use AuthorizesRequests;
 
+    /**
+     * Add a new exercise line to a workout.
+     *
+     * Validates the request, calculates the correct order for the new line,
+     * and attaches it to the specified workout.
+     *
+     * @param  \App\Http\Requests\WorkoutLineStoreRequest  $request  The validated request containing exercise details.
+     * @param  \App\Models\Workout  $workout  The workout to add the line to.
+     * @return \Illuminate\Http\RedirectResponse Redirects back to the workout show page.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to modify the workout.
+     */
     public function store(\App\Http\Requests\WorkoutLineStoreRequest $request, Workout $workout): \Illuminate\Http\RedirectResponse
     {
         $this->authorize('create', [WorkoutLine::class, $workout]);
@@ -26,6 +44,16 @@ class WorkoutLinesController extends Controller
         return redirect()->route('workouts.show', $workout);
     }
 
+    /**
+     * Remove an exercise line from a workout.
+     *
+     * Deletes the specified workout line from the database.
+     *
+     * @param  \App\Models\WorkoutLine  $workoutLine  The workout line to delete.
+     * @return \Illuminate\Http\RedirectResponse Redirects back to the previous page.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to delete the line.
+     */
     public function destroy(\App\Models\WorkoutLine $workoutLine): \Illuminate\Http\RedirectResponse
     {
         $this->authorize('delete', $workoutLine);


### PR DESCRIPTION
Adds comprehensive PHPDoc comments to `app/Http/Controllers/WorkoutLinesController.php`.

The controller was lacking proper documentation blocks, making it harder to understand its parameters, return types, and potential exceptions at a glance.

This PR adds a class-level docblock and detailed method-level docblocks for both `store` and `destroy` methods.

No application logic or behavior has been altered. Testing passed with 0 errors via Pest, Pint, Rector, and PHPStan.

---
*PR created automatically by Jules for task [9547655647752087480](https://jules.google.com/task/9547655647752087480) started by @kuasar-mknd*