### PR TITLE
feat(viz): Add Line Chart for Body Fat

### DIFF
--- a/app/Http/Controllers/BodyMeasurementController.php
+++ b/app/Http/Controllers/BodyMeasurementController.php
@@ -51,10 +51,12 @@ class BodyMeasurementController extends Controller
             ->get();
 
         $weightHistory = $this->statsService->getWeightHistory($this->user(), 365);
+        $bodyFatHistory = $this->statsService->getBodyFatHistory($this->user(), 365);
 
         return Inertia::render('Measurements/Index', [
             'measurements' => $measurements,
             'weightHistory' => $weightHistory,
+            'bodyFatHistory' => $bodyFatHistory,
         ]);
     }
 

--- a/resources/js/Components/Stats/BodyFatLineChart.vue
+++ b/resources/js/Components/Stats/BodyFatLineChart.vue
@@ -1,0 +1,117 @@
+<script setup>
+import { Line } from 'vue-chartjs'
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend,
+    Filler,
+} from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    return {
+        labels: props.data.map((item) => item.date),
+        datasets: [
+            {
+                label: 'Masse Grasse (%)',
+                data: props.data.map((item) => item.body_fat),
+                fill: true,
+                tension: 0.4,
+                borderColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+                    // Gradient matching a neon 'Liquid Glass' theme: Violet to Hot Pink
+                    const gradient = ctx.createLinearGradient(chartArea.left, 0, chartArea.right, 0)
+                    gradient.addColorStop(0, '#8B5CF6') // Violet
+                    gradient.addColorStop(1, '#FF1493') // Hot Pink
+                    return gradient
+                },
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+                    const gradient = ctx.createLinearGradient(0, chartArea.top, 0, chartArea.bottom)
+                    gradient.addColorStop(0, 'rgba(255, 20, 147, 0.25)') // Translucent pink
+                    gradient.addColorStop(1, 'rgba(139, 92, 246, 0.05)') // Fading to faint violet
+                    return gradient
+                },
+                borderWidth: 3,
+                pointRadius: 2,
+                pointBackgroundColor: '#FF1493',
+                pointBorderColor: '#fff',
+                pointBorderWidth: 2,
+                pointHoverRadius: 6,
+                pointHoverBackgroundColor: '#fff',
+                pointHoverBorderColor: '#8B5CF6',
+                pointHoverBorderWidth: 3,
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: {
+            display: false,
+        },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.9)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            padding: 12,
+            cornerRadius: 12,
+            displayColors: false,
+            borderWidth: 1,
+            borderColor: 'rgba(255, 20, 147, 0.1)',
+            callbacks: {
+                label: (context) => `${context.parsed.y} %`,
+            },
+        },
+    },
+    scales: {
+        x: {
+            display: false,
+        },
+        y: {
+            display: true,
+            ticks: {
+                color: '#64748B',
+                font: { size: 10, weight: 'bold' },
+            },
+            grid: {
+                display: false,
+            },
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-40 w-full">
+        <Line :data="chartData" :options="chartOptions" />
+    </div>
+</template>
+
+<style scoped>
+/* Liquid Glass aesthetic drop shadow for the chart line */
+canvas {
+    filter: drop-shadow(0 4px 6px rgba(255, 20, 147, 0.2));
+}
+</style>

--- a/resources/js/Pages/Measurements/Index.vue
+++ b/resources/js/Pages/Measurements/Index.vue
@@ -7,10 +7,12 @@ import { Head, useForm } from '@inertiajs/vue3'
 import { computed, ref, defineAsyncComponent } from 'vue'
 
 const WeightHistoryChart = defineAsyncComponent(() => import('@/Components/Stats/WeightHistoryChart.vue'))
+const BodyFatLineChart = defineAsyncComponent(() => import('@/Components/Stats/BodyFatLineChart.vue'))
 
 const props = defineProps({
     measurements: Array,
     weightHistory: Array,
+    bodyFatHistory: Array,
 })
 
 const showAddForm = ref(false)
@@ -237,16 +239,34 @@ const chartOptions = {
                 </form>
             </GlassCard>
 
-            <!-- Chart -->
-            <GlassCard class="animate-slide-up" style="animation-delay: 0.1s">
-                <h3 class="font-display mb-4 text-xs font-black tracking-[0.2em] text-sky-600 uppercase">Évolution</h3>
-                <div class="h-64">
-                    <WeightHistoryChart v-if="weightHistory && weightHistory.length > 0" :data="weightHistory" />
-                    <div v-else class="text-text-muted/50 flex h-full items-center justify-center font-medium">
-                        Aucune donnée disponible
+            <!-- Charts -->
+            <div class="animate-slide-up grid grid-cols-1 gap-6 lg:grid-cols-2" style="animation-delay: 0.1s">
+                <!-- Weight Chart -->
+                <GlassCard>
+                    <h3 class="font-display mb-4 text-xs font-black tracking-[0.2em] text-sky-600 uppercase">
+                        Évolution Poids
+                    </h3>
+                    <div class="h-64">
+                        <WeightHistoryChart v-if="weightHistory && weightHistory.length > 0" :data="weightHistory" />
+                        <div v-else class="text-text-muted/50 flex h-full items-center justify-center font-medium">
+                            Aucune donnée disponible
+                        </div>
                     </div>
-                </div>
-            </GlassCard>
+                </GlassCard>
+
+                <!-- Body Fat Chart -->
+                <GlassCard>
+                    <h3 class="font-display mb-4 text-xs font-black tracking-[0.2em] text-pink-600 uppercase">
+                        Évolution Masse Grasse
+                    </h3>
+                    <div class="h-64">
+                        <BodyFatLineChart v-if="bodyFatHistory && bodyFatHistory.length > 0" :data="bodyFatHistory" />
+                        <div v-else class="text-text-muted/50 flex h-full items-center justify-center font-medium">
+                            Aucune donnée disponible
+                        </div>
+                    </div>
+                </GlassCard>
+            </div>
 
             <!-- History -->
             <div class="animate-slide-up" style="animation-delay: 0.2s">


### PR DESCRIPTION
Adds a new visual chart component (`BodyFatLineChart`) to visualize the user's body fat progression over time. This data was previously only accessible in a tabular/list format. The chart has been integrated into the `Measurements/Index` view alongside the existing `WeightHistoryChart`, using the application's signature "Liquid Glass" styling (gradients and drop shadows).

The backend controller (`BodyMeasurementController`) was updated to supply the `bodyFatHistory` dataset.

---
*PR created automatically by Jules for task [3031465990829784468](https://jules.google.com/task/3031465990829784468) started by @kuasar-mknd*