### PR TITLE
refactor: Extract logic from Api/HabitController

### DIFF
--- a/app/Actions/Habits/FetchHabitsIndexApiAction.php
+++ b/app/Actions/Habits/FetchHabitsIndexApiAction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Habits;
+
+use App\Models\Habit;
+use App\Models\User;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class FetchHabitsIndexApiAction
+{
+    /**
+     * Fetch paginated list of habits for the given user via API.
+     *
+     * @param  User  $user  The authenticated user.
+     * @param  array<string, mixed>  $requestData  The validated request data.
+     * @return LengthAwarePaginator<int, Habit> The paginated habits list.
+     */
+    public function execute(User $user, array $requestData): LengthAwarePaginator
+    {
+        $query = QueryBuilder::for(Habit::class)
+            ->allowedIncludes(['logs'])
+            ->allowedSorts(['name', 'created_at', 'goal_times_per_week'])
+            ->defaultSort('name')
+            ->where('user_id', $user->id);
+
+        /** @var int $perPage */
+        $perPage = $requestData['per_page'] ?? 15;
+
+        return $query->paginate($perPage);
+    }
+}

--- a/app/Http/Controllers/Api/HabitController.php
+++ b/app/Http/Controllers/Api/HabitController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api;
 
 use App\Actions\Habits\CreateHabitAction;
+use App\Actions\Habits\FetchHabitsIndexApiAction;
 use App\Http\Requests\Api\StoreHabitRequest;
 use App\Http\Requests\Api\UpdateHabitRequest;
 use App\Http\Resources\HabitResource;
@@ -13,7 +14,6 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use OpenApi\Attributes as OA;
-use Spatie\QueryBuilder\QueryBuilder;
 
 class HabitController extends Controller
 {
@@ -26,24 +26,15 @@ class HabitController extends Controller
     )]
     #[OA\Response(response: 200, description: 'Successful operation')]
     #[OA\Response(response: 401, description: 'Unauthenticated')]
-    public function index(Request $request): \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    public function index(Request $request, FetchHabitsIndexApiAction $fetchHabitsIndexApiAction): \Illuminate\Http\Resources\Json\AnonymousResourceCollection
     {
         $this->authorize('viewAny', Habit::class);
-
-        $query = QueryBuilder::for(Habit::class)
-            ->allowedIncludes(['logs'])
-            ->allowedSorts(['name', 'created_at', 'goal_times_per_week'])
-            ->defaultSort('name')
-            ->where('user_id', $this->user()->id);
 
         $validated = $request->validate([
             'per_page' => 'sometimes|integer|min:1|max:100',
         ]);
 
-        /** @var int $perPage */
-        $perPage = $validated['per_page'] ?? 15;
-
-        $habits = $query->paginate($perPage);
+        $habits = $fetchHabitsIndexApiAction->execute($this->user(), $validated);
 
         return HabitResource::collection($habits);
     }


### PR DESCRIPTION
🎯 What
Extracted the business logic (Spatie QueryBuilder logic and request validation parsing) from the `index` method of `App\Http\Controllers\Api\HabitController` into a dedicated Action class (`App\Actions\Habits\FetchHabitsIndexApiAction.php`).

💡 Why
Adhering to SOLID principles, this simplifies the `HabitController` to handle HTTP requests/responses, delegating data retrieval to a specialized Action. This improves code maintainability and testability. The `index` method in `HabitController` was identified as the longest method within `app/Http/Controllers` (excluding Auth controllers) before refactoring. Unused imports were also removed.

✅ Verification
Ran static analysis (`phpstan analyse`), automatic refactoring tools (`rector process`), and style checks (`pint`), ensuring all passed cleanly. Fully ran all test suites with `./vendor/bin/pest`, and all tests passed smoothly.

✨ Result
The `HabitController` is significantly leaner, and the index logic is encapsulated and type-safe via `LengthAwarePaginator<int, Habit>`.

---
*PR created automatically by Jules for task [10899733653286678183](https://jules.google.com/task/10899733653286678183) started by @kuasar-mknd*