### PR TITLE
feat(viz): Add Line Chart for Recent Duration

### DIFF
--- a/resources/js/Components/Stats/RecentWorkoutsDurationChart.vue
+++ b/resources/js/Components/Stats/RecentWorkoutsDurationChart.vue
@@ -1,0 +1,105 @@
+<script setup>
+import { computed } from 'vue'
+import { Line } from 'vue-chartjs'
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Filler,
+} from 'chart.js'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Filler)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    // Reverse the array so chronological order is left-to-right
+    const workouts = [...props.data].reverse()
+
+    return {
+        labels: workouts.map((w) =>
+            new Date(w.started_at).toLocaleDateString('fr-FR', {
+                day: 'numeric',
+                month: 'short',
+            }),
+        ),
+        datasets: [
+            {
+                label: 'Durée (min)',
+                data: workouts.map((w) => {
+                    if (w.duration_minutes) return w.duration_minutes
+                    if (w.ended_at && w.started_at) {
+                        return Math.round((new Date(w.ended_at) - new Date(w.started_at)) / 60000)
+                    }
+                    return 0
+                }),
+                borderColor: '#ec4899', // hot-pink
+                backgroundColor: 'rgba(236, 72, 153, 0.2)',
+                borderWidth: 3,
+                tension: 0.4,
+                fill: true,
+                pointBackgroundColor: '#ec4899',
+                pointBorderColor: '#ffffff',
+                pointBorderWidth: 2,
+                pointRadius: 4,
+                pointHoverRadius: 6,
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: { display: false },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.9)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            borderColor: 'rgba(236, 72, 153, 0.2)',
+            borderWidth: 1,
+            padding: 10,
+            displayColors: false,
+            callbacks: {
+                label: (context) => `${context.parsed.y} min`,
+            },
+        },
+    },
+    scales: {
+        y: {
+            beginAtZero: true,
+            grid: {
+                color: 'rgba(255, 255, 255, 0.1)',
+                drawBorder: false,
+            },
+            ticks: {
+                color: 'rgba(255, 255, 255, 0.7)',
+                font: { size: 10, weight: 'bold' },
+            },
+        },
+        x: {
+            grid: { display: false, drawBorder: false },
+            ticks: {
+                color: 'rgba(255, 255, 255, 0.7)',
+                font: { size: 10, weight: 'bold' },
+            },
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-full w-full" style="filter: drop-shadow(0 4px 6px rgba(236, 72, 153, 0.2))">
+        <Line :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -10,6 +10,9 @@ const WeeklyVolumeChart = defineAsyncComponent(() => import('@/Components/Stats/
 const DurationDistributionChart = defineAsyncComponent(() => import('@/Components/Stats/DurationDistributionChart.vue'))
 const TimeOfDayChart = defineAsyncComponent(() => import('@/Components/Stats/TimeOfDayChart.vue'))
 const RecentWorkoutsChart = defineAsyncComponent(() => import('@/Components/Stats/RecentWorkoutsChart.vue'))
+const RecentWorkoutsDurationChart = defineAsyncComponent(
+    () => import('@/Components/Stats/RecentWorkoutsDurationChart.vue'),
+)
 
 /**
  * Dashboard - Command Center
@@ -305,6 +308,30 @@ const colorForWorkout = (index) => {
                     />
                     <div v-else class="text-text-muted flex h-full items-center justify-center">
                         <p class="text-sm">Pas assez de données de volume</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Recent Workouts Duration Chart -->
+            <section
+                class="glass-panel-light animate-slide-up relative overflow-hidden rounded-3xl p-6"
+                style="animation-delay: 0.195s"
+            >
+                <div class="relative z-10 mb-6">
+                    <h3 class="text-hot-pink mb-1 text-[10px] font-black tracking-[0.2em] uppercase">Endurance</h3>
+                    <p class="font-display text-text-main text-2xl font-black uppercase italic dark:text-white">
+                        Durée Récente
+                    </p>
+                </div>
+
+                <!-- Recent Workouts Duration Line Chart -->
+                <div class="relative -mx-2 mt-2 h-48 w-auto">
+                    <RecentWorkoutsDurationChart
+                        v-if="recentWorkouts && recentWorkouts.length > 0"
+                        :data="recentWorkouts"
+                    />
+                    <div v-else class="text-text-muted flex h-full items-center justify-center">
+                        <p class="text-sm">Pas assez de données de durée</p>
                     </div>
                 </div>
             </section>

--- a/resources/js/Pages/Tools/WarmupCalculator.vue
+++ b/resources/js/Pages/Tools/WarmupCalculator.vue
@@ -28,7 +28,7 @@
                                     v-model="targetWeight"
                                     placeholder="100"
                                     step="0.5"
-                                    class="font-display text-text-main focus:border-white/50 focus:ring-white/20 h-16 w-full rounded-2xl border border-white/20 bg-white/10 px-4 text-center text-3xl font-black backdrop-blur-md transition-all outline-none hover:bg-white/20 focus:ring-2 active:scale-95"
+                                    class="font-display text-text-main h-16 w-full rounded-2xl border border-white/20 bg-white/10 px-4 text-center text-3xl font-black backdrop-blur-md transition-all outline-none hover:bg-white/20 focus:border-white/50 focus:ring-2 focus:ring-white/20 active:scale-95"
                                 />
                                 <span class="text-text-muted absolute top-1/2 right-4 -translate-y-1/2 font-bold"
                                     >kg</span
@@ -42,7 +42,7 @@
                                     type="number"
                                     v-model="form.bar_weight"
                                     placeholder="20"
-                                    class="font-display text-text-main focus:border-white/50 focus:ring-white/20 h-16 w-full rounded-2xl border border-white/20 bg-white/10 px-4 text-center text-3xl font-black backdrop-blur-md transition-all outline-none hover:bg-white/20 focus:ring-2 active:scale-95"
+                                    class="font-display text-text-main h-16 w-full rounded-2xl border border-white/20 bg-white/10 px-4 text-center text-3xl font-black backdrop-blur-md transition-all outline-none hover:bg-white/20 focus:border-white/50 focus:ring-2 focus:ring-white/20 active:scale-95"
                                 />
                                 <span class="text-text-muted absolute top-1/2 right-4 -translate-y-1/2 font-bold"
                                     >kg</span
@@ -121,7 +121,7 @@
                                     <input
                                         type="number"
                                         v-model="step.percent"
-                                        class="w-full rounded-xl border border-white/20 bg-white/10 px-3 py-2 text-sm font-bold text-text-main backdrop-blur-md transition-all outline-none focus:border-white/50 focus:ring-1 focus:ring-white/50 active:scale-95 hover:bg-white/20"
+                                        class="text-text-main w-full rounded-xl border border-white/20 bg-white/10 px-3 py-2 text-sm font-bold backdrop-blur-md transition-all outline-none hover:bg-white/20 focus:border-white/50 focus:ring-1 focus:ring-white/50 active:scale-95"
                                     />
                                     <span class="text-text-muted absolute top-1/2 right-2 -translate-y-1/2 text-xs"
                                         >%</span
@@ -132,7 +132,7 @@
                                 <input
                                     type="number"
                                     v-model="step.reps"
-                                    class="w-full rounded-xl border border-white/20 bg-white/10 px-3 py-2 text-sm font-bold text-text-main backdrop-blur-md transition-all outline-none focus:border-white/50 focus:ring-1 focus:ring-white/50 active:scale-95 hover:bg-white/20"
+                                    class="text-text-main w-full rounded-xl border border-white/20 bg-white/10 px-3 py-2 text-sm font-bold backdrop-blur-md transition-all outline-none hover:bg-white/20 focus:border-white/50 focus:ring-1 focus:ring-white/50 active:scale-95"
                                 />
                             </div>
                             <div class="col-span-5">
@@ -140,7 +140,7 @@
                                     type="text"
                                     v-model="step.label"
                                     placeholder="ex: Barre vide"
-                                    class="w-full rounded-xl border border-white/20 bg-white/10 px-3 py-2 text-sm text-text-main placeholder-slate-400 backdrop-blur-md transition-all outline-none focus:border-white/50 focus:ring-1 focus:ring-white/50 active:scale-95 hover:bg-white/20"
+                                    class="text-text-main w-full rounded-xl border border-white/20 bg-white/10 px-3 py-2 text-sm placeholder-slate-400 backdrop-blur-md transition-all outline-none hover:bg-white/20 focus:border-white/50 focus:ring-1 focus:ring-white/50 active:scale-95"
                                 />
                             </div>
                             <div class="col-span-1 flex items-center justify-center">
@@ -166,11 +166,11 @@
                                 v-for="inc in [0.5, 1, 2.5, 5]"
                                 :key="inc"
                                 @click="form.rounding_increment = inc"
-                                class="flex-1 rounded-xl border py-2 text-sm font-bold transition-all backdrop-blur-md active:scale-95"
+                                class="flex-1 rounded-xl border py-2 text-sm font-bold backdrop-blur-md transition-all active:scale-95"
                                 :class="
                                     form.rounding_increment === inc
                                         ? 'border-electric-orange bg-electric-orange/20 text-electric-orange shadow-[0_0_15px_rgba(255,107,0,0.3)]'
-                                        : 'border-white/20 bg-white/10 text-text-muted hover:bg-white/20 hover:text-text-main'
+                                        : 'text-text-muted hover:text-text-main border-white/20 bg-white/10 hover:bg-white/20'
                                 "
                             >
                                 {{ inc }}


### PR DESCRIPTION
## 🎯 What
Adds a new chart visualization to the Dashboard to display the duration of recent workouts.

## 💡 Why
The `recentWorkouts` dataset on the Dashboard previously only included a volume bar chart and a list of activity cards. Adding a line chart for the workout duration provides users with better insights into their training endurance over time. 

## ✅ Verification
The new component has been verified visually using a Playwright script. It correctly falls back to an empty state when there isn't enough data. Code was formatted via `pnpm run format` and checked via `pnpm run lint:js`. Code review confirmed safe, robust implementation utilizing Vue Reactivity and Chart.js.

## ✨ Result
A Liquid Glass-styled line chart rendering recent workout durations is now visible on the Dashboard.

---
*PR created automatically by Jules for task [3894524449945260284](https://jules.google.com/task/3894524449945260284) started by @kuasar-mknd*