### PR TITLE
design: Liquid Glass overhaul for Measurements/Parts/Index

### DIFF
--- a/resources/js/Pages/Measurements/Parts/Index.vue
+++ b/resources/js/Pages/Measurements/Parts/Index.vue
@@ -63,7 +63,7 @@ const selectCommonPart = (part) => {
 
         <div class="space-y-6">
             <!-- Add Form -->
-            <GlassCard v-if="showAddForm" class="animate-slide-up">
+            <GlassCard v-if="showAddForm" class="animate-slide-up rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl dark:bg-black/40">
                 <h3 class="text-text-main mb-4 font-semibold">New Measurement</h3>
                 <form @submit.prevent="submit" class="space-y-4">
                     <div>
@@ -140,12 +140,13 @@ const selectCommonPart = (part) => {
                 style="animation-delay: 0.1s"
             >
                 <Link
+                    v-press
                     v-for="item in latestMeasurements"
                     :key="item.part"
                     :href="route('body-parts.show', { part: item.part })"
                     class="block"
                 >
-                    <GlassCard class="h-full transition hover:scale-[1.02] hover:bg-white/10">
+                    <GlassCard class="h-full overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-5 shadow-2xl backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl active:scale-95 dark:bg-black/40">
                         <div class="flex items-start justify-between">
                             <div>
                                 <h3 class="text-text-main font-bold">{{ item.part }}</h3>


### PR DESCRIPTION
This PR updates the `Measurements/Parts/Index.vue` component to align with Apple's Human Interface Guidelines by utilizing the 'Liquid Glass' design aesthetic from Tailwind CSS.

### Changes:
- **Card Aesthetics:** Refactored `<GlassCard>` components (the "Add Form" and the "Measurements List") to include:
  - `bg-white/10` and `backdrop-blur-md` for the translucent background.
  - `border border-white/20` for subtle glowing edges.
  - `rounded-3xl` for softer corner radiuses.
  - `dark:bg-black/40` to ensure proper fallback styling in dark mode.
- **Micro-interactions:**
  - Added CSS transitions to hover states (`hover:-translate-y-1`, `hover:bg-white/20`, `hover:shadow-xl`).
  - Implemented the `v-press` directive on the `<Link>` component for explicit haptic feedback upon interaction.
  - Added CSS `active:scale-95` on the cards for an immediate physical click sensation.

These updates provide a smoother, more modern, and tactile user experience. All changes successfully passed frontend visual verification and backend testing.

---
*PR created automatically by Jules for task [15155914654899739160](https://jules.google.com/task/15155914654899739160) started by @kuasar-mknd*