### PR TITLE
refactor: Extract logic from SupplementController

### DIFF
--- a/app/Actions/Supplements/ConsumeSupplementAction.php
+++ b/app/Actions/Supplements/ConsumeSupplementAction.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Supplements;
+
+use App\Models\Supplement;
+use App\Models\SupplementLog;
+use App\Models\User;
+
+class ConsumeSupplementAction
+{
+    /**
+     * Record a consumption event for a supplement.
+     *
+     * Creates a log entry for the consumption and decrements the inventory count.
+     * Prevents the inventory from going below zero.
+     *
+     * @param  User  $user  The user consuming the supplement.
+     * @param  Supplement  $supplement  The supplement consumed.
+     */
+    public function execute(User $user, Supplement $supplement): void
+    {
+        // Create log
+        SupplementLog::create([
+            'user_id' => $user->id,
+            'supplement_id' => $supplement->id,
+            'quantity' => 1,
+            'consumed_at' => now(),
+        ]);
+
+        if ($supplement->servings_remaining > 0) {
+            $supplement->decrement('servings_remaining');
+        }
+    }
+}

--- a/app/Http/Controllers/SupplementController.php
+++ b/app/Http/Controllers/SupplementController.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Actions\Supplements\ConsumeSupplementAction;
 use App\Actions\Supplements\FetchSupplementsIndexAction;
 use App\Http\Requests\SupplementStoreRequest;
 use App\Http\Requests\SupplementUpdateRequest;
 use App\Models\Supplement;
-use App\Models\SupplementLog;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -115,21 +115,11 @@ class SupplementController extends Controller
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException If the user is not authorized (403).
      */
-    public function consume(Request $request, Supplement $supplement): \Illuminate\Http\RedirectResponse
+    public function consume(Request $request, Supplement $supplement, ConsumeSupplementAction $consumeSupplementAction): \Illuminate\Http\RedirectResponse
     {
         $this->authorize('update', $supplement);
 
-        // Create log
-        SupplementLog::create([
-            'user_id' => $this->user()->id,
-            'supplement_id' => $supplement->id,
-            'quantity' => 1,
-            'consumed_at' => now(),
-        ]);
-
-        if ($supplement->servings_remaining > 0) {
-            $supplement->decrement('servings_remaining');
-        }
+        $consumeSupplementAction->execute($this->user(), $supplement);
 
         return redirect()->back()->with('success', 'Consommation enregistrée.');
     }


### PR DESCRIPTION
**🎯 What**
Extracts the business logic for consuming a supplement from `SupplementController@consume` into a dedicated action class `ConsumeSupplementAction`. Also cleans up unused imports in the controller and runs full formatting and static analysis to ensure code health.

**💡 Why**
By delegating logic to the `ConsumeSupplementAction` class, the controller becomes leaner and focuses solely on handling the HTTP request and response, adhering more closely to SOLID principles and improving the overall maintainability and testability of the code.

**✅ Verification**
- Created the new Action class and verified its logic.
- Updated `SupplementController@consume` to utilize this action.
- Ran `pint` for code formatting.
- Ran `rector` for automated code quality improvements.
- Ran `phpstan` to ensure no new static analysis issues (0 errors).
- Executed `pest` tests for the supplement domain, confirming all existing tests still pass successfully.

**✨ Result**
The `SupplementController` is now cleaner and easier to maintain with its core business logic appropriately abstracted into an Action class.

---
*PR created automatically by Jules for task [11233049543946694573](https://jules.google.com/task/11233049543946694573) started by @kuasar-mknd*