### PR TITLE
docs: Update documentation for FastController

### DIFF
--- a/app/Http/Controllers/Api/FastController.php
+++ b/app/Http/Controllers/Api/FastController.php
@@ -11,12 +11,33 @@ use App\Http\Resources\FastResource;
 use App\Models\Fast;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
+use OpenApi\Attributes as OA;
 
+/**
+ * Controller for managing user fasts via API.
+ *
+ * Provides endpoints for creating, retrieving, updating, and deleting
+ * fasting records for the authenticated user.
+ */
 class FastController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * Display a listing of the user's fasts.
+     *
+     * Retrieves a paginated list of fasting records belonging to the authenticated user.
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection A collection of fast resources.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to view fasts.
      */
+    #[OA\Get(
+        path: '/fasts',
+        summary: 'List user fasts',
+        tags: ['Fasts']
+    )]
+    #[OA\Response(response: 200, description: 'Successful operation')]
+    #[OA\Response(response: 401, description: 'Unauthenticated')]
+    #[OA\Response(response: 403, description: 'Forbidden')]
     public function index(): AnonymousResourceCollection
     {
         $this->authorize('viewAny', Fast::class);
@@ -29,8 +50,25 @@ class FastController extends Controller
     }
 
     /**
-     * Store a newly created resource in storage.
+     * Store a newly created fast in storage.
+     *
+     * Validates the request data and starts a new active fast for the user.
+     *
+     * @param  \App\Http\Requests\Api\StoreFastRequest  $request  The incoming validated request.
+     * @return \App\Http\Resources\FastResource The newly created fast resource.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to create a fast.
      */
+    #[OA\Post(
+        path: '/fasts',
+        summary: 'Create a new fast',
+        tags: ['Fasts']
+    )]
+    #[OA\Response(response: 201, description: 'Fast created successfully')]
+    #[OA\Response(response: 400, description: 'Bad request')]
+    #[OA\Response(response: 401, description: 'Unauthenticated')]
+    #[OA\Response(response: 403, description: 'Forbidden')]
+    #[OA\Response(response: 422, description: 'Validation error')]
     public function store(StoreFastRequest $request): FastResource
     {
         $this->authorize('create', Fast::class);
@@ -49,8 +87,31 @@ class FastController extends Controller
     }
 
     /**
-     * Display the specified resource.
+     * Display the specified fast.
+     *
+     * Retrieves the details of a specific fasting record.
+     *
+     * @param  \App\Models\Fast  $fast  The fast instance to display.
+     * @return \App\Http\Resources\FastResource The requested fast resource.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to view the fast.
      */
+    #[OA\Get(
+        path: '/fasts/{id}',
+        summary: 'Get a specific fast',
+        tags: ['Fasts']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        required: true,
+        description: 'ID of the fast',
+        schema: new OA\Schema(type: 'integer')
+    )]
+    #[OA\Response(response: 200, description: 'Successful operation')]
+    #[OA\Response(response: 401, description: 'Unauthenticated')]
+    #[OA\Response(response: 403, description: 'Forbidden')]
+    #[OA\Response(response: 404, description: 'Fast not found')]
     public function show(Fast $fast): FastResource
     {
         $this->authorize('view', $fast);
@@ -59,8 +120,34 @@ class FastController extends Controller
     }
 
     /**
-     * Update the specified resource in storage.
+     * Update the specified fast in storage.
+     *
+     * Modifies the details of an existing fast, for example ending an active fast.
+     *
+     * @param  \App\Http\Requests\Api\UpdateFastRequest  $request  The incoming validated request.
+     * @param  \App\Models\Fast  $fast  The fast instance to update.
+     * @return \App\Http\Resources\FastResource The updated fast resource.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to update the fast.
      */
+    #[OA\Put(
+        path: '/fasts/{id}',
+        summary: 'Update a fast',
+        tags: ['Fasts']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        required: true,
+        description: 'ID of the fast',
+        schema: new OA\Schema(type: 'integer')
+    )]
+    #[OA\Response(response: 200, description: 'Fast updated successfully')]
+    #[OA\Response(response: 400, description: 'Bad request')]
+    #[OA\Response(response: 401, description: 'Unauthenticated')]
+    #[OA\Response(response: 403, description: 'Forbidden')]
+    #[OA\Response(response: 404, description: 'Fast not found')]
+    #[OA\Response(response: 422, description: 'Validation error')]
     public function update(UpdateFastRequest $request, Fast $fast): FastResource
     {
         $this->authorize('update', $fast);
@@ -71,8 +158,31 @@ class FastController extends Controller
     }
 
     /**
-     * Remove the specified resource from storage.
+     * Remove the specified fast from storage.
+     *
+     * Permanently deletes a fasting record from the user's history.
+     *
+     * @param  \App\Models\Fast  $fast  The fast instance to delete.
+     * @return \Illuminate\Http\Response An empty HTTP response indicating success.
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException If the user is not authorized to delete the fast.
      */
+    #[OA\Delete(
+        path: '/fasts/{id}',
+        summary: 'Delete a fast',
+        tags: ['Fasts']
+    )]
+    #[OA\Parameter(
+        name: 'id',
+        in: 'path',
+        required: true,
+        description: 'ID of the fast to delete',
+        schema: new OA\Schema(type: 'integer')
+    )]
+    #[OA\Response(response: 204, description: 'Fast deleted successfully')]
+    #[OA\Response(response: 401, description: 'Unauthenticated')]
+    #[OA\Response(response: 403, description: 'Forbidden')]
+    #[OA\Response(response: 404, description: 'Fast not found')]
     public function destroy(Fast $fast): Response
     {
         $this->authorize('delete', $fast);


### PR DESCRIPTION
🎯 What: Adds detailed PHPDoc blocks and Swagger OpenApi attributes to `app/Http/Controllers/Api/FastController.php`.
💡 Why: The controller lacked necessary API endpoint documentation. This ensures that the code remains readable, understandable, and that the Swagger docs accurately reflect its endpoints, parameters, and exceptions.
✅ Verification: Tested via Pest. Static analysis via PHPStan. Formatting checked via Pint. Code review completed.
✨ Result: `FastController` is now comprehensively documented and integrates with Swagger seamlessly.

---
*PR created automatically by Jules for task [14857261090630624466](https://jules.google.com/task/14857261090630624466) started by @kuasar-mknd*