### PR TITLE
feat(viz): Add Line Chart for Session Volume

### DIFF
--- a/resources/js/Components/Stats/SessionVolumeLineChart.vue
+++ b/resources/js/Components/Stats/SessionVolumeLineChart.vue
@@ -1,0 +1,122 @@
+<script setup>
+import { Line } from 'vue-chartjs'
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend,
+    Filler,
+} from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    const labels = props.data.map((d) => d.date)
+    const volumes = props.data.map((d) => d.volume)
+
+    return {
+        labels,
+        datasets: [
+            {
+                label: 'Volume par séance',
+                data: volumes,
+                fill: true,
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+
+                    const gradient = ctx.createLinearGradient(0, chartArea.top, 0, chartArea.bottom)
+                    gradient.addColorStop(0, 'rgba(136, 0, 255, 0.4)') // vivid-violet
+                    gradient.addColorStop(1, 'rgba(255, 0, 128, 0)') // hot-pink
+
+                    return gradient
+                },
+                borderColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+
+                    const gradient = ctx.createLinearGradient(chartArea.left, 0, chartArea.right, 0)
+                    gradient.addColorStop(0, '#8800FF') // vivid-violet
+                    gradient.addColorStop(1, '#FF0080') // hot-pink
+
+                    return gradient
+                },
+                borderWidth: 4,
+                tension: 0.4,
+                pointBackgroundColor: '#FFFFFF',
+                pointBorderColor: '#8800FF',
+                pointBorderWidth: 2,
+                pointRadius: 4,
+                pointHoverRadius: 6,
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: { display: false },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.9)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            borderColor: 'rgba(136, 0, 255, 0.2)',
+            borderWidth: 1,
+            padding: 10,
+            displayColors: false,
+            callbacks: {
+                label: (context) => `${context.parsed.y} kg`,
+            },
+        },
+    },
+    scales: {
+        x: {
+            grid: { display: false },
+            ticks: {
+                color: '#94a3b8',
+                font: { size: 10, weight: 'bold', family: 'sans-serif' },
+                padding: 10,
+            },
+            border: { display: false },
+        },
+        y: {
+            display: false,
+            beginAtZero: true,
+        },
+    },
+    interaction: {
+        mode: 'index',
+        intersect: false,
+    },
+    layout: {
+        padding: {
+            left: -10,
+            right: -10,
+            bottom: 0,
+            top: 10,
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-full w-full" style="filter: drop-shadow(0 4px 6px rgba(136, 0, 255, 0.15))">
+        <Line :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Exercises/Show.vue
+++ b/resources/js/Pages/Exercises/Show.vue
@@ -16,6 +16,7 @@ const WeightRepsScatterChart = defineAsyncComponent(() => import('@/Components/S
 const SetWeightProgressionChart = defineAsyncComponent(() => import('@/Components/Stats/SetWeightProgressionChart.vue'))
 const Estimated1RMHistoryChart = defineAsyncComponent(() => import('@/Components/Stats/Estimated1RMHistoryChart.vue'))
 const SessionPerformanceChart = defineAsyncComponent(() => import('@/Components/Stats/SessionPerformanceChart.vue'))
+const SessionVolumeLineChart = defineAsyncComponent(() => import('@/Components/Stats/SessionVolumeLineChart.vue'))
 
 /**
  * Component Props
@@ -321,6 +322,25 @@ const scatterData = computed(() => {
                     </div>
                     <div v-else class="flex h-64 flex-col items-center justify-center text-center">
                         <span class="material-symbols-outlined text-text-muted/30 mb-2 text-5xl">bar_chart</span>
+                        <p class="text-text-muted text-sm">Pas assez de données pour afficher le graphique</p>
+                    </div>
+                </GlassCard>
+            </div>
+
+            <!-- Session Volume Line Chart -->
+            <div class="animate-slide-up" style="animation-delay: 0.18s">
+                <GlassCard class="rounded-3xl border border-white/20 bg-white/10 backdrop-blur-md">
+                    <div class="mb-4">
+                        <h3 class="font-display text-text-main text-lg font-black uppercase italic">
+                            Évolution du Volume
+                        </h3>
+                        <p class="text-text-muted text-xs font-semibold">Volume total par séance</p>
+                    </div>
+                    <div v-if="volumeData.length > 0" class="h-64">
+                        <SessionVolumeLineChart :data="volumeData" />
+                    </div>
+                    <div v-else class="flex h-64 flex-col items-center justify-center text-center">
+                        <span class="material-symbols-outlined text-text-muted/30 mb-2 text-5xl">show_chart</span>
                         <p class="text-text-muted text-sm">Pas assez de données pour afficher le graphique</p>
                     </div>
                 </GlassCard>


### PR DESCRIPTION
Added a new line chart `SessionVolumeLineChart.vue` to visualize the total volume per session inside the Exercise Detail view (`Show.vue`). The chart utilizes the "Liquid Glass" aesthetic matching the existing data visualizations, and maps the `date` and `volume` of the `volumeData` dataset representing the specific exercise's historical progression.

---
*PR created automatically by Jules for task [2967001189933935125](https://jules.google.com/task/2967001189933935125) started by @kuasar-mknd*