### PR TITLE
feat(viz): Add Exercises Bar Chart for Recent Workouts

### DIFF
--- a/resources/js/Components/Stats/RecentWorkoutsExercisesChart.vue
+++ b/resources/js/Components/Stats/RecentWorkoutsExercisesChart.vue
@@ -1,0 +1,98 @@
+<script setup>
+import { Bar } from 'vue-chartjs'
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    // Reverse the data so it reads chronologically from left to right
+    const reversedData = [...props.data].reverse()
+
+    const labels = reversedData.map((d) => {
+        const date = new Date(d.started_at)
+        return date.toLocaleDateString('fr-FR', {
+            day: 'numeric',
+            month: 'short',
+        })
+    })
+
+    const exerciseCounts = reversedData.map((d) => d.workout_lines_count || 0)
+
+    return {
+        labels,
+        datasets: [
+            {
+                label: 'Exercices',
+                data: exerciseCounts,
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+
+                    const gradient = ctx.createLinearGradient(0, chartArea.bottom, 0, chartArea.top)
+                    gradient.addColorStop(0, '#00D1FF') // cyan-pure
+                    gradient.addColorStop(1, '#00FF66') // neon-green
+
+                    return gradient
+                },
+                borderRadius: 8,
+                barPercentage: 0.6,
+                borderWidth: 0,
+                hoverBackgroundColor: '#8800FF', // vivid-violet
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: { display: false },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.95)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            borderColor: 'rgba(0, 255, 102, 0.2)',
+            borderWidth: 1,
+            padding: 10,
+            cornerRadius: 12,
+            displayColors: false,
+            callbacks: {
+                label: (context) => `${context.parsed.y} exercices`,
+            },
+        },
+    },
+    scales: {
+        x: {
+            grid: { display: false },
+            ticks: {
+                color: '#94a3b8',
+                font: { size: 10, weight: 'bold', family: 'sans-serif' },
+            },
+            border: { display: false },
+        },
+        y: {
+            display: false,
+            beginAtZero: true,
+            ticks: {
+                stepSize: 1,
+            },
+        },
+    },
+}
+</script>
+
+<template>
+    <div class="h-48 w-full">
+        <Bar :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -13,6 +13,9 @@ const RecentWorkoutsChart = defineAsyncComponent(() => import('@/Components/Stat
 const RecentWorkoutsDurationChart = defineAsyncComponent(
     () => import('@/Components/Stats/RecentWorkoutsDurationChart.vue'),
 )
+const RecentWorkoutsExercisesChart = defineAsyncComponent(
+    () => import('@/Components/Stats/RecentWorkoutsExercisesChart.vue'),
+)
 
 /**
  * Dashboard - Command Center
@@ -340,6 +343,30 @@ const colorForWorkout = (index) => {
                     />
                     <div v-else class="text-text-muted flex h-full items-center justify-center">
                         <p class="text-sm">Pas assez de données de durée</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Recent Workouts Exercises Chart -->
+            <section
+                class="glass-panel-light animate-slide-up relative overflow-hidden rounded-3xl p-6"
+                style="animation-delay: 0.198s"
+            >
+                <div class="relative z-10 mb-6">
+                    <h3 class="text-neon-green mb-1 text-[10px] font-black tracking-[0.2em] uppercase">Diversité</h3>
+                    <p class="font-display text-text-main text-2xl font-black uppercase italic dark:text-white">
+                        Exercices Récents
+                    </p>
+                </div>
+
+                <!-- Recent Workouts Exercises Bar Chart -->
+                <div class="relative -mx-2 mt-2 h-48 w-auto">
+                    <RecentWorkoutsExercisesChart
+                        v-if="recentWorkouts && recentWorkouts.length > 0"
+                        :data="recentWorkouts"
+                    />
+                    <div v-else class="text-text-muted flex h-full items-center justify-center">
+                        <p class="text-sm">Pas assez de données d'exercices</p>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
This PR adds a new data visualization chart to the Dashboard to provide insight into recent workout diversity.

### 💡 What
A new Bar Chart (`RecentWorkoutsExercisesChart.vue`) that plots the number of exercises (workout lines) for the most recent workouts. 

### 🎯 Why
The `recentWorkouts` dataset is already fetched with `workout_lines_count`. The Dashboard previously displayed charts for Recent Workouts Volume and Duration, but not the number of exercises, which is useful for tracking workout intensity and variety.

### 📸 Visuals
The chart utilizes the "Liquid Glass" aesthetic matching the rest of the application, featuring a cyan-to-neon-green gradient and rounded bars without grid lines. It is housed in a `glass-panel-light` section on the Dashboard.

### 🧪 Verification
- Verified visually via Playwright screenshot (`frontend_verification_complete`).
- Verified build succeeds without errors.
- Verified all Pest tests pass successfully.

---
*PR created automatically by Jules for task [14410276315958522642](https://jules.google.com/task/14410276315958522642) started by @kuasar-mknd*