### PR TITLE
🛡️ Sentinel: [HIGH] Fix Broken Function Level Authorization in Controllers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,13 @@
 **Vulnerability:** Found `WorkoutController@store` (and potentially others like `PlateController`) missing an explicit `$this->authorize('create', ...)` call. These controllers relied on `FormRequest::authorize()` which returned `true`, effectively bypassing the `create` ability in their respective Policies.
 **Learning:** Relying solely on the `authorize` method of a `FormRequest` is dangerous if it doesn't actually check the policy. It creates a gap where resource creation is not governed by the central Policy logic, which might include important business rules or permission checks beyond simple ownership.
 **Prevention:** Always include an explicit `$this->authorize('create', Model::class)` call in controller `store` methods. Ensure Policies are the single source of truth for authorization logic.
+
+## 2026-03-23 - Broken Function Level Authorization in Resource Controllers (Continued)
+**Vulnerability:** Found  (both web and API) and  missing explicit `$this->authorize('create', ...)` calls. These controllers relied on `FormRequest::authorize()` which returned `true`, bypassing the `create` ability in their respective Policies.
+**Learning:** This is a recurring issue. Relying solely on the `authorize` method of a `FormRequest` is a consistent vulnerability pattern in this codebase.
+**Prevention:** We must always include an explicit `$this->authorize('create', Model::class)` call in controller `store` methods, even if a FormRequest is used.
+
+## 2026-03-23 - Broken Function Level Authorization in Resource Controllers (Continued)
+**Vulnerability:** Found `PlateController@store` (both web and API) and `WorkoutTemplatesController@store` missing explicit `$this->authorize('create', ...)` calls. These controllers relied on `FormRequest::authorize()` which returned `true`, bypassing the `create` ability in their respective Policies.
+**Learning:** This is a recurring issue. Relying solely on the `authorize` method of a `FormRequest` is a consistent vulnerability pattern in this codebase.
+**Prevention:** We must always include an explicit `$this->authorize('create', Model::class)` call in controller `store` methods, even if a FormRequest is used.

--- a/app/Http/Controllers/Api/PlateController.php
+++ b/app/Http/Controllers/Api/PlateController.php
@@ -37,6 +37,8 @@ class PlateController extends Controller
      */
     public function store(StorePlateRequest $request): PlateResource
     {
+        $this->authorize('create', Plate::class);
+
         $validated = $request->validated();
 
         $plate = new Plate($validated);

--- a/app/Http/Controllers/PlateController.php
+++ b/app/Http/Controllers/PlateController.php
@@ -44,6 +44,8 @@ class PlateController extends Controller
      */
     public function store(\App\Http\Requests\StorePlateRequest $request): \Illuminate\Http\RedirectResponse
     {
+        $this->authorize('create', Plate::class);
+
         $validated = $request->validated();
 
         $plate = new Plate($validated);

--- a/app/Http/Controllers/WorkoutTemplatesController.php
+++ b/app/Http/Controllers/WorkoutTemplatesController.php
@@ -74,6 +74,8 @@ class WorkoutTemplatesController extends Controller
      */
     public function store(\App\Http\Requests\StoreWorkoutTemplateRequest $request, CreateWorkoutTemplateAction $createWorkoutTemplateAction): \Illuminate\Http\RedirectResponse
     {
+        $this->authorize('create', WorkoutTemplate::class);
+
         /** @var array{name: string, description?: string|null, exercises?: array<int, array{id: int, sets?: array<int, array{reps?: int|null, weight?: float|null, is_warmup?: bool}>}>} $validated */
         $validated = $request->validated();
         $createWorkoutTemplateAction->execute($this->user(), $validated);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing authorization checks in controller `store` methods (PlateController web/API, WorkoutTemplatesController).
🎯 Impact: Unauthorized users could potentially bypass FormRequest authorization and create resources they shouldn't.
🔧 Fix: Added explicit `$this->authorize('create', Model::class)` checks inside the `store` methods to govern creation via Policies.
✅ Verification: Ran `./vendor/bin/pest` test suite which passed. Reviewed changes locally.

---
*PR created automatically by Jules for task [18050738771492681970](https://jules.google.com/task/18050738771492681970) started by @kuasar-mknd*