### PR TITLE
refactor: Extract logic from GoalController

### DIFF
--- a/app/Actions/Goals/FetchGoalsIndexAction.php
+++ b/app/Actions/Goals/FetchGoalsIndexAction.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Goals;
+
+use App\Models\Exercise;
+use App\Models\User;
+
+class FetchGoalsIndexAction
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function execute(User $user): array
+    {
+        return [
+            'goals' => $user->goals()
+                ->with('exercise')
+                ->latest()
+                ->get()
+                ->append(['progress', 'unit']),
+            'exercises' => Exercise::getCachedForUser($user->id),
+            'measurementTypes' => [
+                ['value' => 'weight', 'label' => 'Poids de corps'],
+                ['value' => 'waist', 'label' => 'Tour de taille'],
+                ['value' => 'body_fat', 'label' => 'Masse grasse (%)'],
+                ['value' => 'chest', 'label' => 'Tour de poitrine'],
+                ['value' => 'arms', 'label' => 'Tour de bras'],
+            ],
+        ];
+    }
+}

--- a/app/Http/Controllers/GoalController.php
+++ b/app/Http/Controllers/GoalController.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Actions\Goals\CreateGoalAction;
+use App\Actions\Goals\FetchGoalsIndexAction;
 use App\Http\Requests\GoalStoreRequest;
-use App\Models\Exercise;
 use App\Models\Goal;
 use App\Services\GoalService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -41,23 +41,9 @@ class GoalController extends Controller
      *
      * @return \Inertia\Response The Inertia response rendering the 'Goals/Index' page.
      */
-    public function index(): \Inertia\Response
+    public function index(FetchGoalsIndexAction $fetchGoalsIndexAction): \Inertia\Response
     {
-        return Inertia::render('Goals/Index', [
-            'goals' => $this->user()->goals()
-                ->with('exercise')
-                ->latest()
-                ->get()
-                ->append(['progress', 'unit']),
-            'exercises' => Exercise::getCachedForUser($this->user()->id),
-            'measurementTypes' => [
-                ['value' => 'weight', 'label' => 'Poids de corps'],
-                ['value' => 'waist', 'label' => 'Tour de taille'],
-                ['value' => 'body_fat', 'label' => 'Masse grasse (%)'],
-                ['value' => 'chest', 'label' => 'Tour de poitrine'],
-                ['value' => 'arms', 'label' => 'Tour de bras'],
-            ],
-        ]);
+        return Inertia::render('Goals/Index', $fetchGoalsIndexAction->execute($this->user()));
     }
 
     /**


### PR DESCRIPTION
Extracts the business logic out of the `index` method in `GoalController` to a dedicated `FetchGoalsIndexAction` class to improve readability and adhere to SOLID principles. The controller has been simplified to simply call this Action, and the file has been properly formatted.

---
*PR created automatically by Jules for task [7983271190475381668](https://jules.google.com/task/7983271190475381668) started by @kuasar-mknd*