### PR TITLE
🧹 Remove non-professional test data

### DIFF
--- a/tests/Feature/Api/ExerciseControllerTest.php
+++ b/tests/Feature/Api/ExerciseControllerTest.php
@@ -142,7 +142,7 @@ test('authenticated user cannot update system exercise', function (): void {
 
     actingAs($user)
         ->putJson(route('api.v1.exercises.update', $systemExercise), [
-            'name' => 'Hacked Name',
+            'name' => 'Updated Name',
             'type' => 'cardio',
         ])
         ->assertForbidden();
@@ -154,7 +154,7 @@ test('authenticated user cannot update other user exercise', function (): void {
 
     actingAs($user)
         ->putJson(route('api.v1.exercises.update', $otherUserExercise), [
-            'name' => 'Hacked Name',
+            'name' => 'Updated Name',
             'type' => 'cardio',
         ])
         ->assertForbidden();

--- a/tests/Feature/Api/IntervalTimerControllerTest.php
+++ b/tests/Feature/Api/IntervalTimerControllerTest.php
@@ -120,7 +120,7 @@ test('user cannot update another users interval timer', function (): void {
     $timer = IntervalTimer::factory()->create(['user_id' => $otherUser->id]);
 
     $data = [
-        'name' => 'Hacked Timer',
+        'name' => 'Updated Timer',
         'work_seconds' => 30,
         'rest_seconds' => 15,
         'rounds' => 10,

--- a/tests/Feature/Api/V1/AchievementControllerTest.php
+++ b/tests/Feature/Api/V1/AchievementControllerTest.php
@@ -184,14 +184,14 @@ describe('PUT /api/v1/achievements/{achievement}', function (): void {
 
         $response = actingAs($this->user)
             ->putJson("/api/v1/achievements/{$achievement->id}", [
-                'name' => 'Hacked Name',
+                'name' => 'Updated Name',
             ]);
 
         $response->assertForbidden();
 
         assertDatabaseMissing('achievements', [
             'id' => $achievement->id,
-            'name' => 'Hacked Name',
+            'name' => 'Updated Name',
         ]);
     });
 

--- a/tests/Feature/Api/V1/GoalSecurityTest.php
+++ b/tests/Feature/Api/V1/GoalSecurityTest.php
@@ -19,7 +19,7 @@ describe('Goal Security', function (): void {
         $privateExercise = Exercise::factory()->create(['user_id' => $otherUser->id]);
 
         $data = [
-            'title' => 'Hacked Goal',
+            'title' => 'Updated Goal',
             'type' => 'weight',
             'target_value' => 100,
             'exercise_id' => $privateExercise->id,
@@ -41,7 +41,7 @@ describe('Goal Security', function (): void {
         $privateExercise = Exercise::factory()->create(['user_id' => $otherUser->id]);
 
         $data = [
-            'title' => 'Hacked Goal 2',
+            'title' => 'Updated Goal 2',
             'type' => 'weight',
             'target_value' => 100,
             'exercise_id' => $privateExercise->id,

--- a/tests/Feature/Api/V1/GoalTest.php
+++ b/tests/Feature/Api/V1/GoalTest.php
@@ -197,7 +197,7 @@ describe('Authenticated', function (): void {
             $otherUser = User::factory()->create();
             $goal = Goal::factory()->create(['user_id' => $otherUser->id]);
 
-            putJson(route('api.v1.goals.update', $goal), ['title' => 'Hacked'])
+            putJson(route('api.v1.goals.update', $goal), ['title' => 'Updated Goal Title'])
                 ->assertForbidden();
         });
 

--- a/tests/Feature/Api/V1/HabitLogControllerTest.php
+++ b/tests/Feature/Api/V1/HabitLogControllerTest.php
@@ -142,7 +142,7 @@ test('user cannot update another users habit log', function (): void {
     $log = HabitLog::factory()->create(['habit_id' => $habit->id]);
 
     actingAs($user)
-        ->putJson(route('api.v1.habit-logs.update', $log), ['notes' => 'Hacked'])
+        ->putJson(route('api.v1.habit-logs.update', $log), ['notes' => 'Updated Habit Log Notes'])
         ->assertForbidden();
 });
 

--- a/tests/Feature/Api/V1/HabitLogTest.php
+++ b/tests/Feature/Api/V1/HabitLogTest.php
@@ -205,7 +205,7 @@ test('user cannot update other user habit log', function (): void {
 
     actingAs($user, 'sanctum')
         ->putJson(route('api.v1.habit-logs.update', $log), [
-            'notes' => 'Hacked',
+            'notes' => 'Updated Habit Log Notes',
         ])
         ->assertForbidden();
 });

--- a/tests/Feature/Api/V1/IntervalTimerTest.php
+++ b/tests/Feature/Api/V1/IntervalTimerTest.php
@@ -112,7 +112,7 @@ describe('Authenticated', function (): void {
             $timer = IntervalTimer::factory()->create(['user_id' => $otherUser->id]);
 
             putJson(route('api.v1.interval-timers.update', $timer), [
-                'name' => 'Hacked',
+                'name' => 'Updated Timer Name',
                 'work_seconds' => 30,
                 'rest_seconds' => 30,
                 'rounds' => 3,

--- a/tests/Feature/Api/V1/SupplementTest.php
+++ b/tests/Feature/Api/V1/SupplementTest.php
@@ -112,7 +112,7 @@ test('users cannot update others supplements', function (): void {
 
     actingAs($user)
         ->putJson(route('api.v1.supplements.update', $supplement), [
-            'name' => 'Hacked',
+            'name' => 'Updated Supplement Name',
             'servings_remaining' => 10,
             'low_stock_threshold' => 5,
         ])

--- a/tests/Feature/Api/V1/UserControllerTest.php
+++ b/tests/Feature/Api/V1/UserControllerTest.php
@@ -185,7 +185,7 @@ describe('Authenticated', function (): void {
 
             $userToUpdate = User::factory()->create();
 
-            putJson(route('api.v1.users.update', $userToUpdate), ['name' => 'Hacked Name'])
+            putJson(route('api.v1.users.update', $userToUpdate), ['name' => 'Updated Name'])
                 ->assertForbidden();
         });
 

--- a/tests/Feature/Api/V1/WorkoutLineControllerTest.php
+++ b/tests/Feature/Api/V1/WorkoutLineControllerTest.php
@@ -228,7 +228,7 @@ test('it cannot update another user\'s workout line', function (): void {
     ]);
 
     $response = putJson("/api/v1/workout-lines/{$workoutLine->id}", [
-        'notes' => 'Hacked notes',
+        'notes' => 'Updated Notes',
     ]);
 
     $response->assertForbidden();

--- a/tests/Feature/Api/V1/WorkoutTemplateControllerTest.php
+++ b/tests/Feature/Api/V1/WorkoutTemplateControllerTest.php
@@ -168,7 +168,7 @@ test('update returns 403 for other user workout template', function (): void {
     $template = WorkoutTemplate::factory()->create(['user_id' => $otherUser->id]);
     Sanctum::actingAs($user);
 
-    $response = $this->putJson(route('api.v1.workout-templates.update', $template), ['name' => 'Hacked']);
+    $response = $this->putJson(route('api.v1.workout-templates.update', $template), ['name' => 'Updated Template Name']);
 
     $response->assertForbidden();
 });

--- a/tests/Feature/Api/V1/WorkoutTemplateTest.php
+++ b/tests/Feature/Api/V1/WorkoutTemplateTest.php
@@ -158,7 +158,7 @@ test('user cannot update other users workout template', function (): void {
     $otherUser = User::factory()->create();
     $template = WorkoutTemplate::factory()->create(['user_id' => $otherUser->id]);
 
-    $this->putJson(route('api.v1.workout-templates.update', $template), ['name' => 'Hacked'])
+    $this->putJson(route('api.v1.workout-templates.update', $template), ['name' => 'Updated Template Name'])
         ->assertForbidden();
 });
 

--- a/tests/Feature/Api/WorkoutControllerTest.php
+++ b/tests/Feature/Api/WorkoutControllerTest.php
@@ -146,7 +146,7 @@ test('update returns 403 for other user workout', function (): void {
     $workout = Workout::factory()->create(['user_id' => $otherUser->id]);
     Sanctum::actingAs($user);
 
-    $response = $this->putJson(route('api.v1.workouts.update', $workout), ['name' => 'Hacked']);
+    $response = $this->putJson(route('api.v1.workouts.update', $workout), ['name' => 'Updated Workout Name']);
 
     $response->assertForbidden();
 });

--- a/tests/Feature/Api/WorkoutTemplateControllerTest.php
+++ b/tests/Feature/Api/WorkoutTemplateControllerTest.php
@@ -99,7 +99,7 @@ test('user cannot update other user workout template', function (): void {
     $template = WorkoutTemplate::factory()->create(['user_id' => $otherUser->id]);
 
     $data = [
-        'name' => 'Hacked Name',
+        'name' => 'Updated Name',
     ];
 
     actingAs($user)

--- a/tests/Feature/Controllers/GoalControllerTest.php
+++ b/tests/Feature/Controllers/GoalControllerTest.php
@@ -219,7 +219,7 @@ test('user cannot update another users goal', function (): void {
 
     actingAs($user)
         ->patch(route('goals.update', $goal), [
-            'title' => 'Hacked',
+            'title' => 'Updated Goal Title',
             'type' => 'weight',
             'target_value' => 100,
             'exercise_id' => $exercise->id,

--- a/tests/Feature/ExerciseControllerTest.php
+++ b/tests/Feature/ExerciseControllerTest.php
@@ -118,7 +118,7 @@ test('user cannot update an exercise owned by another user', function (): void {
 
     actingAs($user)
         ->put(route('exercises.update', $exercise), [
-            'name' => 'Hacked Name',
+            'name' => 'Updated Name',
             'type' => 'strength',
             'category' => 'Dos',
         ])

--- a/tests/Feature/IntervalTimerTest.php
+++ b/tests/Feature/IntervalTimerTest.php
@@ -92,7 +92,7 @@ test('user cannot update others timer', function (): void {
     ]);
 
     $response = $this->actingAs($user2)->patch(route('tools.interval-timer.update', $timer), [
-        'name' => 'Hacked Timer',
+        'name' => 'Updated Timer',
         'work_seconds' => 40,
         'rest_seconds' => 20,
         'rounds' => 4,

--- a/tests/Feature/Models/ExerciseTest.php
+++ b/tests/Feature/Models/ExerciseTest.php
@@ -102,7 +102,7 @@ class ExerciseTest extends TestCase
         ]);
 
         $response = $this->actingAs($user)->put("/exercises/{$exercise->id}", [
-            'name' => 'Hacked Name',
+            'name' => 'Updated Name',
             'type' => 'strength',
         ]);
 

--- a/tests/Feature/Models/HabitTest.php
+++ b/tests/Feature/Models/HabitTest.php
@@ -100,7 +100,7 @@ test('user cannot update other users habits', function (): void {
 
     $this->actingAs($user)
         ->put(route('habits.update', $habit), [
-            'name' => 'Hacked',
+            'name' => 'Updated Habit Name',
             'goal_times_per_week' => 5,
         ])
         ->assertForbidden();

--- a/tests/Feature/SupplementControllerTest.php
+++ b/tests/Feature/SupplementControllerTest.php
@@ -119,7 +119,7 @@ test('user cannot update another users supplement', function (): void {
 
     actingAs($user2)
         ->patch(route('supplements.update', $supplement), [
-            'name' => 'Hacked Name',
+            'name' => 'Updated Name',
             'servings_remaining' => 10,
             'low_stock_threshold' => 5,
         ])
@@ -127,7 +127,7 @@ test('user cannot update another users supplement', function (): void {
 
     $this->assertDatabaseMissing('supplements', [
         'id' => $supplement->id,
-        'name' => 'Hacked Name',
+        'name' => 'Updated Name',
     ]);
 });
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the non-professional test string "Hacked" and variations with more professional placeholder values like "Updated Name", "Updated Timer", "Updated Goal", etc., across the entire test suite.

💡 **Why:** How this improves maintainability
Ensures the test suite uses clean and descriptive mock data, which aligns with standard coding conventions and makes test failure logs easier to read and comprehend.

✅ **Verification:** How you confirmed the change is safe
Ran the `pest` test suite locally to verify tests still execute. Ran `pint --test` and `phpstan analyse` to verify code format and static analysis remain passing. Double checked `git diff --cached` to ensure all updates only target test string assertions and request payloads without modifying business logic.

✨ **Result:** The improvement achieved
A cleaner and more professionally written test suite without arbitrary, distractive mock data strings.

---
*PR created automatically by Jules for task [5769706740691337579](https://jules.google.com/task/5769706740691337579) started by @kuasar-mknd*