### PR TITLE
🧹 Remove non-professional test data in HabitTest

### DIFF
--- a/tests/Feature/Models/HabitTest.php
+++ b/tests/Feature/Models/HabitTest.php
@@ -100,7 +100,7 @@ test('user cannot update other users habits', function (): void {
 
     $this->actingAs($user)
         ->put(route('habits.update', $habit), [
-            'name' => 'Hacked',
+            'name' => 'Updated Name',
             'goal_times_per_week' => 5,
         ])
         ->assertForbidden();


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the non-professional string `'Hacked'` with `'Updated Name'` in `tests/Feature/Models/HabitTest.php`.

💡 **Why:** How this improves maintainability
Replacing test strings with more standard mock values (like `'Updated Name'`) makes the tests look more professional and maintains a consistent style, especially since other tests in the file use standard names. It improves readability and maintainability.

✅ **Verification:** How you confirmed the change is safe
Ran format and lint checks (`pint`, `phpstan`). Verified that the specific test (`user cannot update other users habits`) and the full suite behaviour remained unchanged. The test is asserting `assertForbidden()`, so the actual payload values do not affect the assertion outcome, making this change completely safe.

✨ **Result:** The improvement achieved
A cleaner, more professional test suite with no functional regressions.

---
*PR created automatically by Jules for task [7955828672020965577](https://jules.google.com/task/7955828672020965577) started by @kuasar-mknd*