### PR TITLE
feat(viz): Add History Chart for Exercise 1RM

### DIFF
--- a/resources/js/Components/Stats/HistoryChart.vue
+++ b/resources/js/Components/Stats/HistoryChart.vue
@@ -1,0 +1,118 @@
+<script setup>
+import { Line } from 'vue-chartjs'
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend,
+    Filler,
+} from 'chart.js'
+import { computed } from 'vue'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
+
+const props = defineProps({
+    data: {
+        type: Array,
+        required: true,
+    },
+})
+
+const chartData = computed(() => {
+    // Expecting history array to have formatted_date and best_1rm
+    // The history array is typically sorted descending (newest first).
+    // Let's reverse it so time flows left to right.
+    const reversedData = [...props.data].reverse()
+
+    const labels = reversedData.map((d) => d.formatted_date)
+    const values = reversedData.map((d) => Math.round(d.best_1rm))
+
+    return {
+        labels,
+        datasets: [
+            {
+                label: 'Meilleur 1RM (kg)',
+                data: values,
+                borderColor: '#FF0080', // hot-pink
+                backgroundColor: (context) => {
+                    const chart = context.chart
+                    const { ctx, chartArea } = chart
+                    if (!chartArea) return null
+
+                    const gradient = ctx.createLinearGradient(0, chartArea.bottom, 0, chartArea.top)
+                    gradient.addColorStop(0, 'rgba(255, 0, 128, 0.05)')
+                    gradient.addColorStop(1, 'rgba(255, 0, 128, 0.4)')
+
+                    return gradient
+                },
+                borderWidth: 3,
+                pointBackgroundColor: '#fff',
+                pointBorderColor: '#FF0080',
+                pointBorderWidth: 2,
+                pointRadius: 4,
+                pointHoverRadius: 6,
+                fill: true,
+                tension: 0.4, // Smooth curve
+            },
+        ],
+    }
+})
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: { display: false },
+        tooltip: {
+            backgroundColor: 'rgba(255, 255, 255, 0.95)',
+            titleColor: '#1e293b',
+            bodyColor: '#1e293b',
+            borderColor: 'rgba(255, 0, 128, 0.2)',
+            borderWidth: 1,
+            padding: 10,
+            cornerRadius: 12,
+            displayColors: false,
+            callbacks: {
+                label: (context) => `${context.parsed.y} kg`,
+            },
+        },
+    },
+    scales: {
+        x: {
+            grid: { display: false },
+            ticks: {
+                color: '#94a3b8',
+                font: { size: 10, weight: 'bold', family: 'sans-serif' },
+            },
+            border: { display: false },
+        },
+        y: {
+            display: false,
+            beginAtZero: false,
+            // Add some padding to top and bottom to make the chart look better
+            suggestedMin: (context) => {
+                const values = context.chart.data.datasets[0].data
+                return Math.min(...values) * 0.9
+            },
+            suggestedMax: (context) => {
+                const values = context.chart.data.datasets[0].data
+                return Math.max(...values) * 1.1
+            },
+        },
+    },
+    interaction: {
+        intersect: false,
+        mode: 'index',
+    },
+}
+</script>
+
+<template>
+    <div class="h-full w-full">
+        <Line :data="chartData" :options="chartOptions" />
+    </div>
+</template>

--- a/resources/js/Pages/Exercises/Show.vue
+++ b/resources/js/Pages/Exercises/Show.vue
@@ -17,6 +17,7 @@ const SetWeightProgressionChart = defineAsyncComponent(() => import('@/Component
 const Estimated1RMHistoryChart = defineAsyncComponent(() => import('@/Components/Stats/Estimated1RMHistoryChart.vue'))
 const SessionPerformanceChart = defineAsyncComponent(() => import('@/Components/Stats/SessionPerformanceChart.vue'))
 const SessionVolumeLineChart = defineAsyncComponent(() => import('@/Components/Stats/SessionVolumeLineChart.vue'))
+const HistoryChart = defineAsyncComponent(() => import('@/Components/Stats/HistoryChart.vue'))
 
 /**
  * Component Props
@@ -346,63 +347,23 @@ const scatterData = computed(() => {
                 </GlassCard>
             </div>
 
-            <!-- History List -->
+            <!-- History Chart -->
             <div class="animate-slide-up" style="animation-delay: 0.2s">
-                <h3 class="font-display text-text-main mb-4 text-lg font-black uppercase italic">Historique</h3>
-
-                <div v-if="history.length === 0" class="py-8 text-center">
-                    <p class="text-text-muted">Aucune donnée historique trouvée.</p>
-                </div>
-
-                <div v-else class="space-y-4">
-                    <GlassCard v-for="session in history" :key="session.id" padding="p-0" class="overflow-hidden">
-                        <!-- Header -->
-                        <div class="flex items-center justify-between border-b border-slate-100 bg-slate-50/50 p-3">
-                            <div class="text-text-main font-bold">
-                                {{ session.formatted_date }}
-                            </div>
-                            <Link
-                                :href="route('workouts.show', { workout: session.workout_id })"
-                                class="text-electric-orange text-xs font-bold tracking-wider uppercase hover:underline"
-                            >
-                                {{ session.workout_name }}
-                            </Link>
-                        </div>
-
-                        <!-- Sets -->
-                        <div class="space-y-2 p-3">
-                            <div
-                                v-for="(set, index) in session.sets"
-                                :key="index"
-                                class="flex items-center justify-between text-sm"
-                            >
-                                <div class="flex items-center gap-3">
-                                    <span class="text-text-muted w-4 font-mono text-xs">{{ index + 1 }}</span>
-                                    <span class="text-text-main font-bold"
-                                        >{{ set.weight }}
-                                        <span class="text-text-muted text-xs font-normal">kg</span></span
-                                    >
-                                    <span class="text-text-muted">x</span>
-                                    <span class="text-text-main font-bold"
-                                        >{{ set.reps }}
-                                        <span class="text-text-muted text-xs font-normal">reps</span></span
-                                    >
-                                </div>
-                                <div class="text-text-muted text-xs font-semibold">
-                                    1RM: {{ Math.round(set['1rm']) }}
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Footer Best 1RM -->
-                        <div
-                            class="text-text-muted border-t border-slate-100 bg-slate-50/30 p-2 text-center text-xs font-medium"
-                        >
-                            Meilleur 1RM estimé:
-                            <span class="text-text-main font-bold">{{ Math.round(session.best_1rm) }} kg</span>
-                        </div>
-                    </GlassCard>
-                </div>
+                <GlassCard class="rounded-3xl border border-white/20 bg-white/10 backdrop-blur-md">
+                    <div class="mb-4">
+                        <h3 class="font-display text-text-main text-lg font-black uppercase italic">
+                            Historique du 1RM
+                        </h3>
+                        <p class="text-text-muted text-xs font-semibold">Évolution du meilleur 1RM estimé</p>
+                    </div>
+                    <div v-if="history.length > 0" class="h-64">
+                        <HistoryChart :data="history" />
+                    </div>
+                    <div v-else class="flex h-64 flex-col items-center justify-center text-center">
+                        <span class="material-symbols-outlined text-text-muted/30 mb-2 text-5xl">show_chart</span>
+                        <p class="text-text-muted text-sm">Pas assez de données pour afficher le graphique</p>
+                    </div>
+                </GlassCard>
             </div>
         </div>
     </AuthenticatedLayout>


### PR DESCRIPTION
This PR enhances the Data Visualization on the Exercise details page. It replaces the plain, text-based session history list with a dynamic line chart (`HistoryChart.vue`) that tracks the progression of the user's estimated 1RM over time for a given exercise.

### Changes
*   **Added:** `HistoryChart.vue` in `resources/js/Components/Stats/` using `vue-chartjs` (Line chart, Liquid Glass styling).
*   **Updated:** `Show.vue` in `resources/js/Pages/Exercises/` to render `<HistoryChart>` instead of the previous list of `history` items.

---
*PR created automatically by Jules for task [5158668162701926045](https://jules.google.com/task/5158668162701926045) started by @kuasar-mknd*