### PR TITLE
refactor: Extract logic from WorkoutTemplateController

### DIFF
--- a/app/Actions/FetchWorkoutTemplatesAction.php
+++ b/app/Actions/FetchWorkoutTemplatesAction.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\User;
+use App\Models\WorkoutTemplate;
+use Illuminate\Database\Eloquent\Collection;
+
+class FetchWorkoutTemplatesAction
+{
+    /**
+     * Fetch all workout templates for the given user, with necessary relations for the index page preview.
+     *
+     * @return Collection<int, WorkoutTemplate>
+     */
+    public function execute(User $user): Collection
+    {
+        // ⚡ Bolt Optimization: Only load the line counts and the first few exercises for preview
+        return WorkoutTemplate::withCount('workoutTemplateLines')
+            ->with([
+                'workoutTemplateLines' => function ($query): void {
+                    $query->select('id', 'workout_template_id', 'exercise_id')
+                        ->orderBy('order')
+                        ->limit(3)
+                        ->withCount('workoutTemplateSets')
+                        ->with('exercise:id,name');
+                },
+            ])
+            ->where('user_id', $user->id)
+            ->latest()
+            ->get();
+    }
+}

--- a/app/Http/Controllers/WorkoutTemplateController.php
+++ b/app/Http/Controllers/WorkoutTemplateController.php
@@ -29,25 +29,12 @@ class WorkoutTemplateController extends Controller
      *
      * @return \Inertia\Response The Inertia response rendering the Templates index page.
      */
-    public function index(): \Inertia\Response
+    public function index(\App\Actions\FetchWorkoutTemplatesAction $fetchWorkoutTemplatesAction): \Inertia\Response
     {
         $this->authorize('viewAny', WorkoutTemplate::class);
 
-        // ⚡ Bolt Optimization: Only load the line counts and the first few exercises for preview
         return Inertia::render('Workouts/Templates/Index', [
-            'templates' => WorkoutTemplate::withCount('workoutTemplateLines')
-                ->with([
-                    'workoutTemplateLines' => function ($query): void {
-                        $query->select('id', 'workout_template_id', 'exercise_id')
-                            ->orderBy('order')
-                            ->limit(3)
-                            ->withCount('workoutTemplateSets')
-                            ->with('exercise:id,name');
-                    },
-                ])
-                ->where('user_id', $this->user()->id)
-                ->latest()
-                ->get(),
+            'templates' => $fetchWorkoutTemplatesAction->execute($this->user()),
         ]);
     }
 


### PR DESCRIPTION
- Extracted logic from `WorkoutTemplateController::index` into `FetchWorkoutTemplatesAction`
- Used dependency injection in the controller.
- Formatted with PSR-12
- Ensured tests pass
- Removed unused imports if any

---
*PR created automatically by Jules for task [1992396241737026643](https://jules.google.com/task/1992396241737026643) started by @kuasar-mknd*