### PR TITLE
🧹 Remove stale comment from FetchDashboardDataAction

### DIFF
--- a/app/Actions/Dashboard/FetchDashboardDataAction.php
+++ b/app/Actions/Dashboard/FetchDashboardDataAction.php
@@ -45,7 +45,6 @@ final class FetchDashboardDataAction
         $latestMetrics = $this->statsService->getLatestBodyMetrics($user);
 
         return [
-            // ⚡ Bolt: Removed unused workoutsCount and thisWeekCount queries to prevent 2 unnecessary queries on dashboard load
             'latestWeight' => $latestMetrics->latest_weight ?? null,
             'activeWorkout' => $this->getActiveWorkout($user),
             'recentWorkouts' => $this->getRecentWorkouts($user),


### PR DESCRIPTION
🎯 **What:** Removed a stale comment referring to unused `workoutsCount` and `thisWeekCount` queries in `FetchDashboardDataAction::getImmediateStats()`.
💡 **Why:** The comment referenced code that no longer exists in the array return structure. Removing it prevents confusion for future developers reading the `getImmediateStats` method and improves code readability.
✅ **Verification:**
- Verified the code visually to ensure only the single-line comment was removed and no functional code was altered.
- Ran `php -l app/Actions/Dashboard/FetchDashboardDataAction.php` to ensure syntax remains correct.
✨ **Result:** A cleaner, more accurate codebase without confusing leftover comments.

---
*PR created automatically by Jules for task [9481343088748822109](https://jules.google.com/task/9481343088748822109) started by @kuasar-mknd*