### PR TITLE
⚡ Bolt: Bulk insert workout template lines to prevent N+1 query

### DIFF
--- a/app/Actions/CreateWorkoutTemplateAction.php
+++ b/app/Actions/CreateWorkoutTemplateAction.php
@@ -50,17 +50,34 @@ final class CreateWorkoutTemplateAction
     /** @param array<int, array{id: int, sets?: array<int, array{reps?: int|null, weight?: float|null, is_warmup?: bool}>}> $exercises */
     private function addExercises(WorkoutTemplate $template, array $exercises): void
     {
+        if ($exercises === []) {
+            return;
+        }
+
+        $linesData = [];
         $setsData = [];
         $now = now()->toDateTimeString();
 
         foreach ($exercises as $index => $ex) {
-            $line = $template->workoutTemplateLines()->create([
+            $linesData[] = [
+                'workout_template_id' => $template->id,
                 'exercise_id' => $ex['id'],
                 'order' => $index,
-            ]);
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
 
+        \App\Models\WorkoutTemplateLine::insert($linesData);
+
+        $lines = $template->workoutTemplateLines()->get()->keyBy('order');
+
+        foreach ($exercises as $index => $ex) {
             if (isset($ex['sets'])) {
-                $this->appendSetsData($setsData, $ex['sets'], $line->id, $now);
+                $line = $lines->get($index);
+                if ($line) {
+                    $this->appendSetsData($setsData, $ex['sets'], $line->id, $now);
+                }
             }
         }
 


### PR DESCRIPTION
💡 **What:** 
Refactored `CreateWorkoutTemplateAction` to replace the individual `create()` calls inside the `$exercises` foreach loop with a single bulk `insert()` operation. 

🎯 **Why:** 
Previously, creating a workout template with multiple exercises triggered an N+1 query issue for the template lines (one INSERT query per exercise). By aggregating the data into an array and inserting it all at once, we reduce database overhead. We retrieve the inserted IDs via a single `get()` query keyed by `order` to allow subsequent nested insertions of sets.

📊 **Measured Improvement:** 
While exact benchmarking within the restricted local Docker environment was limited due to image rate limits, moving from O(N) queries to O(1) bulk insert fundamentally scales better and avoids the `N+1` insert bottleneck as the number of exercises increases, ensuring much faster and resilient database execution within the wrapping transaction.

---
*PR created automatically by Jules for task [13479797754127712914](https://jules.google.com/task/13479797754127712914) started by @kuasar-mknd*