### PR TITLE
🧪 Add tests for useHaptics composable

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/vite": "^4.2.2",
         "@vitejs/plugin-vue": "^6.0.5",
+        "@vue/test-utils": "^2.4.6",
         "autoprefixer": "^10.4.27",
         "axios": "^1.14.0",
         "concurrently": "^9.0.1",
         "husky": "^9.1.7",
+        "jsdom": "^29.0.2",
         "laravel-vite-plugin": "^2.0.0",
         "lint-staged": "^16.3.2",
         "postcss": "^8.4.31",
@@ -32,11 +34,12 @@
         "tailwindcss": "^4.2.2",
         "vite": "^7.3.2",
         "vite-plugin-pwa": "^1.2.0",
-        "workbox-window": "^7.4.0",
+        "vitest": "^4.1.3",
         "vue": "^3.5.32",
         "workbox-precaching": "^7.4.0",
         "workbox-routing": "^7.4.0",
-        "workbox-strategies": "^7.4.0"
+        "workbox-strategies": "^7.4.0",
+        "workbox-window": "^7.4.0"
     },
     "dependencies": {
         "@sentry/vue": "^10.47.0",

--- a/resources/js/composables/__tests__/useHaptics.spec.js
+++ b/resources/js/composables/__tests__/useHaptics.spec.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import useHapticsModule, { isHapticsSupported, triggerHaptic, stopVibration, useHaptics } from '../useHaptics.js'
+
+describe('useHaptics', () => {
+    let originalNavigator
+
+    beforeEach(() => {
+        // Save the original navigator to restore it later if needed
+        originalNavigator = global.navigator
+
+        // Mock navigator with vibrate support for testing happy paths
+        const mockNavigator = {
+            vibrate: vi.fn().mockReturnValue(true),
+        }
+
+        // We use Object.defineProperty to override the getter in jsdom
+        Object.defineProperty(global, 'navigator', {
+            value: mockNavigator,
+            writable: true,
+            configurable: true,
+        })
+    })
+
+    describe('isHapticsSupported', () => {
+        it('should return true if navigator.vibrate exists', () => {
+            expect(isHapticsSupported()).toBe(true)
+        })
+
+        it('should return false if navigator is undefined', () => {
+            Object.defineProperty(global, 'navigator', {
+                value: undefined,
+                writable: true,
+                configurable: true,
+            })
+            expect(isHapticsSupported()).toBe(false)
+        })
+
+        it('should return false if vibrate is not in navigator', () => {
+            Object.defineProperty(global, 'navigator', {
+                value: {},
+                writable: true,
+                configurable: true,
+            })
+            expect(isHapticsSupported()).toBe(false)
+        })
+    })
+
+    describe('triggerHaptic', () => {
+        it('should return false and not call vibrate if not supported', () => {
+            Object.defineProperty(global, 'navigator', {
+                value: {},
+                writable: true,
+                configurable: true,
+            })
+
+            const result = triggerHaptic('tap')
+            expect(result).toBe(false)
+        })
+
+        it('should call navigator.vibrate with tap pattern by default', () => {
+            triggerHaptic()
+            expect(global.navigator.vibrate).toHaveBeenCalledWith([5])
+        })
+
+        it('should call navigator.vibrate with the requested pattern', () => {
+            triggerHaptic('success')
+            expect(global.navigator.vibrate).toHaveBeenCalledWith([50, 30, 50])
+        })
+
+        it('should fallback to tap pattern if requested pattern does not exist', () => {
+            triggerHaptic('unknown_pattern')
+            expect(global.navigator.vibrate).toHaveBeenCalledWith([5])
+        })
+
+        it('should return true if vibrate call is successful', () => {
+            const result = triggerHaptic('tap')
+            expect(result).toBe(true)
+        })
+
+        it('should return false and catch error if vibrate throws', () => {
+            global.navigator.vibrate.mockImplementation(() => {
+                throw new Error('Test error')
+            })
+
+            const result = triggerHaptic('tap')
+            expect(result).toBe(false)
+        })
+    })
+
+    describe('stopVibration', () => {
+        it('should call navigator.vibrate with 0', () => {
+            stopVibration()
+            expect(global.navigator.vibrate).toHaveBeenCalledWith(0)
+        })
+
+        it('should return false and not call vibrate if not supported', () => {
+            Object.defineProperty(global, 'navigator', {
+                value: {},
+                writable: true,
+                configurable: true,
+            })
+
+            const result = stopVibration()
+            expect(result).toBe(false)
+        })
+
+        it('should return true if vibrate(0) call is successful', () => {
+            const result = stopVibration()
+            expect(result).toBe(true)
+        })
+
+        it('should return false and catch error if vibrate throws', () => {
+            global.navigator.vibrate.mockImplementation(() => {
+                throw new Error('Test error')
+            })
+
+            const result = stopVibration()
+            expect(result).toBe(false)
+        })
+    })
+
+    describe('useHaptics composable', () => {
+        it('should return the expected interface', () => {
+            const haptics = useHaptics()
+            expect(haptics).toHaveProperty('isSupported')
+            expect(haptics).toHaveProperty('triggerHaptic')
+            expect(haptics).toHaveProperty('stopVibration')
+            expect(haptics).toHaveProperty('patterns')
+        })
+
+        it('should have correct initial values', () => {
+            const haptics = useHaptics()
+            expect(haptics.isSupported).toBe(true)
+            expect(haptics.triggerHaptic).toBe(triggerHaptic)
+            expect(haptics.stopVibration).toBe(stopVibration)
+        })
+    })
+
+    describe('default export', () => {
+        it('should expose the necessary methods and properties', () => {
+            expect(useHapticsModule).toHaveProperty('triggerHaptic')
+            expect(useHapticsModule).toHaveProperty('stopVibration')
+            expect(useHapticsModule).toHaveProperty('isHapticsSupported')
+            expect(useHapticsModule).toHaveProperty('patterns')
+        })
+    })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+})


### PR DESCRIPTION
🎯 **What:** 
Added missing test coverage for the `useHaptics` composable to ensure standardized vibration patterns and graceful fallbacks work as intended.

📊 **Coverage:** 
- `isHapticsSupported()` checking navigator and vibrate existence.
- `triggerHaptic()` evaluating proper method calls with respective patterns (tap, success, unknown, unsupported).
- `stopVibration()` correctly sending `0` to halt haptics.
- Error handling paths where `navigator.vibrate` throws.

✨ **Result:** 
Full test coverage implemented in `useHaptics.spec.js` using Vitest and JSdom mocks, preventing regressions in mobile interaction feedbacks.

---
*PR created automatically by Jules for task [9874497843281922354](https://jules.google.com/task/9874497843281922354) started by @kuasar-mknd*