### PR TITLE
🧪 Add Pest coverage for HabitPolicy

### DIFF
--- a/tests/Unit/Policies/HabitPolicyTest.php
+++ b/tests/Unit/Policies/HabitPolicyTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Habit;
+use App\Models\User;
+use App\Policies\HabitPolicy;
+
+beforeEach(function (): void {
+    $this->policy = new HabitPolicy();
+    $this->user = User::factory()->make(['id' => 1]);
+    $this->otherUser = User::factory()->make(['id' => 2]);
+    $this->habit = Habit::factory()->make([
+        'user_id' => $this->user->id,
+    ]);
+});
+
+describe('HabitPolicy', function (): void {
+    it('allows any user to view any', function (): void {
+        expect($this->policy->viewAny())->toBeTrue();
+    });
+
+    it('allows a user to view their own habit', function (): void {
+        expect($this->policy->view($this->user, $this->habit))->toBeTrue();
+    });
+
+    it('prevents a user from viewing another user\'s habit', function (): void {
+        expect($this->policy->view($this->otherUser, $this->habit))->toBeFalse();
+    });
+
+    it('allows any user to create', function (): void {
+        expect($this->policy->create())->toBeTrue();
+    });
+
+    it('allows a user to update their own habit', function (): void {
+        expect($this->policy->update($this->user, $this->habit))->toBeTrue();
+    });
+
+    it('prevents a user from updating another user\'s habit', function (): void {
+        expect($this->policy->update($this->otherUser, $this->habit))->toBeFalse();
+    });
+
+    it('allows a user to delete their own habit', function (): void {
+        expect($this->policy->delete($this->user, $this->habit))->toBeTrue();
+    });
+
+    it('prevents a user from deleting another user\'s habit', function (): void {
+        expect($this->policy->delete($this->otherUser, $this->habit))->toBeFalse();
+    });
+});


### PR DESCRIPTION
🎯 **What:** 
A missing test file for `app/Policies/HabitPolicy.php` has been implemented to establish proper testing of the habit ownership logic, ensuring that unauthorized access or actions are correctly prevented.

📊 **Coverage:**
The new Pest tests provide comprehensive unit test coverage for the following methods in the `HabitPolicy`:
- `viewAny`: Ensures any user can view the index.
- `view`: Verifies that only the owner of a habit can view it.
- `create`: Ensures any user can create habits.
- `update`: Verifies that only the owner of a habit can update it.
- `delete`: Verifies that only the owner of a habit can delete it.

✨ **Result:**
The addition of these targeted unit tests significantly increases the reliability and coverage of the codebase, ensuring that access control checks around habits are robust and resistant to regressions during future refactoring. The tests run efficiently without requiring database persistence by utilizing factory `make()` techniques.

---
*PR created automatically by Jules for task [9419173679267454297](https://jules.google.com/task/9419173679267454297) started by @kuasar-mknd*