### PR TITLE
🧪 [testing improvement] Add test suite for usePullToRefresh composable

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "build": "vite build",
         "format": "prettier --write \"resources/**/*.{js,vue,css}\" && ./vendor/bin/pint",
         "lint": "npm run lint:js && npm run lint:php",
+        "test:js": "vitest run",
         "lint:js": "prettier --check \"resources/**/*.{js,vue,css}\"",
         "lint:php": "./vendor/bin/phpstan analyze --memory-limit=2G",
         "prepare": "husky"
@@ -20,10 +21,12 @@
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/vite": "^4.2.2",
         "@vitejs/plugin-vue": "^6.0.5",
+        "@vue/test-utils": "^2.4.6",
         "autoprefixer": "^10.4.27",
         "axios": "^1.14.0",
         "concurrently": "^9.0.1",
         "husky": "^9.1.7",
+        "jsdom": "^29.0.2",
         "laravel-vite-plugin": "^2.0.0",
         "lint-staged": "^16.3.2",
         "postcss": "^8.4.31",
@@ -32,11 +35,12 @@
         "tailwindcss": "^4.2.2",
         "vite": "^7.3.2",
         "vite-plugin-pwa": "^1.2.0",
-        "workbox-window": "^7.4.0",
+        "vitest": "^4.1.3",
         "vue": "^3.5.32",
         "workbox-precaching": "^7.4.0",
         "workbox-routing": "^7.4.0",
-        "workbox-strategies": "^7.4.0"
+        "workbox-strategies": "^7.4.0",
+        "workbox-window": "^7.4.0"
     },
     "dependencies": {
         "@sentry/vue": "^10.47.0",

--- a/tests/js/composables/usePullToRefresh.test.js
+++ b/tests/js/composables/usePullToRefresh.test.js
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, ref, nextTick } from 'vue'
+import { usePullToRefresh } from '@/composables/usePullToRefresh'
+import { router } from '@inertiajs/vue3'
+import * as haptics from '@/composables/useHaptics'
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: {
+        reload: vi.fn(),
+    },
+}))
+
+vi.mock('@/composables/useHaptics', () => ({
+    triggerHaptic: vi.fn(),
+}))
+
+const TestComponent = defineComponent({
+    setup() {
+        const { isRefreshing, pullDistance, isPulling } = usePullToRefresh({
+            threshold: 100,
+        })
+        return { isRefreshing, pullDistance, isPulling }
+    },
+    template: '<div></div>',
+})
+
+const ContainerTestComponent = defineComponent({
+    setup() {
+        const containerRef = ref(null)
+        const { isRefreshing, pullDistance, isPulling } = usePullToRefresh({
+            threshold: 100,
+            containerRef,
+        })
+        return { isRefreshing, pullDistance, isPulling, containerRef }
+    },
+    template: '<div ref="containerRef"></div>',
+})
+
+describe('usePullToRefresh', () => {
+    let wrapper
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        vi.useFakeTimers()
+
+        Object.defineProperty(window, 'scrollY', {
+            value: 0,
+            writable: true,
+        })
+    })
+
+    afterEach(() => {
+        if (wrapper) {
+            wrapper.unmount()
+        }
+        vi.useRealTimers()
+    })
+
+    it('initializes with default values', () => {
+        wrapper = mount(TestComponent)
+        expect(wrapper.vm.isRefreshing).toBe(false)
+        expect(wrapper.vm.pullDistance).toBe(0)
+        expect(wrapper.vm.isPulling).toBe(false)
+    })
+
+    it('starts pulling when at top of page', async () => {
+        wrapper = mount(TestComponent)
+        window.scrollY = 0
+
+        const touchStartEvent = new TouchEvent('touchstart', {
+            touches: [{ clientY: 100 }],
+        })
+        window.dispatchEvent(touchStartEvent)
+
+        expect(wrapper.vm.isPulling).toBe(true)
+    })
+
+    it('does not start pulling when not at top of page', async () => {
+        wrapper = mount(TestComponent)
+        window.scrollY = 50
+
+        const touchStartEvent = new TouchEvent('touchstart', {
+            touches: [{ clientY: 100 }],
+        })
+        window.dispatchEvent(touchStartEvent)
+
+        expect(wrapper.vm.isPulling).toBe(false)
+    })
+
+    it('updates pull distance on move when pulling down', async () => {
+        wrapper = mount(TestComponent)
+
+        const touchStartEvent = new TouchEvent('touchstart', {
+            touches: [{ clientY: 100 }],
+        })
+        window.dispatchEvent(touchStartEvent)
+
+        const touchMoveEvent = new TouchEvent('touchmove', {
+            touches: [{ clientY: 200 }], // Pulled down 100px
+        })
+        window.dispatchEvent(touchMoveEvent)
+
+        expect(wrapper.vm.isPulling).toBe(true)
+        expect(wrapper.vm.pullDistance).toBeGreaterThan(0)
+        // Math.pow(100, 0.8) is approximately 39.81
+        expect(wrapper.vm.pullDistance).toBeCloseTo(39.81)
+    })
+
+    it('cancels pull if moved up', async () => {
+        wrapper = mount(TestComponent)
+
+        const touchStartEvent = new TouchEvent('touchstart', {
+            touches: [{ clientY: 100 }],
+        })
+        window.dispatchEvent(touchStartEvent)
+
+        const touchMoveEvent = new TouchEvent('touchmove', {
+            touches: [{ clientY: 50 }], // Moved up
+        })
+        window.dispatchEvent(touchMoveEvent)
+
+        expect(wrapper.vm.isPulling).toBe(true) // Still considered 'pulling' but distance is 0
+        expect(wrapper.vm.pullDistance).toBe(0)
+    })
+
+    it('cancels pull if scrolled down during pull', async () => {
+        wrapper = mount(TestComponent)
+
+        const touchStartEvent = new TouchEvent('touchstart', {
+            touches: [{ clientY: 100 }],
+        })
+        window.dispatchEvent(touchStartEvent)
+
+        window.scrollY = 10 // Scrolled down
+
+        const touchMoveEvent = new TouchEvent('touchmove', {
+            touches: [{ clientY: 150 }],
+        })
+        window.dispatchEvent(touchMoveEvent)
+
+        expect(wrapper.vm.isPulling).toBe(false)
+        expect(wrapper.vm.pullDistance).toBe(0)
+    })
+
+    it('triggers refresh when threshold is reached and released', async () => {
+        wrapper = mount(TestComponent)
+
+        const touchStartEvent = new TouchEvent('touchstart', {
+            touches: [{ clientY: 100 }],
+        })
+        window.dispatchEvent(touchStartEvent)
+
+        // Move enough to exceed threshold of 100 after pow(0.8)
+        // delta ^ 0.8 > 100 => delta > 100 ^ 1.25 => delta > 316.22
+        const touchMoveEvent = new TouchEvent('touchmove', {
+            touches: [{ clientY: 450 }], // delta = 350, pow(350, 0.8) ~= 108
+        })
+        window.dispatchEvent(touchMoveEvent)
+
+        const touchEndEvent = new TouchEvent('touchend')
+        window.dispatchEvent(touchEndEvent)
+
+        // We have to wait for the async onRefresh to be called
+        await nextTick()
+
+        expect(wrapper.vm.isRefreshing).toBe(true)
+        expect(wrapper.vm.isPulling).toBe(false)
+        expect(wrapper.vm.pullDistance).toBe(100) // snapped to threshold
+
+        expect(haptics.triggerHaptic).toHaveBeenCalledWith('time')
+        expect(router.reload).toHaveBeenCalledWith({ preserveScroll: true })
+
+        // Fast forward 500ms to clear refreshing state
+        vi.advanceTimersByTime(500)
+        await nextTick()
+
+        expect(wrapper.vm.isRefreshing).toBe(false)
+        expect(wrapper.vm.pullDistance).toBe(0)
+    })
+
+    it('does not trigger refresh if released before threshold', async () => {
+        wrapper = mount(TestComponent)
+
+        const touchStartEvent = new TouchEvent('touchstart', {
+            touches: [{ clientY: 100 }],
+        })
+        window.dispatchEvent(touchStartEvent)
+
+        // Move slightly
+        const touchMoveEvent = new TouchEvent('touchmove', {
+            touches: [{ clientY: 150 }], // delta = 50, pow(50, 0.8) ~= 22.9
+        })
+        window.dispatchEvent(touchMoveEvent)
+
+        const touchEndEvent = new TouchEvent('touchend')
+        window.dispatchEvent(touchEndEvent)
+
+        await nextTick()
+
+        expect(wrapper.vm.isRefreshing).toBe(false)
+        expect(wrapper.vm.isPulling).toBe(false)
+        expect(wrapper.vm.pullDistance).toBe(0)
+
+        expect(haptics.triggerHaptic).not.toHaveBeenCalled()
+        expect(router.reload).not.toHaveBeenCalled()
+    })
+
+    it('works with a specific container element', async () => {
+        wrapper = mount(ContainerTestComponent)
+
+        const container = wrapper.element
+        Object.defineProperty(container, 'scrollTop', {
+            value: 0,
+            writable: true,
+        })
+
+        const touchStartEvent = new TouchEvent('touchstart', {
+            touches: [{ clientY: 100 }],
+        })
+        container.dispatchEvent(touchStartEvent)
+
+        expect(wrapper.vm.isPulling).toBe(true)
+
+        // Scrolled down container
+        container.scrollTop = 20
+        const touchStartEvent2 = new TouchEvent('touchstart', {
+            touches: [{ clientY: 100 }],
+        })
+        container.dispatchEvent(touchStartEvent2)
+
+        expect(wrapper.vm.isPulling).toBe(false)
+    })
+
+    it('uses custom onRefresh callback if provided', async () => {
+        const customRefresh = vi.fn().mockResolvedValue()
+        const CustomRefreshComponent = defineComponent({
+            setup() {
+                const { isRefreshing, pullDistance, isPulling } = usePullToRefresh({
+                    threshold: 100,
+                    onRefresh: customRefresh,
+                })
+                return { isRefreshing, pullDistance, isPulling }
+            },
+            template: '<div></div>',
+        })
+
+        wrapper = mount(CustomRefreshComponent)
+
+        const touchStartEvent = new TouchEvent('touchstart', {
+            touches: [{ clientY: 100 }],
+        })
+        window.dispatchEvent(touchStartEvent)
+
+        const touchMoveEvent = new TouchEvent('touchmove', {
+            touches: [{ clientY: 450 }],
+        })
+        window.dispatchEvent(touchMoveEvent)
+
+        const touchEndEvent = new TouchEvent('touchend')
+        window.dispatchEvent(touchEndEvent)
+
+        await nextTick()
+
+        expect(customRefresh).toHaveBeenCalled()
+        expect(router.reload).not.toHaveBeenCalled()
+    })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './resources/js'),
+    },
+  },
+})


### PR DESCRIPTION
🎯 **What:** 
The `usePullToRefresh.js` Vue composable handles touch events for mobile "pull to refresh" interactions but was previously missing test coverage due to the lack of a Javascript/DOM testing infrastructure (like `vitest` and `jsdom`).

📊 **Coverage:**
A complete setup of `vitest` and `@vue/test-utils` has been implemented along with 10 comprehensive tests. Covered scenarios include:
- Initial default values checking.
- Start and cancellation of pull logic depending on window scroll thresholds and interactions.
- Complex user interactions like reversing scroll and early release.
- Verifying math transformations (`Math.pow(delta, 0.8)` mapping to pixel changes).
- Correct routing/trigger callbacks alongside haptic triggers using correct arguments.
- Handling container elements over the default global window object.

✨ **Result:**
The testing gap is addressed completely with `jsdom` testing enabled globally in `package.json` under the `test:js` script, dramatically increasing test reliability and allowing confident composable refactoring moving forward.

---
*PR created automatically by Jules for task [11581229706665136306](https://jules.google.com/task/11581229706665136306) started by @kuasar-mknd*