### PR TITLE
⚡ Bolt: Replace updateOrCreate loop with upsert in UpdateNotificationPreferencesAction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -79,3 +79,7 @@
 ## 2025-06-16 - [Optimizing workout date extraction in AchievementService]
 **Learning:** Using `toBase()` before `pluck()` on a datetime column prevents Eloquent from hydrating dummy models and instantiating Carbon objects for every row during serialization. Using `substr($date, 0, 10)` for date extraction is significantly more efficient than using Carbon's `format()`. For 1000 records, this reduced memory by ~77% and time by ~45%.
 **Action:** Always use `toBase()` when only raw column values are needed from a large dataset, especially for casted columns like datetimes.
+
+## 2024-05-24 - Upsert instead of updateOrCreate in Loops
+**Learning:** `updateOrCreate` inside a loop fires individual `SELECT` and `INSERT`/`UPDATE` queries per iteration, leading to N+1 performance bottlenecks. Bulk `upsert()` resolves this but skips Eloquent model lifecycle events (like `saving`, `updated`) and Observers.
+**Action:** Always prefer `upsert()` for batched insertions/updates to optimize database queries, but strictly verify that the target model does not rely on observers or lifecycle events before applying the optimization. When using `upsert()` to replace relationship methods, remember to explicitly include the foreign key (e.g., `user_id`) in the payload.

--- a/app/Actions/Profile/UpdateNotificationPreferencesAction.php
+++ b/app/Actions/Profile/UpdateNotificationPreferencesAction.php
@@ -17,14 +17,23 @@ class UpdateNotificationPreferencesAction
      */
     public function execute(User $user, array $data): void
     {
+        // ⚡ Bolt: Replaced updateOrCreate loop with a single bulk upsert to prevent N+1 queries.
+        $upsertData = [];
         foreach ($data['preferences'] as $type => $isEnabled) {
-            $user->notificationPreferences()->updateOrCreate(
-                ['type' => $type],
-                [
-                    'is_enabled' => $isEnabled,
-                    'is_push_enabled' => $data['push_preferences'][$type] ?? false,
-                    'value' => $data['values'][$type] ?? null,
-                ]
+            $upsertData[] = [
+                'user_id' => $user->id,
+                'type' => $type,
+                'is_enabled' => $isEnabled,
+                'is_push_enabled' => $data['push_preferences'][$type] ?? false,
+                'value' => $data['values'][$type] ?? null,
+            ];
+        }
+
+        if ($upsertData !== []) {
+            \App\Models\NotificationPreference::upsert(
+                $upsertData,
+                ['user_id', 'type'],
+                ['is_enabled', 'is_push_enabled', 'value']
             );
         }
     }


### PR DESCRIPTION
💡 **What:**
Replaced the `updateOrCreate()` method called inside a `foreach` loop with a single bulk `NotificationPreference::upsert()` operation in `UpdateNotificationPreferencesAction`.

🎯 **Why:**
Using `updateOrCreate` inside a loop executes a `SELECT` and an `INSERT` or `UPDATE` query for every single iteration, leading to N+1 database queries. A bulk `upsert` handles all records in a single database roundtrip, significantly reducing database load.

📊 **Impact:**
Reduces the number of database queries from `2 * N` to just `1` during notification preference updates, improving response time and lowering DB connection overhead.

🔬 **Measurement:**
This can be verified by enabling DB Query Logging before and after the action. The optimized action will execute exactly one `insert into ... on duplicate key update` query instead of multiple `select` and `update` queries. I also manually verified that `NotificationPreference` does not rely on any model lifecycle events or observers which `upsert` normally bypasses.

---
*PR created automatically by Jules for task [12970496335744779523](https://jules.google.com/task/12970496335744779523) started by @kuasar-mknd*