### PR TITLE
🛡️ Sentinel: [HIGH] Fix Insecure Account Linking vulnerability

### DIFF
--- a/app/Actions/ResolveSocialUserAction.php
+++ b/app/Actions/ResolveSocialUserAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Exceptions\SocialAuthException;
 use App\Models\User;
 use Illuminate\Support\Str;
 use Laravel\Socialite\Contracts\User as SocialUser;
@@ -19,6 +20,12 @@ final class ResolveSocialUserAction
         $existingUser = User::where('email', $socialUser->getEmail())->first();
 
         if ($existingUser) {
+            // Security: Prevent account linking if the existing account is not verified.
+            // Linking an unverified account via social login poses an account takeover risk.
+            if (! $existingUser->hasVerifiedEmail()) {
+                throw new SocialAuthException(__('Your account must be verified before linking it with a social provider.'));
+            }
+
             // Update provider info if not set (linking account)
             if (! $existingUser->provider_id) {
                 $existingUser->forceFill([


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Pre-authentication Account Takeover in social authentication. Existing unverified local accounts could be linked to a social provider based solely on a matching email.
🎯 Impact: An attacker could pre-register an account with a victim's email. If the victim later attempts to log in via a social provider (e.g., Google) with that same email, the accounts would be linked, potentially allowing the attacker to retain access or influence the account state.
🔧 Fix: Updated `ResolveSocialUserAction` to verify that an existing local account is already verified (`hasVerifiedEmail()`) before allowing it to be linked to a social provider. If the account is unverified, a `SocialAuthException` is thrown, which is gracefully handled by the `SocialAuthController`.
✅ Verification: Manually verified the logic in `ResolveSocialUserAction.php` and its integration with `SocialAuthController.php`. Confirmed the existence of `App\Exceptions\SocialAuthException`. Performed syntax checks using `php -l`.

---
*PR created automatically by Jules for task [4555575069346023748](https://jules.google.com/task/4555575069346023748) started by @kuasar-mknd*