### PR TITLE
🎨 Palette: Add aria-labels to Supplements index buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-04-11 - Standardize character count for textareas
 **Learning:** Adding a visible character counter to textareas (like Workout Notes or Journal entries) improves UX by providing immediate feedback on validation limits before submission.
 **Action:** Always include a `{{ current / max }}` indicator for textareas with `maxlength` constraints, using the `text-red-400` class for limit warnings to maintain consistency with the 'Liquid Glass' design system.
+## 2026-04-12 - Add aria-labels to icon-only buttons
+**Learning:** Icon-only buttons (like those using only `material-symbols-outlined`) often miss `aria-label` attributes, making them inaccessible to screen readers. This is common in lists where actions like 'Edit' or 'Delete' are represented solely by icons to save space.
+**Action:** Always ensure that any button containing only an icon has a descriptive `aria-label` attribute (e.g., `aria-label="Modifier le complément"`) to convey its purpose to assistive technologies.

--- a/resources/js/Pages/Supplements/Index.vue
+++ b/resources/js/Pages/Supplements/Index.vue
@@ -122,6 +122,7 @@ const formatDate = (dateString) => {
                 <!-- Mobile Add Button -->
                 <button
                     @click="showAddForm = true"
+                    aria-label="Ajouter un complément"
                     class="bg-gradient-main flex size-12 items-center justify-center rounded-xl text-white shadow-lg active:scale-95 sm:hidden"
                 >
                     <span class="material-symbols-outlined">add</span>
@@ -225,12 +226,14 @@ const formatDate = (dateString) => {
                                 <div class="flex gap-1">
                                     <button
                                         @click="startEdit(supplement)"
+                                        aria-label="Modifier le complément"
                                         class="text-text-muted hover:text-electric-orange p-1 transition-colors"
                                     >
                                         <span class="material-symbols-outlined text-lg">edit</span>
                                     </button>
                                     <button
                                         @click="deleteSupplement(supplement.id)"
+                                        aria-label="Supprimer le complément"
                                         class="text-text-muted p-1 transition-colors hover:text-red-500"
                                     >
                                         <span class="material-symbols-outlined text-lg">delete</span>


### PR DESCRIPTION
**💡 What:**
Added `aria-label` attributes to the icon-only buttons (Add, Edit, Delete) in the `Supplements/Index.vue` page.

**🎯 Why:**
Icon-only buttons rely entirely on visual cues (Material icons) to convey their purpose. Screen reader users could not determine what these buttons do because they lacked text content or accessible labels. Adding `aria-label` provides this necessary context.

**📸 Before/After:**
*Before:*
```html
<button @click="showAddForm = true" class="...">
    <span class="material-symbols-outlined">add</span>
</button>
```
*After:*
```html
<button @click="showAddForm = true" aria-label="Ajouter un complément" class="...">
    <span class="material-symbols-outlined">add</span>
</button>
```

**♿ Accessibility:**
Improved screen reader experience by ensuring all interactive icon-only elements in the Supplements list have clear, descriptive labels in French, matching the application's primary language.

---
*PR created automatically by Jules for task [14800935217301769808](https://jules.google.com/task/14800935217301769808) started by @kuasar-mknd*