### PR TITLE
⚡ Bolt: Optimize StreakService by avoiding redundant DB queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -87,3 +87,7 @@
 ## 2026-04-10 - [Native PHP Date Math in Analytical Loops]
 **Learning:** Instantiating 'Carbon' objects inside large analytical loops causes significant O(N) object instantiation overhead and memory pressure. Native PHP 'strtotime()' and 'date()' are 80-90% faster in these scenarios.
 **Action:** Replace 'Carbon::parse()' with native 'strtotime()' and 'date()' within performance-critical loops that evaluate date sequences for charts or distributions.
+
+## 2024-05-25 - [toBase() Type Safety with Datetimes]
+**Learning:** Using `toBase()->value('column')` on a datetime column bypasses Eloquent's attribute casting and returns a raw string instead of a `Carbon` instance. This can break existing logic that relies on `instanceof Carbon` checks or Carbon-specific methods.
+**Action:** When using `toBase()` for performance on datetime columns, always explicitly parse the result with `Carbon::parse()` if the subsequent logic expects a Carbon object, or rely on native PHP string/date functions for even better performance.

--- a/app/Services/StreakService.php
+++ b/app/Services/StreakService.php
@@ -25,8 +25,8 @@ final class StreakService
      * it resets to 1. If consecutive, it increments. It also updates the
      * user's `last_workout_at` timestamp.
      *
-     * @param  \App\Models\User  $user  The user whose streak is being updated.
-     * @param  \App\Models\Workout|null  $workout  The newly completed or updated workout (optional).
+     * @param  User  $user  The user whose streak is being updated.
+     * @param  Workout|null  $workout  The newly completed or updated workout (optional).
      */
     public function updateStreak(User $user, ?Workout $workout = null): void
     {
@@ -50,23 +50,32 @@ final class StreakService
 
         $this->calculateNewStreak($user, $workoutDate, $lastRecordedDate);
 
-        // Ensure we assign a Carbon instance or null, handling the mixed return of value()
-        $latestStartedAt = $user->workouts()->latest('started_at')->value('started_at');
-        $latestStartedAtCarbon = null;
+        if ($workout !== null) {
+            // ⚡ Bolt: PERFORMANCE OPTIMIZATION
+            // If a workout is provided, use its started_at date directly.
+            // This avoids an unnecessary database query to find the "latest" workout.
+            $user->last_workout_at = $workout->started_at;
+        } else {
+            // ⚡ Bolt: PERFORMANCE OPTIMIZATION
+            // Only query the database if no workout was provided.
+            // Using value() without toBase() ensures Eloquent casting to Carbon.
+            $latestStartedAt = $user->workouts()
+                ->latest('started_at')
+                ->value('started_at');
 
-        if ($latestStartedAt && is_scalar($latestStartedAt)) {
-            $latestStartedAtCarbon = Carbon::parse((string) $latestStartedAt);
+            $user->last_workout_at = ($latestStartedAt instanceof Carbon)
+                ? $latestStartedAt
+                : ($latestStartedAt && is_scalar($latestStartedAt) ? Carbon::parse((string) $latestStartedAt) : null);
         }
 
-        $user->last_workout_at = $workout !== null ? $workout->started_at : $latestStartedAtCarbon;
         $user->save();
     }
 
     /**
      * Get the user's last recorded workout date as a Carbon instance.
      *
-     * @param  \App\Models\User  $user  The user model.
-     * @return \Illuminate\Support\Carbon|null The start of the day of the last workout, or null if never recorded.
+     * @param  User  $user  The user model.
+     * @return Carbon|null The start of the day of the last workout, or null if never recorded.
      */
     protected function getLastRecordedDate(User $user): ?Carbon
     {
@@ -87,9 +96,9 @@ final class StreakService
      * or remain the same (same day). It also updates the `longest_streak` if
      * the new current streak exceeds it.
      *
-     * @param  \App\Models\User  $user  The user whose streak is being calculated.
-     * @param  \Illuminate\Support\Carbon  $workoutDate  The resolved start-of-day date of the current workout.
-     * @param  \Illuminate\Support\Carbon|null  $lastRecordedDate  The start-of-day date of the previously recorded workout.
+     * @param  User  $user  The user whose streak is being calculated.
+     * @param  Carbon  $workoutDate  The resolved start-of-day date of the current workout.
+     * @param  Carbon|null  $lastRecordedDate  The start-of-day date of the previously recorded workout.
      */
     protected function calculateNewStreak(User $user, Carbon $workoutDate, ?Carbon $lastRecordedDate): void
     {
@@ -124,12 +133,14 @@ final class StreakService
      * The returned date is always normalized to the start of the day to ensure
      * accurate day-to-day streak calculations.
      *
-     * @param  \App\Models\User  $user  The user model.
-     * @param  \App\Models\Workout|null  $workout  The explicitly provided workout.
-     * @return \Illuminate\Support\Carbon|null The resolved date normalized to start of day, or null if no workouts exist.
+     * @param  User  $user  The user model.
+     * @param  Workout|null  $workout  The explicitly provided workout.
+     * @return Carbon|null The resolved date normalized to start of day, or null if no workouts exist.
      */
     private function resolveWorkoutDate(User $user, ?Workout $workout): ?Carbon
     {
+        // ⚡ Bolt: PERFORMANCE OPTIMIZATION
+        // Use the provided workout's date if available to avoid a database query.
         $startedAt = $workout->started_at ?? $user->workouts()->latest('started_at')->value('started_at');
 
         if ($startedAt instanceof Carbon) {


### PR DESCRIPTION
This PR introduces a small but effective performance optimization in the `StreakService`. 

### 💡 What:
The `updateStreak` method was previously querying the database for the most recent workout's start date even when a `Workout` object was already passed as a parameter. I've refactored this to use the provided object's data directly.

### 🎯 Why:
Every time a workout is saved or updated, the `StreakService` is invoked. By eliminating one database query per call, we reduce the load on the database and slightly improve the response time of workout-related actions.

### 📊 Impact:
- Reduces database queries by 1 per `updateStreak` call when a workout is provided.
- Improves efficiency of the workout completion flow.

### 🔬 Measurement:
Verified with the existing test suite: `php artisan test tests/Feature/Services/StreakServiceTest.php`. All 6 tests passed.

---
*PR created automatically by Jules for task [2649156835149206660](https://jules.google.com/task/2649156835149206660) started by @kuasar-mknd*