### PR TITLE
🎨 Palette: Improve textarea accessibility and interactions

### DIFF
--- a/resources/js/Components/Dashboard/RecentActivity.vue
+++ b/resources/js/Components/Dashboard/RecentActivity.vue
@@ -3,7 +3,9 @@ import { Link } from '@inertiajs/vue3'
 import GlassButton from '@/Components/UI/GlassButton.vue'
 import { defineAsyncComponent } from 'vue'
 
-const RecentWorkoutsTimelineChart = defineAsyncComponent(() => import('@/Components/Stats/RecentWorkoutsTimelineChart.vue'))
+const RecentWorkoutsTimelineChart = defineAsyncComponent(
+    () => import('@/Components/Stats/RecentWorkoutsTimelineChart.vue'),
+)
 
 defineProps({
     recentWorkouts: { type: Array, required: true },
@@ -46,8 +48,10 @@ const colorForWorkout = (index) => {
 
         <!-- Activity Cards and Chart -->
         <div v-else class="flex flex-col gap-3">
-            <div class="relative overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-4 backdrop-blur-md mb-2">
-                <div class="mb-4 text-[10px] font-black tracking-[0.2em] text-vivid-violet uppercase">
+            <div
+                class="relative mb-2 overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-4 backdrop-blur-md"
+            >
+                <div class="text-vivid-violet mb-4 text-[10px] font-black tracking-[0.2em] uppercase">
                     Durée des séances
                 </div>
                 <RecentWorkoutsTimelineChart :data="recentWorkouts" />

--- a/resources/js/Components/Journal/JournalForm.vue
+++ b/resources/js/Components/Journal/JournalForm.vue
@@ -126,6 +126,7 @@ const emit = defineEmits(['close', 'submit'])
                 <div class="mb-1 flex items-center justify-between">
                     <label for="journal-content" class="text-text-muted block text-sm font-medium">Notes</label>
                     <span
+                        id="journal-content-counter"
                         class="text-[10px] font-bold tracking-wider uppercase"
                         :class="form.content?.length > 1000 ? 'text-red-400' : 'text-text-muted/50'"
                     >
@@ -137,7 +138,8 @@ const emit = defineEmits(['close', 'submit'])
                     v-model="form.content"
                     rows="4"
                     maxlength="1000"
-                    class="text-text-main placeholder-text-muted/50 w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-3 backdrop-blur-md transition-all duration-300 hover:border-white/30 hover:bg-white/15 focus:border-white/50 focus:bg-white/20 focus:shadow-[0_0_15px_rgba(255,255,255,0.1)] focus:ring-0 focus:outline-none active:scale-[0.98]"
+                    aria-describedby="journal-content-counter"
+                    class="text-text-main placeholder-text-muted/50 w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-3 backdrop-blur-md transition-all duration-300 hover:border-white/30 hover:bg-white/15 focus:border-white/50 focus:bg-white/20 focus:shadow-[0_0_15px_rgba(255,255,255,0.1)] focus:ring-0 focus:outline-none"
                     placeholder="Comment s'est passée votre journée ? Entraînement, repas, sensations..."
                 ></textarea>
                 <div v-if="form.errors.content" class="mt-1 text-xs text-red-400">

--- a/resources/js/Components/Stats/RecentWorkoutsTimelineChart.vue
+++ b/resources/js/Components/Stats/RecentWorkoutsTimelineChart.vue
@@ -27,7 +27,7 @@ const chartData = computed(() => {
     const reversedData = [...props.data].reverse()
 
     const labels = reversedData.map((workout) =>
-        new Date(workout.started_at).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' })
+        new Date(workout.started_at).toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' }),
     )
 
     const durations = reversedData.map((workout) => {

--- a/resources/js/Components/Workout/WorkoutSettingsModal.vue
+++ b/resources/js/Components/Workout/WorkoutSettingsModal.vue
@@ -30,6 +30,7 @@ const emit = defineEmits(['close', 'submit'])
                             Notes
                         </label>
                         <span
+                            id="workout-notes-counter"
                             class="text-[10px] font-bold tracking-wider uppercase"
                             :class="form.notes?.length > 1000 ? 'text-red-400' : 'text-text-muted/50'"
                         >
@@ -41,6 +42,7 @@ const emit = defineEmits(['close', 'submit'])
                         v-model="form.notes"
                         rows="4"
                         maxlength="1000"
+                        aria-describedby="workout-notes-counter"
                         class="text-text-main placeholder:text-text-muted/50 w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-3 backdrop-blur-md transition-all duration-300 hover:border-white/30 hover:bg-white/15 focus:border-white/50 focus:bg-white/20 focus:shadow-[0_0_15px_rgba(255,255,255,0.1)] focus:ring-0 focus:outline-none dark:border-slate-700 dark:bg-slate-800/80 dark:text-white dark:hover:border-slate-600 dark:focus:bg-slate-800"
                         placeholder="Notes sur la séance..."
                         dusk="workout-notes-input"


### PR DESCRIPTION
**💡 What:**
Added `aria-describedby` links between `textarea` inputs and their visual character counters in `JournalForm.vue` and `WorkoutSettingsModal.vue`. Also removed an inconsistent `active:scale-[0.98]` class from the journal textarea.

**🎯 Why:**
Screen readers previously had no way to associate the visual character count (e.g. "0 / 1000") with the input itself, making it confusing for users relying on assistive technologies to know their character limits. Additionally, form inputs shouldn't scale down when clicked/tapped, as this violates standard form UX expectations.

**📸 Before/After:**
*(Visual changes are minimal: just the removal of the click-shrink effect on the Journal textarea.)*

**♿ Accessibility:**
- Added `aria-describedby` connecting textareas to character counter IDs.
- Screen readers will now announce the character limit contextually.

---
*PR created automatically by Jules for task [4713562831602433910](https://jules.google.com/task/4713562831602433910) started by @kuasar-mknd*