### PR TITLE
🎨 Palette: Add keyboard focus states to Dashboard Quick Actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Ensure all custom "buttons" have accessibility tags when busy
 **Learning:** Found that custom "Dashboard Action" button blocks, which show loading states with `autorenew`, missed `aria-busy` declarations. Complex, visually styled interactive elements might miss standard button a11y properties that components like `GlassButton` abstract away.
 **Action:** When adding or verifying loading state animations on large custom touch targets, explicitly check for `aria-busy` and visual cursor feedbacks (`cursor-wait`), ensuring they mirror the a11y patterns of standard buttons in the system.
+## 2025-05-18 - Ensure interactive QuickActions have focus-visible styles
+**Learning:** Found that custom buttons and links in the QuickActions component, styled heavily for visual appearance, missed focus states (`focus-visible:ring-2`) and keyboard outlines, making them inaccessible for keyboard navigation.
+**Action:** When working on heavily styled interactive components (custom buttons, cards acting as links), ensure `focus-visible` utilities (`focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none focus-visible:ring-electric-orange`) are included so that the keyboard experience matches the standard components.

--- a/resources/js/Components/Dashboard/QuickActions.vue
+++ b/resources/js/Components/Dashboard/QuickActions.vue
@@ -19,7 +19,7 @@ const emit = defineEmits(['startWorkout'])
             aria-label="Démarrer une nouvelle séance d'entraînement"
             id="start-workout-button"
             dusk="start-workout-button"
-            class="hover:shadow-glow-orange/70 group shadow-glow-orange relative h-52 overflow-hidden rounded-3xl transition-all duration-300"
+            class="hover:shadow-glow-orange/70 group shadow-glow-orange focus-visible:ring-electric-orange relative h-52 overflow-hidden rounded-3xl transition-all duration-300 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
             :class="{ 'cursor-wait': processing }"
         >
             <div class="absolute inset-0 z-0 bg-white/60 backdrop-blur-md dark:bg-slate-800/60"></div>
@@ -56,7 +56,7 @@ const emit = defineEmits(['startWorkout'])
             v-press
             :href="route('templates.index')"
             aria-label="Voir mes programmes d'entraînement"
-            class="hover:shadow-glow-violet/70 group shadow-glow-violet relative h-52 overflow-hidden rounded-3xl transition-all duration-300"
+            class="hover:shadow-glow-violet/70 group shadow-glow-violet focus-visible:ring-electric-orange relative h-52 overflow-hidden rounded-3xl transition-all duration-300 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
             <div class="absolute inset-0 z-0 bg-white/60 backdrop-blur-md dark:bg-slate-800/60"></div>
             <div


### PR DESCRIPTION
🎨 Palette: Add keyboard focus states to Dashboard Quick Actions

💡 What:
Added missing `focus-visible` styling (`focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none focus-visible:ring-electric-orange`) to the interactive elements (the "Démarrer Séance" button and "Mes Programmes" link) within the `QuickActions.vue` component.

🎯 Why:
To ensure that keyboard users can clearly identify when these heavily styled custom buttons have focus, improving overall application accessibility and consistency with standard `GlassButton` behaviors.

📸 Before/After:
Before: The buttons provided no visual indication when navigated via keyboard.
After: The buttons now display a distinct orange focus ring.

♿ Accessibility:
Fixes missing keyboard focus states for main dashboard calls to action.

---
*PR created automatically by Jules for task [11265863606232406132](https://jules.google.com/task/11265863606232406132) started by @kuasar-mknd*