### PR TITLE
⚡ Bolt: Optimize collection chains in VolumeStatsService

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -95,3 +95,7 @@
 ## 2024-05-26 - [Consolidating Collection Methods into Single Loop]
 **Learning:** Chaining multiple Laravel collection methods like `map()`, `filter()`, and `values()` across the same dataset creates multiple O(N) iterations. When these methods also perform redundant expensive operations like `strtotime()` and `date()` parsing, the performance penalty is compounded.
 **Action:** Consolidate multiple collection transformations into a single `foreach` loop. Parse raw data (like datetimes) once and reuse the results to populate multiple destination arrays, reducing both iteration overhead and redundant function calls.
+
+## 2026-04-14 - [Consolidating Collection Chains to Foreach Loops]
+**Learning:** Chaining multiple collection methods (`map`, `filter`, `toArray`) on the same dataset creates multiple O(N) iterations. In high-frequency statistical methods like `getVolumeTrend` or `getVolumeHistory`, this adds significant function call overhead and memory pressure.
+**Action:** Consolidate multiple collection transformations into a single `foreach` loop to reduce execution time and memory overhead, especially when processing analytical data. Reuse expensive results (e.g., date parsing) within the single pass to further minimize redundant processing.

--- a/app/Services/Stats/VolumeStatsService.php
+++ b/app/Services/Stats/VolumeStatsService.php
@@ -36,32 +36,35 @@ final class VolumeStatsService
         return Cache::remember(
             "stats.volume_trend.{$user->id}.{$days}",
             now()->addMinutes(30),
-            fn (): array => $user->workouts()
+            function () use ($user, $days): array {
                 // ⚡ Bolt: PERFORMANCE OPTIMIZATION
                 // Use toBase() to avoid hydrating Eloquent models and instantiating Carbon objects.
-                // This significantly reduces memory usage and execution time for large datasets.
-                ->toBase()
-                ->where('started_at', '>=', now()->subDays($days))
-                ->select(['id', 'started_at', 'name', 'workout_volume as volume'])
-                ->orderBy('started_at')
-                ->get()
-                ->map(function (object $row): ?VolumeTrendPoint {
+                // Consolidate map/filter/values chains into a single foreach loop to prevent multiple O(N) iterations.
+                $workouts = $user->workouts()
+                    ->toBase()
+                    ->where('started_at', '>=', now()->subDays($days))
+                    ->select(['id', 'started_at', 'name', 'workout_volume as volume'])
+                    ->orderBy('started_at')
+                    ->get();
+
+                $trend = [];
+                foreach ($workouts as $row) {
                     $timestamp = strtotime((string) $row->started_at);
 
                     if ($timestamp === false) {
-                        return null;
+                        continue;
                     }
 
-                    return new VolumeTrendPoint(
+                    $trend[] = new VolumeTrendPoint(
                         date('d/m', $timestamp),
                         date('Y-m-d', $timestamp),
                         (string) $row->name,
                         is_numeric($row->volume) ? (float) $row->volume : 0.0,
                     );
-                })
-                ->filter()
-                ->values()
-                ->toArray()
+                }
+
+                return $trend;
+            }
         );
     }
 
@@ -167,31 +170,35 @@ final class VolumeStatsService
         return Cache::remember(
             "stats.volume_history.{$user->id}.{$limit}",
             now()->addMinutes(30),
-            fn (): array => $user->workouts()
+            function () use ($user, $limit): array {
                 // ⚡ Bolt: PERFORMANCE OPTIMIZATION
                 // Use toBase() to avoid hydrating Eloquent models and instantiating Carbon objects.
-                // This significantly reduces memory usage and execution time for large datasets.
-                ->toBase()
-                ->whereNotNull('ended_at')
-                ->select(['id', 'started_at', 'name', 'workout_volume as volume'])
-                ->orderBy('started_at')
-                ->limit($limit)
-                ->get()
-                ->map(function (object $row): ?VolumeHistoryPoint {
+                // Consolidate map/filter/values chains into a single foreach loop to prevent multiple O(N) iterations.
+                $workouts = $user->workouts()
+                    ->toBase()
+                    ->whereNotNull('ended_at')
+                    ->select(['id', 'started_at', 'name', 'workout_volume as volume'])
+                    ->orderBy('started_at')
+                    ->limit($limit)
+                    ->get();
+
+                $history = [];
+                foreach ($workouts as $row) {
                     $timestamp = strtotime((string) $row->started_at);
 
                     if ($timestamp === false) {
-                        return null;
+                        continue;
                     }
 
-                    return new VolumeHistoryPoint(
+                    $history[] = new VolumeHistoryPoint(
                         date('d/m', $timestamp),
                         is_numeric($row->volume) ? (float) $row->volume : 0.0,
                         (string) $row->name,
                     );
-                })
-                ->filter()
-                ->toArray()
+                }
+
+                return $history;
+            }
         );
     }
 


### PR DESCRIPTION
💡 **What:** Replaced the Laravel Collection method chains (`map()->filter()->values()->toArray()`) with standard PHP `foreach` loops in `VolumeStatsService::getVolumeTrend()` and `VolumeStatsService::getVolumeHistory()`.

🎯 **Why:** Chaining multiple collection methods across the same dataset creates multiple O(N) iterations. When processing analytical data, this introduces significant function call overhead and memory pressure. Consolidating into a single `foreach` loop reduces the iteration count to exactly one per query result, improving CPU usage and lowering memory allocation without sacrificing readability.

📊 **Impact:** Reduces time complexity of data transformation from multiple passes to a single pass, improving overall performance of the Volume Stats backend queries, especially for users with extensive workout histories.

🔬 **Measurement:** Execute `vendor/bin/pest --filter VolumeStatsService` to verify that calculations and filtering logic remain fully correct. The PHPStan lint checks also verify type safety of the refactoring.

---
*PR created automatically by Jules for task [3762676809182567558](https://jules.google.com/task/3762676809182567558) started by @kuasar-mknd*