### PR TITLE
🧹 Remove unused 'computed' import from Supplement Index

### DIFF
--- a/resources/js/Pages/Supplements/Index.vue
+++ b/resources/js/Pages/Supplements/Index.vue
@@ -4,7 +4,7 @@ import GlassCard from '@/Components/UI/GlassCard.vue'
 import GlassButton from '@/Components/UI/GlassButton.vue'
 import GlassInput from '@/Components/UI/GlassInput.vue'
 import { Head, useForm, router } from '@inertiajs/vue3'
-import { ref, computed, defineAsyncComponent } from 'vue'
+import { ref, defineAsyncComponent } from 'vue'
 
 const SupplementUsageChart = defineAsyncComponent(() => import('@/Components/Stats/SupplementUsageChart.vue'))
 


### PR DESCRIPTION
🎯 What: Removed the unused `computed` import from the `vue` imports in `resources/js/Pages/Supplements/Index.vue`.
💡 Why: Improves code cleanliness by removing an import that is not used anywhere else in the file, keeping the script leaner.
✅ Verification: Ran `pnpm lint:js` to ensure code formatting was met, and ran `pnpm test:js` to verify all front end tests continue to pass.
✨ Result: Codebase is marginally cleaner.

---
*PR created automatically by Jules for task [13643376513582973615](https://jules.google.com/task/13643376513582973615) started by @kuasar-mknd*