### PR TITLE
🧹 Remove unused imports in Stats Index

### DIFF
--- a/resources/js/Pages/Stats/Index.vue
+++ b/resources/js/Pages/Stats/Index.vue
@@ -1,9 +1,8 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
-import { Head, router, Deferred } from '@inertiajs/vue3'
+import { Head, router } from '@inertiajs/vue3'
 import { ref } from 'vue'
 
-import GlassSkeleton from '@/Components/UI/GlassSkeleton.vue'
 import WeightEvolutionCard from '@/Components/Stats/WeightEvolutionCard.vue'
 import BodyMetricsGrid from '@/Components/Stats/BodyMetricsGrid.vue'
 import VolumeTrendCard from '@/Components/Stats/VolumeTrendCard.vue'


### PR DESCRIPTION
🎯 What: Removed the unused GlassSkeleton component and Deferred from the @inertiajs/vue3 import in resources/js/Pages/Stats/Index.vue.
💡 Why: To improve code health and maintainability by removing dead code.
✅ Verification: Ran pnpm lint:js and pnpm test:js to ensure the codebase remains healthy without regressions.
✨ Result: Cleaner code in Stats/Index.vue with no impact on functionality.

---
*PR created automatically by Jules for task [7450919305103688705](https://jules.google.com/task/7450919305103688705) started by @kuasar-mknd*