### PR TITLE
🧹 Remove unused 'computed' import from Supplements/Index.vue

### DIFF
--- a/resources/js/Pages/Supplements/Index.vue
+++ b/resources/js/Pages/Supplements/Index.vue
@@ -4,7 +4,7 @@ import GlassCard from '@/Components/UI/GlassCard.vue'
 import GlassButton from '@/Components/UI/GlassButton.vue'
 import GlassInput from '@/Components/UI/GlassInput.vue'
 import { Head, useForm, router } from '@inertiajs/vue3'
-import { ref, computed, defineAsyncComponent } from 'vue'
+import { ref, defineAsyncComponent } from 'vue'
 
 const SupplementUsageChart = defineAsyncComponent(() => import('@/Components/Stats/SupplementUsageChart.vue'))
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `computed` import from `vue` in `resources/js/Pages/Supplements/Index.vue`.
💡 **Why:** The `computed` function was imported but never used in the component. Removing it cleans up dead code and improves maintainability.
✅ **Verification:** Verified by running `pnpm lint:js` and `pnpm test:js`, both of which passed successfully. Code review confirmed the safety and correctness of the change.
✨ **Result:** A cleaner component with no unnecessary imports, adhering to code health best practices.

---
*PR created automatically by Jules for task [5345124104222400598](https://jules.google.com/task/5345124104222400598) started by @kuasar-mknd*