### PR TITLE
🧹 Remove unused 'watch' import in useTheme composable

### DIFF
--- a/resources/js/composables/useTheme.js
+++ b/resources/js/composables/useTheme.js
@@ -4,7 +4,7 @@
  * Manages dark/light mode with system preference detection
  * and localStorage persistence.
  */
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 
 /**
  * @typedef {'system' | 'light' | 'dark'} ThemeMode


### PR DESCRIPTION
🎯 **What:** Removed unused 'watch' import from vue in resources/js/composables/useTheme.js.
💡 **Why:** The 'watch' API was not being used anywhere in this file. Removing unused imports reduces dead code, improves readability, and avoids potential confusion.
✅ **Verification:** Ran pnpm run lint:js and pnpm run test:js to ensure tests pass and there are no linting issues.
✨ **Result:** A cleaner useTheme.js composable file without dead imports.

---
*PR created automatically by Jules for task [10296600423958744665](https://jules.google.com/task/10296600423958744665) started by @kuasar-mknd*