### PR TITLE
🧹 Remove unused imports in OneRepMax.vue

### DIFF
--- a/resources/js/Pages/Tools/OneRepMax.vue
+++ b/resources/js/Pages/Tools/OneRepMax.vue
@@ -141,10 +141,7 @@
 <script setup>
 import { ref, computed, defineAsyncComponent } from 'vue'
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
-import PageHeader from '@/Components/Navigation/PageHeader.vue'
 import GlassCard from '@/Components/UI/GlassCard.vue'
-import GlassInput from '@/Components/UI/GlassInput.vue'
-import InputLabel from '@/Components/Form/InputLabel.vue'
 
 const OneRepMaxPercentagesChart = defineAsyncComponent(() => import('@/Components/Stats/OneRepMaxPercentagesChart.vue'))
 


### PR DESCRIPTION
🎯 **What:** Removed unused imports `PageHeader`, `GlassInput`, and `InputLabel` from `resources/js/Pages/Tools/OneRepMax.vue`.
💡 **Why:** This code health improvement removes dead code from the Vue component file, which helps simplify the file, minimize the bundle size somewhat, and improve code maintainability and readability.
✅ **Verification:** Verified by running `pnpm prettier --write` to ensure correct formatting and `pnpm lint:js` to verify there are no more style violations. Also ran `pnpm test:js` (Vitest) successfully, ensuring no existing functionalities or regressions occurred.
✨ **Result:** Cleaned up unused Vue component imports in `OneRepMax.vue` without altering the component's functionality.

---
*PR created automatically by Jules for task [5013859723833720328](https://jules.google.com/task/5013859723833720328) started by @kuasar-mknd*