### PR TITLE
🧹 Remove unused imports in DurationSection.vue

### DIFF
--- a/resources/js/Components/Dashboard/DurationSection.vue
+++ b/resources/js/Components/Dashboard/DurationSection.vue
@@ -1,7 +1,5 @@
 <script setup>
-import { Deferred } from '@inertiajs/vue3'
 import { defineAsyncComponent } from 'vue'
-import GlassSkeleton from '@/Components/UI/GlassSkeleton.vue'
 
 const DurationDistributionChart = defineAsyncComponent(() => import('@/Components/Stats/DurationDistributionChart.vue'))
 


### PR DESCRIPTION
🎯 **What:** Removed unused imports (`GlassSkeleton`, `Deferred`) in `DurationSection.vue`.
💡 **Why:** To improve codebase maintainability and readability by eliminating dead code, as flagged by the unused import checker script.
✅ **Verification:**
- Ran `pnpm install` and formatted the file with `pnpm prettier --write`.
- Ran JS linting (`pnpm lint:js`) and tests (`pnpm test:js`), which all passed successfully.
- Verified functionality is preserved as these were unused imports.
✨ **Result:** Cleaned up the file without changing behavior, improving code health.

---
*PR created automatically by Jules for task [6512555330754602667](https://jules.google.com/task/6512555330754602667) started by @kuasar-mknd*