### PR TITLE
🧹 [code health] Remove unused GlassSkeleton import

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,6 @@
+🧹 [code health] Remove unused GlassSkeleton import
+
+🎯 **What:** The code health issue addressed was an unused import of `GlassSkeleton` in `resources/js/Components/Dashboard/WeeklyVolumeSection.vue`.
+💡 **Why:** Removing unused imports improves code readability and maintainability by reducing clutter and potential confusion for other developers.
+✅ **Verification:** Verified that the component still compiles and functions correctly. Ran the test suite using `pnpm test:js` to ensure no regressions were introduced.
+✨ **Result:** The codebase is cleaner and more maintainable with the removal of dead code.

--- a/resources/js/Components/Dashboard/WeeklyVolumeSection.vue
+++ b/resources/js/Components/Dashboard/WeeklyVolumeSection.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { Deferred } from '@inertiajs/vue3'
 import { defineAsyncComponent } from 'vue'
-import GlassSkeleton from '@/Components/UI/GlassSkeleton.vue'
 
 const WeeklyVolumeChart = defineAsyncComponent(() => import('@/Components/Stats/WeeklyVolumeChart.vue'))
 


### PR DESCRIPTION
🧹 [code health] Remove unused GlassSkeleton import

🎯 **What:** The code health issue addressed was an unused import of `GlassSkeleton` in `resources/js/Components/Dashboard/WeeklyVolumeSection.vue`.
💡 **Why:** Removing unused imports improves code readability and maintainability by reducing clutter and potential confusion for other developers.
✅ **Verification:** Verified that the component still compiles and functions correctly. Ran the test suite using `pnpm test:js` to ensure no regressions were introduced.
✨ **Result:** The codebase is cleaner and more maintainable with the removal of dead code.

---
*PR created automatically by Jules for task [4016139232655198759](https://jules.google.com/task/4016139232655198759) started by @kuasar-mknd*