### PR TITLE
🧹 Remove unused Deferred import from Stats Index

### DIFF
--- a/resources/js/Pages/Stats/Index.vue
+++ b/resources/js/Pages/Stats/Index.vue
@@ -1,6 +1,6 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
-import { Head, router, Deferred } from '@inertiajs/vue3'
+import { Head, router } from '@inertiajs/vue3'
 import { ref } from 'vue'
 
 import GlassSkeleton from '@/Components/UI/GlassSkeleton.vue'


### PR DESCRIPTION
🎯 **What:** Removed unused `Deferred` import from `resources/js/Pages/Stats/Index.vue`.
💡 **Why:** Improves code health by eliminating unused and dead code, maintaining a cleaner import list.
✅ **Verification:** Ran `pnpm lint:js` and `pnpm test:js` to verify there are no unintended side-effects. Built the production assets using `pnpm run build` to confirm build process works smoothly.
✨ **Result:** Cleaned up the Vue component script block.

---
*PR created automatically by Jules for task [8113346472401937986](https://jules.google.com/task/8113346472401937986) started by @kuasar-mknd*