### PR TITLE
🧪 Add test for Admin getActivitylogOptions

### DIFF
--- a/tests/Unit/Models/AdminTest.php
+++ b/tests/Unit/Models/AdminTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Models\Admin;
+use ReflectionClass;
+use Spatie\Activitylog\LogOptions;
+use Tests\TestCase;
+
+class AdminTest extends TestCase
+{
+    public function test_get_activitylog_options(): void
+    {
+        $admin = new Admin();
+        $options = $admin->getActivitylogOptions();
+
+        $this->assertInstanceOf(LogOptions::class, $options);
+
+        // Reflection is required to access the internal state of LogOptions
+        // since the properties are protected and it has no getters.
+        $reflection = new ReflectionClass($options);
+
+        $logAttributesProp = $reflection->getProperty('logAttributes');
+        $logAttributesProp->setAccessible(true);
+        $this->assertEquals(['name', 'email'], $logAttributesProp->getValue($options));
+
+        $logOnlyDirtyProp = $reflection->getProperty('logOnlyDirty');
+        $logOnlyDirtyProp->setAccessible(true);
+        $this->assertTrue($logOnlyDirtyProp->getValue($options));
+
+        $submitEmptyLogsProp = $reflection->getProperty('submitEmptyLogs');
+        $submitEmptyLogsProp->setAccessible(true);
+        $this->assertFalse($submitEmptyLogsProp->getValue($options));
+    }
+}

--- a/tests/Unit/Models/AdminTest.php
+++ b/tests/Unit/Models/AdminTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Unit\Models;
 
 use App\Models\Admin;
-use ReflectionClass;
 use Spatie\Activitylog\LogOptions;
 use Tests\TestCase;
 
@@ -18,20 +17,9 @@ class AdminTest extends TestCase
 
         $this->assertInstanceOf(LogOptions::class, $options);
 
-        // Reflection is required to access the internal state of LogOptions
-        // since the properties are protected and it has no getters.
-        $reflection = new ReflectionClass($options);
-
-        $logAttributesProp = $reflection->getProperty('logAttributes');
-        $logAttributesProp->setAccessible(true);
-        $this->assertEquals(['name', 'email'], $logAttributesProp->getValue($options));
-
-        $logOnlyDirtyProp = $reflection->getProperty('logOnlyDirty');
-        $logOnlyDirtyProp->setAccessible(true);
-        $this->assertTrue($logOnlyDirtyProp->getValue($options));
-
-        $submitEmptyLogsProp = $reflection->getProperty('submitEmptyLogs');
-        $submitEmptyLogsProp->setAccessible(true);
-        $this->assertFalse($submitEmptyLogsProp->getValue($options));
+        // Properties are public in Spatie\Activitylog\LogOptions
+        $this->assertEquals(['name', 'email'], $options->logAttributes);
+        $this->assertTrue($options->logOnlyDirty);
+        $this->assertFalse($options->submitEmptyLogs);
     }
 }


### PR DESCRIPTION
🎯 **What:** Added a unit test to verify the behavior of `getActivitylogOptions` in the `Admin` model.
📊 **Coverage:** Tests that the method returns a `LogOptions` instance and properly configures `logOnly`, `logOnlyDirty`, and `dontSubmitEmptyLogs`.
✨ **Result:** Increased test coverage and ensured regression safety for the `Admin` model's activity logging configuration.

---
*PR created automatically by Jules for task [10498817774418568140](https://jules.google.com/task/10498817774418568140) started by @kuasar-mknd*