### PR TITLE
🧹 Remove unused 'watch' import in Calendar Index

### DIFF
--- a/resources/js/Pages/Calendar/Index.vue
+++ b/resources/js/Pages/Calendar/Index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed } from 'vue'
 import { Head, Link, router } from '@inertiajs/vue3'
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
 import GlassCard from '@/Components/UI/GlassCard.vue'


### PR DESCRIPTION
🎯 What: Removed the unused 'watch' import from vue in resources/js/Pages/Calendar/Index.vue.
💡 Why: Improves code health by removing dead code.
✅ Verification: Ran pnpm lint:js, pnpm test:js, and visually verified the code.
✨ Result: Cleaner component file.

---
*PR created automatically by Jules for task [12282406830401812035](https://jules.google.com/task/12282406830401812035) started by @kuasar-mknd*