### PR TITLE
chore: Update comment to prevent false positive task generation

### DIFF
--- a/app/Support/Csp/Policies/CustomPolicy.php
+++ b/app/Support/Csp/Policies/CustomPolicy.php
@@ -63,7 +63,7 @@ class CustomPolicy extends Basic
         // as it is bundled and managed internally by Filament.
         $policy->add(Directive::SCRIPT, Keyword::UNSAFE_EVAL);
 
-        // Fix for Filament Style Attributes: Instead of adding 'unsafe-inline' only to
+        // Filament Style Attributes: Instead of adding 'unsafe-inline' only to
         // the global style-src directive, we also use style-src-attr to specifically allow
         // inline attributes on elements.
         // NOTE: Style nonces are disabled because Filament injects <style> tags at runtime.


### PR DESCRIPTION
Updated the "Fix for Filament Style Attributes" comment in `CustomPolicy.php` to "Filament Style Attributes". This prevents automated issue tracking scanners from incorrectly flagging the explanatory comment as a pending task.

---
*PR created automatically by Jules for task [18121008622321614096](https://jules.google.com/task/18121008622321614096) started by @kuasar-mknd*