### PR TITLE
🧹 Remove unused `Deferred` and `GlassSkeleton` imports in Dashboard components

### DIFF
--- a/resources/js/Components/Dashboard/DurationSection.vue
+++ b/resources/js/Components/Dashboard/DurationSection.vue
@@ -1,7 +1,5 @@
 <script setup>
-import { Deferred } from '@inertiajs/vue3'
 import { defineAsyncComponent } from 'vue'
-import GlassSkeleton from '@/Components/UI/GlassSkeleton.vue'
 
 const DurationDistributionChart = defineAsyncComponent(() => import('@/Components/Stats/DurationDistributionChart.vue'))
 

--- a/resources/js/Components/Dashboard/TimeOfDaySection.vue
+++ b/resources/js/Components/Dashboard/TimeOfDaySection.vue
@@ -1,7 +1,5 @@
 <script setup>
-import { Deferred } from '@inertiajs/vue3'
 import { defineAsyncComponent } from 'vue'
-import GlassSkeleton from '@/Components/UI/GlassSkeleton.vue'
 
 const TimeOfDayChart = defineAsyncComponent(() => import('@/Components/Stats/TimeOfDayChart.vue'))
 

--- a/resources/js/Components/Dashboard/WeeklyVolumeSection.vue
+++ b/resources/js/Components/Dashboard/WeeklyVolumeSection.vue
@@ -1,7 +1,5 @@
 <script setup>
-import { Deferred } from '@inertiajs/vue3'
 import { defineAsyncComponent } from 'vue'
-import GlassSkeleton from '@/Components/UI/GlassSkeleton.vue'
 
 const WeeklyVolumeChart = defineAsyncComponent(() => import('@/Components/Stats/WeeklyVolumeChart.vue'))
 


### PR DESCRIPTION
🎯 **What:** Removed unused imports `Deferred` from `@inertiajs/vue3` and `GlassSkeleton` in `WeeklyVolumeSection.vue`, `TimeOfDaySection.vue`, and `DurationSection.vue`.
💡 **Why:** These components were importing dependencies that were never utilized within their template or script sections. Removing them cleans up dead code, reduces cognitive load, and slightly improves component parsing time, improving overall maintainability.
✅ **Verification:** Ran `pnpm lint:js` and `pnpm test:js` to ensure code is properly formatted and tests pass.
✨ **Result:** Cleaned up unused imports in multiple Dashboard components without changing any existing functionality.

---
*PR created automatically by Jules for task [13926016876833472759](https://jules.google.com/task/13926016876833472759) started by @kuasar-mknd*