### PR TITLE
🧪 Add Pest test coverage for HabitLog scopeWhereDateBetween

### DIFF
--- a/tests/Feature/Models/HabitLogTest.php
+++ b/tests/Feature/Models/HabitLogTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Habit;
+use App\Models\HabitLog;
+use Illuminate\Support\Carbon;
+
+test('whereDateBetween scope works with separate arguments', function (): void {
+    $habit = Habit::factory()->create();
+
+    HabitLog::factory()->create(['habit_id' => $habit->id, 'date' => '2023-01-05']);
+    HabitLog::factory()->create(['habit_id' => $habit->id, 'date' => '2023-01-15']);
+    HabitLog::factory()->create(['habit_id' => $habit->id, 'date' => '2023-01-25']);
+
+    $results = HabitLog::whereDateBetween('2023-01-10', '2023-01-20')->get();
+
+    expect($results)->toHaveCount(1)
+        ->and($results->first()->date->toDateString())->toBe('2023-01-15');
+});
+
+test('whereDateBetween scope works with an array argument', function (): void {
+    $habit = Habit::factory()->create();
+
+    HabitLog::factory()->create(['habit_id' => $habit->id, 'date' => '2023-01-05']);
+    HabitLog::factory()->create(['habit_id' => $habit->id, 'date' => '2023-01-15']);
+    HabitLog::factory()->create(['habit_id' => $habit->id, 'date' => '2023-01-25']);
+
+    $results = HabitLog::whereDateBetween(['2023-01-10', '2023-01-20'])->get();
+
+    expect($results)->toHaveCount(1)
+        ->and($results->first()->date->toDateString())->toBe('2023-01-15');
+});
+
+test('whereDateBetween scope ignores incomplete arguments', function (): void {
+    $habit = Habit::factory()->create();
+
+    HabitLog::factory()->create(['habit_id' => $habit->id, 'date' => '2023-01-05']);
+    HabitLog::factory()->create(['habit_id' => $habit->id, 'date' => '2023-01-15']);
+
+    $results = HabitLog::whereDateBetween('2023-01-10')->get();
+
+    expect($results)->toHaveCount(2); // Should not filter
+});
+
+test('whereDateBetween scope ignores single element array argument', function (): void {
+    $habit = Habit::factory()->create();
+
+    HabitLog::factory()->create(['habit_id' => $habit->id, 'date' => '2023-01-05']);
+    HabitLog::factory()->create(['habit_id' => $habit->id, 'date' => '2023-01-15']);
+
+    $results = HabitLog::whereDateBetween(['2023-01-10'])->get();
+
+    expect($results)->toHaveCount(2); // Should not filter
+});

--- a/tests/Feature/Models/HabitLogTest.php
+++ b/tests/Feature/Models/HabitLogTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use App\Models\Habit;
 use App\Models\HabitLog;
-use Illuminate\Support\Carbon;
 
 test('whereDateBetween scope works with separate arguments', function (): void {
     $habit = Habit::factory()->create();


### PR DESCRIPTION
🎯 **What:** 
Added Pest test coverage for the `scopeWhereDateBetween` scope method in the `HabitLog` model. This fills a testing gap where the scope was previously untested.

📊 **Coverage:** 
The new test file (`tests/Feature/Models/HabitLogTest.php`) covers:
- Passing arguments as separate elements (`'2023-01-01', '2023-01-31'`).
- Passing arguments wrapped within an array (e.g. `['2023-01-01', '2023-01-31']`), which simulates behavior from packages like Spatie QueryBuilder.
- Passing incomplete arguments (`['2023-01-01']`) to ensure the scope ignores the execution gracefully without breaking the query builder.

✨ **Result:** 
Enhanced the application's overall test suite coverage, ensuring future refactoring inside the `HabitLog` queries remains reliable and predictable against regressions.

---
*PR created automatically by Jules for task [18194753383751227622](https://jules.google.com/task/18194753383751227622) started by @kuasar-mknd*