### PR TITLE
🧹 Remove unused PageHeader import in OneRepMax.vue

### DIFF
--- a/resources/js/Pages/Tools/OneRepMax.vue
+++ b/resources/js/Pages/Tools/OneRepMax.vue
@@ -141,7 +141,6 @@
 <script setup>
 import { ref, computed, defineAsyncComponent } from 'vue'
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
-import PageHeader from '@/Components/Navigation/PageHeader.vue'
 import GlassCard from '@/Components/UI/GlassCard.vue'
 import GlassInput from '@/Components/UI/GlassInput.vue'
 import InputLabel from '@/Components/Form/InputLabel.vue'


### PR DESCRIPTION
🎯 **What:** Removed unused `PageHeader` import from `resources/js/Pages/Tools/OneRepMax.vue`.
💡 **Why:** This component was imported but never used in the template, creating dead code.
✅ **Verification:** Verified via `grep` that the component is not used. Ran `pnpm lint:js`, `pnpm test:js`, and `pnpm build` to ensure everything still passes.
✨ **Result:** Cleaner component script setup.

---
*PR created automatically by Jules for task [7342665209113118417](https://jules.google.com/task/7342665209113118417) started by @kuasar-mknd*