### PR TITLE
🧹 refactor: Extract preCalculateMetrics queries to separate methods

### DIFF
--- a/app/Services/GoalService.php
+++ b/app/Services/GoalService.php
@@ -310,14 +310,13 @@ final class GoalService
     /**
      * Pre-calculate max weights for given exercise IDs.
      *
-     * @phpstan-ignore return.type
-     *
      * @param  array<array-key, mixed>  $exerciseIds
      * @return array<int, float>
      */
     private function preCalculateMaxWeights(User $user, array $exerciseIds): array
     {
-        return \Illuminate\Support\Facades\DB::table('workouts')
+        /** @var array<int, float> $maxWeights */
+        $maxWeights = \Illuminate\Support\Facades\DB::table('workouts')
             ->join('workout_lines', 'workouts.id', '=', 'workout_lines.workout_id')
             ->join('sets', 'workout_lines.id', '=', 'sets.workout_line_id')
             ->where('workouts.user_id', $user->id)
@@ -327,12 +326,12 @@ final class GoalService
             ->pluck('max_weight', 'exercise_id')
             ->map(fn (mixed $val): float => is_numeric($val) ? (float) $val : 0.0)
             ->toArray();
+
+        return $maxWeights;
     }
 
     /**
      * Pre-calculate max volumes for given exercise IDs.
-     *
-     * @phpstan-ignore return.type
      *
      * @param  array<array-key, mixed>  $exerciseIds
      * @return array<int, float>
@@ -349,12 +348,15 @@ final class GoalService
             ->selectRaw('workout_lines.exercise_id, workouts.id as workout_id, SUM(sets.weight * sets.reps) as total_volume')
             ->groupBy('workout_lines.exercise_id', 'workouts.id');
 
-        return \Illuminate\Support\Facades\DB::query()
+        /** @var array<int, float> $maxVolumes */
+        $maxVolumes = \Illuminate\Support\Facades\DB::query()
             ->fromSub($subQuery, 'volumes')
             ->selectRaw('exercise_id, MAX(total_volume) as max_volume')
             ->groupBy('exercise_id')
             ->pluck('max_volume', 'exercise_id')
             ->map(fn (mixed $val): float => is_numeric($val) ? (float) $val : 0.0)
             ->toArray();
+
+        return $maxVolumes;
     }
 }

--- a/app/Services/GoalService.php
+++ b/app/Services/GoalService.php
@@ -310,8 +310,9 @@ final class GoalService
     /**
      * Pre-calculate max weights for given exercise IDs.
      *
-     * @param  User  $user
-     * @param  array<int, int>  $exerciseIds
+     * @phpstan-ignore return.type
+     *
+     * @param  array<array-key, mixed>  $exerciseIds
      * @return array<int, float>
      */
     private function preCalculateMaxWeights(User $user, array $exerciseIds): array
@@ -331,8 +332,9 @@ final class GoalService
     /**
      * Pre-calculate max volumes for given exercise IDs.
      *
-     * @param  User  $user
-     * @param  array<int, int>  $exerciseIds
+     * @phpstan-ignore return.type
+     *
+     * @param  array<array-key, mixed>  $exerciseIds
      * @return array<int, float>
      */
     private function preCalculateMaxVolumes(User $user, array $exerciseIds): array
@@ -347,7 +349,6 @@ final class GoalService
             ->selectRaw('workout_lines.exercise_id, workouts.id as workout_id, SUM(sets.weight * sets.reps) as total_volume')
             ->groupBy('workout_lines.exercise_id', 'workouts.id');
 
-        /** @var array<int, float> $maxVolumes */
         return \Illuminate\Support\Facades\DB::query()
             ->fromSub($subQuery, 'volumes')
             ->selectRaw('exercise_id, MAX(total_volume) as max_volume')

--- a/app/Services/GoalService.php
+++ b/app/Services/GoalService.php
@@ -291,42 +291,11 @@ final class GoalService
         }
 
         if ($types->contains(GoalType::Weight) && $exerciseIds !== []) {
-            /** @var array<int, float> $maxWeights */
-            $maxWeights = \Illuminate\Support\Facades\DB::table('workouts')
-                ->join('workout_lines', 'workouts.id', '=', 'workout_lines.workout_id')
-                ->join('sets', 'workout_lines.id', '=', 'sets.workout_line_id')
-                ->where('workouts.user_id', $user->id)
-                ->whereIn('workout_lines.exercise_id', $exerciseIds)
-                ->selectRaw('workout_lines.exercise_id, MAX(sets.weight) as max_weight')
-                ->groupBy('workout_lines.exercise_id')
-                ->pluck('max_weight', 'exercise_id')
-                ->map(fn (mixed $val): float => is_numeric($val) ? (float) $val : 0.0)
-                ->toArray();
-
-            $metrics['max_weights'] = $maxWeights;
+            $metrics['max_weights'] = $this->preCalculateMaxWeights($user, $exerciseIds);
         }
 
         if ($types->contains(GoalType::Volume) && $exerciseIds !== []) {
-            // ⚡ Bolt Optimization: Calculate max volumes directly in SQL using a subquery instead of pulling all records into memory.
-            // Impact: Prevents memory overflow and reduces execution time from O(N) to O(1) in PHP for users with many workouts.
-            $subQuery = \Illuminate\Support\Facades\DB::table('workouts')
-                ->join('workout_lines', 'workouts.id', '=', 'workout_lines.workout_id')
-                ->join('sets', 'workout_lines.id', '=', 'sets.workout_line_id')
-                ->where('workouts.user_id', $user->id)
-                ->whereIn('workout_lines.exercise_id', $exerciseIds)
-                ->selectRaw('workout_lines.exercise_id, workouts.id as workout_id, SUM(sets.weight * sets.reps) as total_volume')
-                ->groupBy('workout_lines.exercise_id', 'workouts.id');
-
-            /** @var array<int, float> $maxVolumes */
-            $maxVolumes = \Illuminate\Support\Facades\DB::query()
-                ->fromSub($subQuery, 'volumes')
-                ->selectRaw('exercise_id, MAX(total_volume) as max_volume')
-                ->groupBy('exercise_id')
-                ->pluck('max_volume', 'exercise_id')
-                ->map(fn (mixed $val): float => is_numeric($val) ? (float) $val : 0.0)
-                ->toArray();
-
-            $metrics['max_volumes'] = $maxVolumes;
+            $metrics['max_volumes'] = $this->preCalculateMaxVolumes($user, $exerciseIds);
         }
 
         if ($types->contains(GoalType::Measurement)) {
@@ -336,5 +305,55 @@ final class GoalService
         }
 
         return $metrics;
+    }
+
+    /**
+     * Pre-calculate max weights for given exercise IDs.
+     *
+     * @param  User  $user
+     * @param  array<int, int>  $exerciseIds
+     * @return array<int, float>
+     */
+    private function preCalculateMaxWeights(User $user, array $exerciseIds): array
+    {
+        return \Illuminate\Support\Facades\DB::table('workouts')
+            ->join('workout_lines', 'workouts.id', '=', 'workout_lines.workout_id')
+            ->join('sets', 'workout_lines.id', '=', 'sets.workout_line_id')
+            ->where('workouts.user_id', $user->id)
+            ->whereIn('workout_lines.exercise_id', $exerciseIds)
+            ->selectRaw('workout_lines.exercise_id, MAX(sets.weight) as max_weight')
+            ->groupBy('workout_lines.exercise_id')
+            ->pluck('max_weight', 'exercise_id')
+            ->map(fn (mixed $val): float => is_numeric($val) ? (float) $val : 0.0)
+            ->toArray();
+    }
+
+    /**
+     * Pre-calculate max volumes for given exercise IDs.
+     *
+     * @param  User  $user
+     * @param  array<int, int>  $exerciseIds
+     * @return array<int, float>
+     */
+    private function preCalculateMaxVolumes(User $user, array $exerciseIds): array
+    {
+        // ⚡ Bolt Optimization: Calculate max volumes directly in SQL using a subquery instead of pulling all records into memory.
+        // Impact: Prevents memory overflow and reduces execution time from O(N) to O(1) in PHP for users with many workouts.
+        $subQuery = \Illuminate\Support\Facades\DB::table('workouts')
+            ->join('workout_lines', 'workouts.id', '=', 'workout_lines.workout_id')
+            ->join('sets', 'workout_lines.id', '=', 'sets.workout_line_id')
+            ->where('workouts.user_id', $user->id)
+            ->whereIn('workout_lines.exercise_id', $exerciseIds)
+            ->selectRaw('workout_lines.exercise_id, workouts.id as workout_id, SUM(sets.weight * sets.reps) as total_volume')
+            ->groupBy('workout_lines.exercise_id', 'workouts.id');
+
+        /** @var array<int, float> $maxVolumes */
+        return \Illuminate\Support\Facades\DB::query()
+            ->fromSub($subQuery, 'volumes')
+            ->selectRaw('exercise_id, MAX(total_volume) as max_volume')
+            ->groupBy('exercise_id')
+            ->pluck('max_volume', 'exercise_id')
+            ->map(fn (mixed $val): float => is_numeric($val) ? (float) $val : 0.0)
+            ->toArray();
     }
 }


### PR DESCRIPTION
🎯 **What:** The overly long `preCalculateMetrics` function in `app/Services/GoalService.php` was refactored by extracting two large, inline database queries (`max_weights` and `max_volumes`) into their own dedicated private methods: `preCalculateMaxWeights` and `preCalculateMaxVolumes`.

💡 **Why:** `preCalculateMetrics` was growing too large and complex, mixing high-level logic (checking which metrics to calculate) with low-level implementation details (complex, multi-line database queries with joins and aggregations). This extraction improves readability and maintainability by isolating the database query logic and keeping the main function focused on control flow.

✅ **Verification:** 
- The PHP refactoring safely moves code without changing logic.
- We used `php -l` to ensure syntax validity. 
- The refactored code correctly calls the new helper methods, passing in the required parameters (`$user` and `$exerciseIds`) and receiving the exact same return values.
- (Note: local tests via `php artisan test` could not be executed due to system PHP 8.3 constraints blocking PHP 8.4 dependencies for this project setup, but manual inspection verifies the structural integrity of the code).

✨ **Result:** Improved readability and maintainability of `GoalService`'s pre-calculation logic, with zero functional behavioral changes.

---
*PR created automatically by Jules for task [13574755040035339551](https://jules.google.com/task/13574755040035339551) started by @kuasar-mknd*