### PR TITLE
Remove historical comment in WorkoutStoreAuthorizationTest

### DIFF
--- a/tests/Feature/Api/WorkoutStoreAuthorizationTest.php
+++ b/tests/Feature/Api/WorkoutStoreAuthorizationTest.php
@@ -32,8 +32,6 @@ class WorkoutStoreAuthorizationTest extends TestCase
 
         $response = $this->postJson(route('api.v1.workouts.store'), $data);
 
-        // Before our fix, this would have returned 201 Created because the policy was not checked.
-        // After our fix, it should return 403 Forbidden.
         $response->assertForbidden();
     }
 


### PR DESCRIPTION
This PR removes a historical comment in the `WorkoutStoreAuthorizationTest.php` file that described the behavior before a fix was applied and asserted the new behavior. Since it is not an open task and is just historical context better tracked by version control, it has been removed.

---
*PR created automatically by Jules for task [7684448079260838465](https://jules.google.com/task/7684448079260838465) started by @kuasar-mknd*