### PR TITLE
🧪 test: Add test coverage for decrementVolumes in Set

### DIFF
--- a/app/Models/Set.php
+++ b/app/Models/Set.php
@@ -75,8 +75,8 @@ class Set extends Model
     public function updateVolumes(): void
     {
         $this->loadMissing('workoutLine.workout.user');
-        $workout = $this->workoutLine->workout;
-        $user = $workout->user;
+        $workout = $this->workoutLine?->workout;
+        $user = $workout?->user;
 
         if (! $user || ! $workout) {
             return;
@@ -96,8 +96,8 @@ class Set extends Model
     public function decrementVolumes(): void
     {
         $this->loadMissing('workoutLine.workout.user');
-        $workout = $this->workoutLine->workout;
-        $user = $workout->user;
+        $workout = $this->workoutLine?->workout;
+        $user = $workout?->user;
 
         if (! $user || ! $workout) {
             return;

--- a/tests/Feature/Models/SetTest.php
+++ b/tests/Feature/Models/SetTest.php
@@ -192,4 +192,76 @@ class SetTest extends TestCase
             ->delete(route('sets.destroy', $set))
             ->assertForbidden();
     }
+
+    public function test_decrement_volumes_reduces_user_and_workout_volumes(): void
+    {
+        $user = User::factory()->create(['total_volume' => 1000]);
+        $workout = Workout::factory()->create([
+            'user_id' => $user->id,
+            'workout_volume' => 500,
+        ]);
+        $exercise = Exercise::factory()->create();
+        $workoutLine = WorkoutLine::factory()->create([
+            'workout_id' => $workout->id,
+            'exercise_id' => $exercise->id,
+        ]);
+
+        $set = Set::factory()->create([
+            'workout_line_id' => $workoutLine->id,
+            'weight' => 50,
+            'reps' => 10,
+        ]);
+
+        // Because creating a set via factory also runs updateVolumes which increases the DB volume
+        // Set it back to exactly 1000 and 500 via direct DB query without triggering Eloquent events
+        \Illuminate\Support\Facades\DB::table('users')->where('id', $user->id)->update(['total_volume' => 1000]);
+        \Illuminate\Support\Facades\DB::table('workouts')->where('id', $workout->id)->update(['workout_volume' => 500]);
+
+        $set->decrementVolumes();
+
+        $this->assertEquals(500, (float)$user->fresh()->total_volume);
+        $this->assertEquals(0, (float)$workout->fresh()->workout_volume);
+    }
+
+    public function test_decrement_volumes_does_nothing_if_volume_is_zero(): void
+    {
+        $user = User::factory()->create(['total_volume' => 1000]);
+        $workout = Workout::factory()->create([
+            'user_id' => $user->id,
+            'workout_volume' => 500,
+        ]);
+        $exercise = Exercise::factory()->create();
+        $workoutLine = WorkoutLine::factory()->create([
+            'workout_id' => $workout->id,
+            'exercise_id' => $exercise->id,
+        ]);
+
+        $set = Set::factory()->create([
+            'workout_line_id' => $workoutLine->id,
+            'weight' => 0,
+            'reps' => 10,
+        ]);
+
+        // Because creating a set via factory also runs updateVolumes which increases the DB volume
+        // Set it back to exactly 1000 and 500 via direct DB query without triggering Eloquent events
+        \Illuminate\Support\Facades\DB::table('users')->where('id', $user->id)->update(['total_volume' => 1000]);
+        \Illuminate\Support\Facades\DB::table('workouts')->where('id', $workout->id)->update(['workout_volume' => 500]);
+
+        $set->decrementVolumes();
+
+        $this->assertEquals(1000, (float)$user->fresh()->total_volume);
+        $this->assertEquals(500, (float)$workout->fresh()->workout_volume);
+    }
+
+    public function test_decrement_volumes_handles_missing_relations_smoothly(): void
+    {
+        $set = new Set([
+            'weight' => 50,
+            'reps' => 10,
+        ]);
+
+        // Should not throw an error
+        $set->decrementVolumes();
+        $this->assertTrue(true);
+    }
 }


### PR DESCRIPTION
Add test coverage for the `decrementVolumes` method in `Set` model.

🎯 **What:** Tests were added for the `decrementVolumes` method on the `Set` model to cover the happy path (reducing user/workout volume), the zero-volume edge case, and missing relations. Safely refactored relationships with null safe operators.
📊 **Coverage:** The `decrementVolumes` method is now completely covered.
✨ **Result:** A potential failure mode where relations are absent was resolved (adding `?->`) and the model's functionality is verified securely against regressions.

---
*PR created automatically by Jules for task [12395517806571787547](https://jules.google.com/task/12395517806571787547) started by @kuasar-mknd*