### PR TITLE
🧪 Add test for getActivitylogOptions in Supplement model

### DIFF
--- a/tests/Unit/Models/SupplementTest.php
+++ b/tests/Unit/Models/SupplementTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Models\Supplement;
+use Spatie\Activitylog\LogOptions;
+use Tests\TestCase;
+
+class SupplementTest extends TestCase
+{
+    public function test_get_activitylog_options_returns_correct_configuration(): void
+    {
+        $supplement = new Supplement();
+        $options = $supplement->getActivitylogOptions();
+
+        $this->assertInstanceOf(LogOptions::class, $options);
+
+        $this->assertContains('name', $options->logAttributes);
+        $this->assertContains('brand', $options->logAttributes);
+        $this->assertContains('dosage', $options->logAttributes);
+        $this->assertContains('servings_remaining', $options->logAttributes);
+        $this->assertContains('low_stock_threshold', $options->logAttributes);
+
+        $this->assertTrue($options->logOnlyDirty);
+        $this->assertFalse($options->submitEmptyLogs);
+    }
+}


### PR DESCRIPTION
🎯 What: Added missing unit test for the `getActivitylogOptions` method in the `Supplement` model.
📊 Coverage: Validates the Activitylog `LogOptions` object properties (`logAttributes`, `logOnlyDirty`, and `submitEmptyLogs`) correctly map to the expected behavior.
✨ Result: Ensured future modifications to the model's logging configuration are protected against regressions.

---
*PR created automatically by Jules for task [10061811400947157714](https://jules.google.com/task/10061811400947157714) started by @kuasar-mknd*