### PR TITLE
test: Clean up explanatory comments from authorization test

### DIFF
--- a/tests/Feature/Api/WorkoutStoreAuthorizationTest.php
+++ b/tests/Feature/Api/WorkoutStoreAuthorizationTest.php
@@ -32,8 +32,6 @@ class WorkoutStoreAuthorizationTest extends TestCase
 
         $response = $this->postJson(route('api.v1.workouts.store'), $data);
 
-        // Before our fix, this would have returned 201 Created because the policy was not checked.
-        // After our fix, it should return 403 Forbidden.
         $response->assertForbidden();
     }
 


### PR DESCRIPTION
Removed historical contextual comments ('Before our fix...', 'After our fix...') from WorkoutStoreAuthorizationTest.php as they are unnecessary clutter in the source code.

---
*PR created automatically by Jules for task [13579212339701075644](https://jules.google.com/task/13579212339701075644) started by @kuasar-mknd*