### PR TITLE
🧪 Add tests for getVolume and getOriginalVolume in Set.php

### DIFF
--- a/tests/Feature/Models/SetTest.php
+++ b/tests/Feature/Models/SetTest.php
@@ -192,4 +192,46 @@ class SetTest extends TestCase
             ->delete(route('sets.destroy', $set))
             ->assertForbidden();
     }
+
+    public function test_get_volume_calculates_correctly(): void
+    {
+        $set = new Set(['weight' => 50, 'reps' => 10]);
+        $this->assertEquals(500.0, $set->getVolume());
+
+        $set = new Set(['weight' => 22.5, 'reps' => 8]);
+        $this->assertEquals(180.0, $set->getVolume());
+
+        $set = new Set(['weight' => null, 'reps' => 10]);
+        $this->assertEquals(0.0, $set->getVolume());
+
+        $set = new Set(['weight' => 50, 'reps' => null]);
+        $this->assertEquals(0.0, $set->getVolume());
+
+        $set = new Set(['weight' => null, 'reps' => null]);
+        $this->assertEquals(0.0, $set->getVolume());
+    }
+
+    public function test_get_original_volume_calculates_correctly(): void
+    {
+        $user = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $user->id]);
+        $exercise = Exercise::factory()->create();
+        $workoutLine = WorkoutLine::factory()->create([
+            'workout_id' => $workout->id,
+            'exercise_id' => $exercise->id,
+        ]);
+        $set = Set::factory()->create([
+            'workout_line_id' => $workoutLine->id,
+            'weight' => 50,
+            'reps' => 10,
+        ]);
+
+        $this->assertEquals(500.0, $set->getOriginalVolume());
+
+        $set->weight = 60;
+        $set->reps = 8;
+
+        $this->assertEquals(500.0, $set->getOriginalVolume());
+        $this->assertEquals(480.0, $set->getVolume());
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test for getVolume and getOriginalVolume in Set.php.
📊 **Coverage:** What scenarios are now tested: Covered standard integer, floating point weights, and null edge cases.
✨ **Result:** The improvement in test coverage: `getVolume` and `getOriginalVolume` are fully covered in `SetTest.php`.

---
*PR created automatically by Jules for task [5755846265049178891](https://jules.google.com/task/5755846265049178891) started by @kuasar-mknd*