### PR TITLE
🧪 test: Add test for getLatestAchievementCached in User

### DIFF
--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Models\User;
+use App\Services\NotificationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\DatabaseNotification;
+use Mockery;
+use Tests\TestCase;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_get_latest_achievement_cached_delegates_to_notification_service(): void
+    {
+        $user = User::factory()->create();
+
+        $mockNotification = new DatabaseNotification(['id' => 'test-id']);
+
+        // Use Mockery::mock but without type hinting the class since it's final
+        $mockService = Mockery::mock();
+        $mockService->shouldReceive('getLatestAchievement')
+            ->once()
+            ->with($user)
+            ->andReturn($mockNotification);
+
+        $this->app->instance(NotificationService::class, $mockService);
+
+        $result = $user->getLatestAchievementCached();
+
+        $this->assertSame($mockNotification, $result);
+    }
+
+    public function test_get_unread_notifications_count_cached_delegates_to_notification_service(): void
+    {
+        $user = User::factory()->create();
+
+        $mockService = Mockery::mock();
+        $mockService->shouldReceive('getUnreadCount')
+            ->once()
+            ->with($user)
+            ->andReturn(5);
+
+        $this->app->instance(NotificationService::class, $mockService);
+
+        $result = $user->getUnreadNotificationsCountCached();
+
+        $this->assertEquals(5, $result);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for `getLatestAchievementCached` (and `getUnreadNotificationsCountCached`) in `User.php`.
📊 **Coverage:** Tested that the User model correctly delegates these method calls to `NotificationService` by mocking it in the application container, guaranteeing isolation.
✨ **Result:** Increased testing coverage and safety-net for these wrapper methods without relying on internal caching or implementation details of the underlying service.

---
*PR created automatically by Jules for task [10728901301743328196](https://jules.google.com/task/10728901301743328196) started by @kuasar-mknd*