### PR TITLE
🧪 Add test for scopeForUser in Exercise model

### DIFF
--- a/tests/Feature/Models/ExerciseTest.php
+++ b/tests/Feature/Models/ExerciseTest.php
@@ -170,4 +170,21 @@ class ExerciseTest extends TestCase
 
         $response->assertRedirect('/login');
     }
+
+    public function test_scope_for_user_returns_system_and_user_exercises(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $systemExercise = Exercise::factory()->create(['user_id' => null]);
+        $user1Exercise = Exercise::factory()->create(['user_id' => $user1->id]);
+        $user2Exercise = Exercise::factory()->create(['user_id' => $user2->id]);
+
+        $exercises = Exercise::forUser($user1->id)->get();
+
+        $this->assertCount(2, $exercises);
+        $this->assertTrue($exercises->contains('id', $systemExercise->id));
+        $this->assertTrue($exercises->contains('id', $user1Exercise->id));
+        $this->assertFalse($exercises->contains('id', $user2Exercise->id));
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing test coverage for the `scopeForUser` method inside the `Exercise` model. This scope is responsible for filtering exercises to only include those belonging to the given user, or system-wide exercises (where `user_id` is null).

📊 **Coverage:** The test ensures that the returned collection from `scopeForUser` includes exercises with `user_id` equal to null, exercises specifically created for that user, and completely excludes exercises created by any other user.

✨ **Result:** A new unit test `test_scope_for_user_returns_system_and_user_exercises` has been added to `tests/Feature/Models/ExerciseTest.php` that properly checks against three sets of exercises (user's, system's, and other user's), successfully boosting test coverage and confidence in the system when retrieving the user exercises.

---
*PR created automatically by Jules for task [6418047922990191453](https://jules.google.com/task/6418047922990191453) started by @kuasar-mknd*