### PR TITLE
refactor: Extract logic from StatsController

### DIFF
--- a/app/Actions/Stats/GetStatsDashboardAction.php
+++ b/app/Actions/Stats/GetStatsDashboardAction.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Stats;
+
+use App\Models\User;
+use App\Services\StatsService;
+use Illuminate\Http\Request;
+
+/**
+ * Action responsible for compiling the full stats dashboard data.
+ *
+ * It aggregates immediate stats and prepares deferred data loading
+ * for heavy analytical queries (like performance trends).
+ */
+class GetStatsDashboardAction
+{
+    /**
+     * Create a new GetStatsDashboardAction instance.
+     */
+    public function __construct(
+        protected FetchStatsOverviewAction $fetchStatsOverview,
+        protected StatsService $statsService
+    ) {
+    }
+
+    /**
+     * Execute the action to compile dashboard data.
+     *
+     * @param  \App\Models\User  $user  The authenticated user.
+     * @param  \Illuminate\Http\Request  $request  The incoming HTTP request.
+     * @return array<string, mixed> Array of data for the Inertia response.
+     */
+    public function execute(User $user, Request $request): array
+    {
+        $period = $request->query('period', '30j');
+        $days = $this->fetchStatsOverview->parsePeriod($period);
+
+        // Immediate data
+        $immediateData = $this->fetchStatsOverview->getImmediateStats($user, $period);
+
+        return [
+            ...$immediateData,
+            // Return a closure so the presentation layer (Controller) can wrap it as needed (e.g. Inertia::defer)
+            'deferredData' => fn (): array => [
+                'performance' => $this->statsService->getPerformanceOverview($user, $days),
+                'body' => $this->statsService->getBodyProgressOverview($user, $days),
+            ],
+        ];
+    }
+}

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use App\Actions\Stats\FetchStatsOverviewAction;
+use App\Actions\Stats\GetStatsDashboardAction;
 use App\Models\Exercise;
 use App\Services\StatsService;
 use Illuminate\Http\Request;
@@ -34,29 +34,22 @@ class StatsController extends Controller
      * deferred loading for heavier analytical queries (like trends and distributions).
      *
      * @param  \Illuminate\Http\Request  $request  The incoming HTTP request.
-     * @param  \App\Actions\Stats\FetchStatsOverviewAction  $fetchStatsOverview  Action to fetch overview stats.
+     * @param  \App\Actions\Stats\GetStatsDashboardAction  $getStatsDashboard  Action to fetch overview stats.
      * @return \Inertia\Response The Inertia response rendering the 'Stats/Index' page.
      */
-    public function index(Request $request, FetchStatsOverviewAction $fetchStatsOverview): \Inertia\Response
+    public function index(Request $request, GetStatsDashboardAction $getStatsDashboard): \Inertia\Response
     {
-        $user = $this->user();
-        $period = $request->query('period', '30j');
-        $days = $fetchStatsOverview->parsePeriod($period);
+        $data = $getStatsDashboard->execute($this->user(), $request);
 
-        // Immediate data
-        $immediateData = $fetchStatsOverview->getImmediateStats($user, $period);
+        // ⚡ Bolt: PERFORMANCE OPTIMIZATION
+        // Consolidate deferred props to reduce the number of async requests and backend executions.
+        // This reduces HTTP overhead (1 XHR instead of 2) and ensures related visualizations
+        // appear together for a better user experience.
+        /** @var callable(): mixed $deferredDataCallable */
+        $deferredDataCallable = $data['deferredData'];
+        $data['deferredData'] = Inertia::defer($deferredDataCallable);
 
-        return Inertia::render('Stats/Index', [
-            ...$immediateData,
-            // ⚡ Bolt: PERFORMANCE OPTIMIZATION
-            // Consolidate deferred props to reduce the number of async requests and backend executions.
-            // This reduces HTTP overhead (1 XHR instead of 2) and ensures related visualizations
-            // appear together for a better user experience.
-            'deferredData' => Inertia::defer(fn (): array => [
-                'performance' => $this->statsService->getPerformanceOverview($user, $days),
-                'body' => $this->statsService->getBodyProgressOverview($user, $days),
-            ]),
-        ]);
+        return Inertia::render('Stats/Index', $data);
     }
 
     /**


### PR DESCRIPTION
🎯 **What:** Extracted the logic inside `StatsController@index` (the longest method body in `app/Http/Controllers`) into a dedicated `App\Actions\Stats\GetStatsDashboardAction` class.
💡 **Why:** To improve code readability, maintainability, and adhere to SOLID principles. The Controller now delegates the heavy lifting of data aggregation and structure to the Action.
✅ **Verification:** Ran `phpstan analyze` and `pest` tests. Formatting was fixed via `pint`.
✨ **Result:** The `StatsController` is cleaner and only concerns itself with HTTP request mapping and rendering the `Inertia` response.

---
*PR created automatically by Jules for task [7831142786586852227](https://jules.google.com/task/7831142786586852227) started by @kuasar-mknd*