### PR TITLE
🛡️ Sentinel: [security improvement] Enforce input length limits

### DIFF
--- a/app/Http/Requests/Api/StoreAchievementRequest.php
+++ b/app/Http/Requests/Api/StoreAchievementRequest.php
@@ -27,7 +27,7 @@ class StoreAchievementRequest extends FormRequest
         return [
             'slug' => ['required', 'string', 'max:255', Rule::unique('achievements')],
             'name' => ['required', 'string', 'max:255'],
-            'description' => ['required', 'string'],
+            'description' => ['required', 'string', 'max:5000'],
             'icon' => ['required', 'string', 'max:255'],
             'type' => ['required', 'string', 'max:255'],
             'threshold' => ['required', 'numeric', 'min:0'],

--- a/app/Http/Requests/Api/UpdateAchievementRequest.php
+++ b/app/Http/Requests/Api/UpdateAchievementRequest.php
@@ -30,7 +30,7 @@ class UpdateAchievementRequest extends FormRequest
         return [
             'slug' => ['sometimes', 'required', 'string', 'max:255', Rule::unique('achievements')->ignore($achievement->id)],
             'name' => ['sometimes', 'required', 'string', 'max:255'],
-            'description' => ['sometimes', 'required', 'string'],
+            'description' => ['sometimes', 'required', 'string', 'max:5000'],
             'icon' => ['sometimes', 'required', 'string', 'max:255'],
             'type' => ['sometimes', 'required', 'string', 'max:255'],
             'threshold' => ['sometimes', 'required', 'numeric', 'min:0'],

--- a/app/Http/Requests/Api/WorkoutTemplateStoreRequest.php
+++ b/app/Http/Requests/Api/WorkoutTemplateStoreRequest.php
@@ -26,7 +26,7 @@ class WorkoutTemplateStoreRequest extends FormRequest
     {
         return [
             'name' => 'required|string|max:255',
-            'description' => 'nullable|string',
+            'description' => 'nullable|string|max:1000',
             'exercises' => 'nullable|array',
             'exercises.*.id' => [
                 'required',

--- a/app/Http/Requests/Api/WorkoutTemplateUpdateRequest.php
+++ b/app/Http/Requests/Api/WorkoutTemplateUpdateRequest.php
@@ -26,7 +26,7 @@ class WorkoutTemplateUpdateRequest extends FormRequest
     {
         return [
             'name' => 'required|string|max:255',
-            'description' => 'nullable|string',
+            'description' => 'nullable|string|max:1000',
             'exercises' => 'nullable|array',
             'exercises.*.id' => [
                 'required',

--- a/app/Http/Requests/PersonalRecordStoreRequest.php
+++ b/app/Http/Requests/PersonalRecordStoreRequest.php
@@ -21,7 +21,7 @@ class PersonalRecordStoreRequest extends FormRequest
     {
         return [
             'exercise_id' => $this->getExerciseIdRules(),
-            'type' => 'required|string',
+            'type' => 'required|string|max:255',
             'value' => 'required|numeric',
             'secondary_value' => 'nullable|numeric',
             'workout_id' => $this->getWorkoutIdRules(),

--- a/app/Http/Requests/PersonalRecordUpdateRequest.php
+++ b/app/Http/Requests/PersonalRecordUpdateRequest.php
@@ -21,7 +21,7 @@ class PersonalRecordUpdateRequest extends FormRequest
     {
         return [
             'exercise_id' => $this->getExerciseIdRules(),
-            'type' => 'sometimes|string',
+            'type' => 'sometimes|string|max:255',
             'value' => 'sometimes|numeric',
             'secondary_value' => 'nullable|numeric',
             'workout_id' => $this->getWorkoutIdRules(),

--- a/app/Http/Requests/StoreWorkoutTemplateRequest.php
+++ b/app/Http/Requests/StoreWorkoutTemplateRequest.php
@@ -26,7 +26,7 @@ class StoreWorkoutTemplateRequest extends FormRequest
     {
         return [
             'name' => 'required|string|max:255',
-            'description' => 'nullable|string',
+            'description' => 'nullable|string|max:1000',
             'exercises' => 'nullable|array',
             'exercises.*.id' => [
                 'required',


### PR DESCRIPTION
### 🛡️ Sentinel Security Improvement

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing character length limits on user-supplied text inputs in several FormRequests.
🎯 **Impact:** Potential for resource exhaustion, database-level Denial of Service (DoS), or storage exhaustion if an attacker submits excessively large payloads for description or type fields.
🔧 **Fix:** Added `max` character length validation rules to `description` and `type` fields in both web and API FormRequests:
- `StoreWorkoutTemplateRequest`
- `WorkoutTemplateStoreRequest`
- `WorkoutTemplateUpdateRequest`
- `PersonalRecordStoreRequest`
- `PersonalRecordUpdateRequest`
- `StoreAchievementRequest`
- `UpdateAchievementRequest`
✅ **Verification:** Verified changes by running `pnpm run build`, `./vendor/bin/pint`, `./vendor/bin/phpstan`, and the full test suite `php artisan test`. All checks passed.

---
*PR created automatically by Jules for task [16125160868353447706](https://jules.google.com/task/16125160868353447706) started by @kuasar-mknd*