### PR TITLE
⚡ Bolt: Batch achievement unlocks to reduce database queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -99,3 +99,7 @@
 ## 2026-04-14 - [Consolidating Collection Chains to Foreach Loops]
 **Learning:** Chaining multiple collection methods (`map`, `filter`, `toArray`) on the same dataset creates multiple O(N) iterations. In high-frequency statistical methods like `getVolumeTrend` or `getVolumeHistory`, this adds significant function call overhead and memory pressure.
 **Action:** Consolidate multiple collection transformations into a single `foreach` loop to reduce execution time and memory overhead, especially when processing analytical data. Reuse expensive results (e.g., date parsing) within the single pass to further minimize redundant processing.
+
+## 2026-04-20 - [Batch Achievement Unlocks]
+**Learning:** Unlocking multiple achievements simultaneously (common for new users or high-volume workouts) caused O(N) database queries to the 'user_achievements' pivot table when using individual 'attach()' calls.
+**Action:** Refactor synchronization logic to collect all eligible achievements first, then perform a single '$user->achievements()->attach($attachData)' call to process all unlocks in a single database transaction.

--- a/app/Services/AchievementService.php
+++ b/app/Services/AchievementService.php
@@ -36,32 +36,49 @@ final class AchievementService
 
         $metrics = $this->preCalculateMetrics($user, $locked);
 
+        $toUnlock = [];
         foreach ($locked as $achievement) {
-            $this->checkAndUnlock($user, $achievement, $metrics);
+            if ($this->isCriteriaMet($achievement, $metrics)) {
+                $toUnlock[] = $achievement;
+            }
+        }
+
+        if ($toUnlock !== []) {
+            // ⚡ Bolt: PERFORMANCE OPTIMIZATION
+            // Batch achievement unlocks in a single database query to the pivot table.
+            // This reduces queries from O(N) to O(1) during the attachment phase.
+            $now = now();
+            $attachData = [];
+
+            foreach ($toUnlock as $achievement) {
+                $attachData[$achievement->id] = ['achieved_at' => $now];
+            }
+
+            $user->achievements()->attach($attachData);
+
+            // Send notifications individually to preserve user experience
+            foreach ($toUnlock as $achievement) {
+                $user->notify(new \App\Notifications\AchievementUnlocked($achievement));
+            }
         }
     }
 
     /**
-     * Check if an achievement is unlocked based on calculated metrics and unlock it if so.
+     * Determine if an achievement's criteria is met based on calculated metrics.
      *
-     * @param  User  $user  The user to check the achievement for.
      * @param  Achievement  $achievement  The achievement to check.
      * @param  array<string, int|float>  $metrics  The pre-calculated metrics.
+     * @return bool True if criteria is met, false otherwise.
      */
-    private function checkAndUnlock(User $user, Achievement $achievement, array $metrics): void
+    private function isCriteriaMet(Achievement $achievement, array $metrics): bool
     {
-        $isUnlocked = match ($achievement->type) {
+        return match ($achievement->type) {
             'count' => ($metrics['count'] ?? 0) >= $achievement->threshold,
             'weight_record' => ($metrics['max_weight'] ?? 0) >= $achievement->threshold,
             'volume_total' => ($metrics['total_volume'] ?? 0) >= $achievement->threshold,
             'streak' => ($metrics['max_streak'] ?? 0) >= $achievement->threshold,
             default => false,
         };
-
-        if ($isUnlocked) {
-            $user->achievements()->attach($achievement->id, ['achieved_at' => now()]);
-            $user->notify(new \App\Notifications\AchievementUnlocked($achievement));
-        }
     }
 
     /**
@@ -77,7 +94,9 @@ final class AchievementService
         $metrics = [];
 
         if ($types->contains('count')) {
-            $metrics['count'] = $user->workouts()->count();
+            // ⚡ Bolt: Use workouts_count if already loaded on the user model to save a query.
+            /** @phpstan-ignore property.notFound */
+            $metrics['count'] = $user->workouts_count ?? $user->workouts()->count();
         }
 
         if ($types->contains('weight_record')) {


### PR DESCRIPTION
⚡ Bolt: Batch achievement unlocks to reduce database queries

This PR optimizes the `AchievementService` by batching the insertion of unlocked achievements into the pivot table. 

### 💡 What:
- Refactored `syncAchievements` to gather all achievements meeting the criteria before unlocking.
- Used a single `$user->achievements()->attach($attachData)` call.
- Optimized `preCalculateMetrics` to check for `workouts_count` on the model before querying the database.

### 🎯 Why:
To reduce the number of database interactions when multiple achievements are unlocked at once, which is common during initialization or high-performance workouts.

### 📊 Impact:
- Database INSERTs for achievements reduced from O(N) to O(1).
- Slight reduction in CPU overhead by avoiding redundant `COUNT` queries.

### 🔬 Measurement:
- Verified with `tests/Feature/Services/AchievementServiceTest.php`.
- Code quality verified with `Laravel Pint`.

---
*PR created automatically by Jules for task [13146476266255178751](https://jules.google.com/task/13146476266255178751) started by @kuasar-mknd*