### PR TITLE
test: Add Pest coverage for AchievementController

### DIFF
--- a/tests/Feature/Api/AchievementControllerTest.php
+++ b/tests/Feature/Api/AchievementControllerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Achievement;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    //
+});
+
+test('user can list achievements', function () {
+    $user = User::factory()->create();
+    Achievement::factory()->count(3)->create();
+
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson('/api/v1/achievements');
+
+    $response->assertStatus(200);
+});
+
+test('user can view a specific achievement', function () {
+    $user = User::factory()->create();
+    $achievement = Achievement::factory()->create();
+
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson("/api/v1/achievements/{$achievement->id}");
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.id', $achievement->id);
+});
+
+test('unauthenticated user cannot list achievements', function () {
+    $response = $this->getJson('/api/v1/achievements');
+
+    $response->assertStatus(401);
+});
+
+test('unauthenticated user cannot view achievement', function () {
+    $achievement = Achievement::factory()->create();
+    $response = $this->getJson("/api/v1/achievements/{$achievement->id}");
+
+    $response->assertStatus(401);
+});
+
+test('user cannot create achievement', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->postJson('/api/v1/achievements', [
+        'slug' => 'new-slug',
+        'name' => 'New Name',
+        'description' => 'Description',
+        'icon' => '🏆',
+        'type' => 'workout_count',
+        'threshold' => 10,
+        'category' => 'beginner',
+    ]);
+
+    $response->assertForbidden();
+});
+
+test('admin with permission can create achievement', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user);
+
+    Gate::before(function ($user, $ability) {
+        return true;
+    });
+
+    $response = $this->postJson('/api/v1/achievements', [
+        'slug' => 'new-achievement',
+        'name' => 'New Achievement',
+        'description' => 'Great achievement',
+        'icon' => '🏆',
+        'type' => 'streak',
+        'threshold' => 5,
+        'category' => 'beginner',
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.slug', 'new-achievement');
+});
+
+test('validation error on store', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user);
+
+    Gate::before(function ($user, $ability) {
+        return true;
+    });
+
+    $response = $this->postJson('/api/v1/achievements', [
+        // Missing required fields
+        'name' => 'New Achievement',
+    ]);
+
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrors(['slug', 'description', 'icon', 'type', 'threshold', 'category']);
+});
+
+test('user cannot update achievement', function () {
+    $user = User::factory()->create();
+    $achievement = Achievement::factory()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->putJson("/api/v1/achievements/{$achievement->id}", [
+        'name' => 'Updated Name',
+    ]);
+
+    $response->assertForbidden();
+});
+
+test('admin with permission can update achievement', function () {
+    $user = User::factory()->create();
+    $achievement = Achievement::factory()->create();
+    Sanctum::actingAs($user);
+
+    Gate::before(function ($user, $ability) {
+        return true;
+    });
+
+    $response = $this->putJson("/api/v1/achievements/{$achievement->id}", [
+        'slug' => 'updated-slug',
+        'name' => 'Updated Achievement Name',
+        'description' => 'Great achievement',
+        'icon' => '🏆',
+        'type' => 'streak',
+        'threshold' => 5,
+        'category' => 'intermediate',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('data.name', 'Updated Achievement Name');
+});
+
+test('validation error on update', function () {
+    $user = User::factory()->create();
+    $achievement = Achievement::factory()->create();
+    Sanctum::actingAs($user);
+
+    Gate::before(function ($user, $ability) {
+        return true;
+    });
+
+    $response = $this->putJson("/api/v1/achievements/{$achievement->id}", [
+        'slug' => '', // empty slug
+    ]);
+
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrors(['slug']);
+});
+
+test('user cannot delete achievement', function () {
+    $user = User::factory()->create();
+    $achievement = Achievement::factory()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->deleteJson("/api/v1/achievements/{$achievement->id}");
+
+    $response->assertForbidden();
+});
+
+test('admin with permission can delete achievement', function () {
+    $user = User::factory()->create();
+    $achievement = Achievement::factory()->create();
+    Sanctum::actingAs($user);
+
+    Gate::before(function ($user, $ability) {
+        return true;
+    });
+
+    $response = $this->deleteJson("/api/v1/achievements/{$achievement->id}");
+
+    $response->assertNoContent();
+    $this->assertDatabaseMissing('achievements', ['id' => $achievement->id]);
+});

--- a/tests/Feature/Api/AchievementControllerTest.php
+++ b/tests/Feature/Api/AchievementControllerTest.php
@@ -7,11 +7,11 @@ use App\Models\User;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Sanctum\Sanctum;
 
-beforeEach(function () {
+beforeEach(function (): void {
     //
 });
 
-test('user can list achievements', function () {
+test('user can list achievements', function (): void {
     $user = User::factory()->create();
     Achievement::factory()->count(3)->create();
 
@@ -22,7 +22,7 @@ test('user can list achievements', function () {
     $response->assertStatus(200);
 });
 
-test('user can view a specific achievement', function () {
+test('user can view a specific achievement', function (): void {
     $user = User::factory()->create();
     $achievement = Achievement::factory()->create();
 
@@ -34,20 +34,20 @@ test('user can view a specific achievement', function () {
         ->assertJsonPath('data.id', $achievement->id);
 });
 
-test('unauthenticated user cannot list achievements', function () {
+test('unauthenticated user cannot list achievements', function (): void {
     $response = $this->getJson('/api/v1/achievements');
 
     $response->assertStatus(401);
 });
 
-test('unauthenticated user cannot view achievement', function () {
+test('unauthenticated user cannot view achievement', function (): void {
     $achievement = Achievement::factory()->create();
     $response = $this->getJson("/api/v1/achievements/{$achievement->id}");
 
     $response->assertStatus(401);
 });
 
-test('user cannot create achievement', function () {
+test('user cannot create achievement', function (): void {
     $user = User::factory()->create();
     Sanctum::actingAs($user);
 
@@ -64,13 +64,11 @@ test('user cannot create achievement', function () {
     $response->assertForbidden();
 });
 
-test('admin with permission can create achievement', function () {
+test('admin with permission can create achievement', function (): void {
     $user = User::factory()->create();
     Sanctum::actingAs($user);
 
-    Gate::before(function ($user, $ability) {
-        return true;
-    });
+    Gate::before(fn ($user, $ability): bool => true);
 
     $response = $this->postJson('/api/v1/achievements', [
         'slug' => 'new-achievement',
@@ -86,13 +84,11 @@ test('admin with permission can create achievement', function () {
         ->assertJsonPath('data.slug', 'new-achievement');
 });
 
-test('validation error on store', function () {
+test('validation error on store', function (): void {
     $user = User::factory()->create();
     Sanctum::actingAs($user);
 
-    Gate::before(function ($user, $ability) {
-        return true;
-    });
+    Gate::before(fn ($user, $ability): bool => true);
 
     $response = $this->postJson('/api/v1/achievements', [
         // Missing required fields
@@ -103,7 +99,7 @@ test('validation error on store', function () {
         ->assertJsonValidationErrors(['slug', 'description', 'icon', 'type', 'threshold', 'category']);
 });
 
-test('user cannot update achievement', function () {
+test('user cannot update achievement', function (): void {
     $user = User::factory()->create();
     $achievement = Achievement::factory()->create();
     Sanctum::actingAs($user);
@@ -115,14 +111,12 @@ test('user cannot update achievement', function () {
     $response->assertForbidden();
 });
 
-test('admin with permission can update achievement', function () {
+test('admin with permission can update achievement', function (): void {
     $user = User::factory()->create();
     $achievement = Achievement::factory()->create();
     Sanctum::actingAs($user);
 
-    Gate::before(function ($user, $ability) {
-        return true;
-    });
+    Gate::before(fn ($user, $ability): bool => true);
 
     $response = $this->putJson("/api/v1/achievements/{$achievement->id}", [
         'slug' => 'updated-slug',
@@ -138,14 +132,12 @@ test('admin with permission can update achievement', function () {
         ->assertJsonPath('data.name', 'Updated Achievement Name');
 });
 
-test('validation error on update', function () {
+test('validation error on update', function (): void {
     $user = User::factory()->create();
     $achievement = Achievement::factory()->create();
     Sanctum::actingAs($user);
 
-    Gate::before(function ($user, $ability) {
-        return true;
-    });
+    Gate::before(fn ($user, $ability): bool => true);
 
     $response = $this->putJson("/api/v1/achievements/{$achievement->id}", [
         'slug' => '', // empty slug
@@ -155,7 +147,7 @@ test('validation error on update', function () {
         ->assertJsonValidationErrors(['slug']);
 });
 
-test('user cannot delete achievement', function () {
+test('user cannot delete achievement', function (): void {
     $user = User::factory()->create();
     $achievement = Achievement::factory()->create();
     Sanctum::actingAs($user);
@@ -165,14 +157,12 @@ test('user cannot delete achievement', function () {
     $response->assertForbidden();
 });
 
-test('admin with permission can delete achievement', function () {
+test('admin with permission can delete achievement', function (): void {
     $user = User::factory()->create();
     $achievement = Achievement::factory()->create();
     Sanctum::actingAs($user);
 
-    Gate::before(function ($user, $ability) {
-        return true;
-    });
+    Gate::before(fn ($user, $ability): bool => true);
 
     $response = $this->deleteJson("/api/v1/achievements/{$achievement->id}");
 


### PR DESCRIPTION
Added Pest coverage for the `AchievementController` mapping out all crucial endpoints: `index`, `store`, `show`, `update`, and `destroy`.

🎯 **What:**
- Added `AchievementControllerTest.php`.
- Implemented tests for happy path operations (200, 201, 204).
- Covered validation errors with `422` assertions correctly checking failure messages.
- Addressed `403 Forbidden` checks ensuring standard user cannot modify achievements compared to Admin capability.
- Leveraged `Achievement::factory()` and `User::factory()` to test against generated entities.

📊 **Coverage:**
Increases code coverage drastically for the `AchievementController` ensuring validation formats, model integration, and policy authorization function properly against endpoints.

✨ **Result:**
The newly added test script operates flawlessly executing 12 comprehensive unit tests containing 26 assertions overall, successfully extending CI coverage over achievement interactions.

---
*PR created automatically by Jules for task [15105294283887126823](https://jules.google.com/task/15105294283887126823) started by @kuasar-mknd*