### PR TITLE
🎨 Palette: Add visual disabled state to QuickActions Start Workout button

### DIFF
--- a/resources/js/Components/Dashboard/QuickActions.vue
+++ b/resources/js/Components/Dashboard/QuickActions.vue
@@ -20,7 +20,7 @@ const emit = defineEmits(['startWorkout'])
             id="start-workout-button"
             dusk="start-workout-button"
             class="hover:shadow-glow-orange/70 group shadow-glow-orange focus-visible:ring-electric-orange relative h-52 overflow-hidden rounded-3xl transition-all duration-300 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-            :class="{ 'cursor-wait': processing }"
+            :class="{ 'cursor-wait opacity-50': processing }"
         >
             <div class="absolute inset-0 z-0 bg-white/60 backdrop-blur-md dark:bg-slate-800/60"></div>
             <div


### PR DESCRIPTION
💡 **What:** Added the `opacity-50` Tailwind CSS class to the "Start Workout" button in the QuickActions component when it is in the `processing` state.

🎯 **Why:** The button was functionally disabled during processing, but there was no visual indication other than the loading spinner. Lowering the opacity provides immediate, standard visual feedback that the element is temporarily disabled and unclickable, improving overall UX and accessibility.

📸 **Before/After:** The button now appears dimmed out when a user clicks it, prior to navigation.

♿ **Accessibility:** Visual indication of disabled state helps users understand the interface status quickly without relying solely on the spinner or `aria-busy` attributes.

---
*PR created automatically by Jules for task [16081826075110347289](https://jules.google.com/task/16081826075110347289) started by @kuasar-mknd*