### PR TITLE
refactor: Extract logic from HabitLogController

### DIFF
--- a/app/Actions/Habits/FetchHabitLogsIndexApiAction.php
+++ b/app/Actions/Habits/FetchHabitLogsIndexApiAction.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Habits;
+
+use App\Models\HabitLog;
+use App\Models\User;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\QueryBuilder;
+
+class FetchHabitLogsIndexApiAction
+{
+    /**
+     * Fetch a paginated list of habit logs for the user.
+     *
+     * @return LengthAwarePaginator<int, HabitLog>
+     */
+    public function execute(User $user): LengthAwarePaginator
+    {
+        return QueryBuilder::for(HabitLog::class)
+            ->allowedIncludes(['habit'])
+            ->allowedFilters([
+                AllowedFilter::exact('habit_id'),
+                AllowedFilter::scope('date_between', 'whereDateBetween'),
+            ])
+            ->allowedSorts(['date', 'created_at'])
+            ->defaultSort('-date')
+            // Bolt: Optimize belongsTo filtering with INNER JOIN
+            ->join('habits', 'habit_logs.habit_id', '=', 'habits.id')
+            ->where('habits.user_id', $user->id)
+            ->select('habit_logs.*')
+            ->paginate();
+    }
+}

--- a/app/Http/Controllers/Api/HabitLogController.php
+++ b/app/Http/Controllers/Api/HabitLogController.php
@@ -11,8 +11,6 @@ use App\Http\Resources\HabitLogResource;
 use App\Models\HabitLog;
 use Illuminate\Http\Response;
 use OpenApi\Attributes as OA;
-use Spatie\QueryBuilder\AllowedFilter;
-use Spatie\QueryBuilder\QueryBuilder;
 
 class HabitLogController extends Controller
 {
@@ -23,23 +21,11 @@ class HabitLogController extends Controller
     )]
     #[OA\Response(response: 200, description: 'Successful operation')]
     #[OA\Response(response: 401, description: 'Unauthenticated')]
-    public function index(): \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+    public function index(\App\Actions\Habits\FetchHabitLogsIndexApiAction $fetchHabitLogsIndexApiAction): \Illuminate\Http\Resources\Json\AnonymousResourceCollection
     {
         $this->authorize('viewAny', HabitLog::class);
 
-        $logs = QueryBuilder::for(HabitLog::class)
-            ->allowedIncludes(['habit'])
-            ->allowedFilters([
-                AllowedFilter::exact('habit_id'),
-                AllowedFilter::scope('date_between', 'whereDateBetween'),
-            ])
-            ->allowedSorts(['date', 'created_at'])
-            ->defaultSort('-date')
-            // Bolt: Optimize belongsTo filtering with INNER JOIN
-            ->join('habits', 'habit_logs.habit_id', '=', 'habits.id')
-            ->where('habits.user_id', $this->user()->id)
-            ->select('habit_logs.*')
-            ->paginate();
+        $logs = $fetchHabitLogsIndexApiAction->execute($this->user());
 
         return HabitLogResource::collection($logs);
     }


### PR DESCRIPTION
Extracted the query building logic from `HabitLogController::index` into a dedicated `FetchHabitLogsIndexApiAction` class to follow SOLID principles and clean up the controller.

Also:
- Cleaned up unused imports in the controller.
- Ensured PHPStan passes by adding generic types to `LengthAwarePaginator`.
- Maintained exact functionality of the original query.

---
*PR created automatically by Jules for task [17821064431104486379](https://jules.google.com/task/17821064431104486379) started by @kuasar-mknd*