### PR TITLE
design: Liquid Glass overhaul for GlassSection

### DIFF
--- a/resources/js/Components/UI/GlassSection.vue
+++ b/resources/js/Components/UI/GlassSection.vue
@@ -28,7 +28,10 @@ defineProps({
 </script>
 
 <template>
-    <component :is="as">
+    <component
+        :is="as"
+        class="bg-white/10 backdrop-blur-md rounded-3xl border border-white/20 p-6 transition-all duration-300 hover:bg-white/20 hover:-translate-y-1 hover:shadow-xl active:scale-[0.98]"
+    >
         <header class="mb-6">
             <h2 class="text-text-main text-lg font-medium dark:text-white">
                 {{ title }}


### PR DESCRIPTION
Refactored `GlassSection.vue` to adopt the "Liquid Glass" aesthetic by applying `bg-white/10`, `backdrop-blur-md`, `rounded-3xl`, and `border border-white/20`. Also added micro-interactions with hover (`hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl`) and active (`active:scale-[0.98]`) states.

---
*PR created automatically by Jules for task [3073022692754424580](https://jules.google.com/task/3073022692754424580) started by @kuasar-mknd*