### PR TITLE
🛡️ Sentinel: [security improvement] Add input length limits to Goal measurement_type

### DIFF
--- a/app/Http/Requests/GoalStoreRequest.php
+++ b/app/Http/Requests/GoalStoreRequest.php
@@ -37,7 +37,7 @@ class GoalStoreRequest extends FormRequest
                     });
                 }),
             ],
-            'measurement_type' => ['required_if:type,measurement', 'nullable', 'string'],
+            'measurement_type' => ['required_if:type,measurement', 'nullable', 'string', 'max:255'],
             'deadline' => ['nullable', 'date', 'after:today'],
             'start_value' => ['nullable', 'numeric'],
         ];

--- a/app/Http/Requests/GoalUpdateRequest.php
+++ b/app/Http/Requests/GoalUpdateRequest.php
@@ -39,7 +39,7 @@ class GoalUpdateRequest extends FormRequest
                     });
                 }),
             ],
-            'measurement_type' => ['sometimes', 'nullable', 'string'],
+            'measurement_type' => ['sometimes', 'nullable', 'string', 'max:255'],
             'deadline' => ['nullable', 'date'], // Removed after:today to allow editing old goals without validation error if deadline passed
             'completed_at' => ['nullable', 'date'],
         ];


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing input length limits on the `measurement_type` field in Goal creation and update requests.
🎯 Impact: An attacker could potentially send excessively large strings, leading to database-level errors (if the column width is exceeded), memory exhaustion, or storage-based Denial of Service.
🔧 Fix: Added a `max:255` validation rule to the `measurement_type` field in both `GoalStoreRequest` and `GoalUpdateRequest`.
✅ Verification: Created a test case to verify that strings longer than 255 characters are rejected with a 422 error, while 255-character strings are accepted. Also ran existing goal-related tests to ensure no regressions.

---
*PR created automatically by Jules for task [16419380084678064462](https://jules.google.com/task/16419380084678064462) started by @kuasar-mknd*