### PR TITLE
🛡️ Sentinel: [security improvement] Add max length limits to authentication fields

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -96,3 +96,8 @@
 **Vulnerability:** Unvalidated user input (the `$provider` string from the URL path) was passed directly to `Socialite::driver($provider)`.
 **Learning:** Laravel Socialite uses the Manager pattern. While typically configured drivers work fine, passing arbitrary strings could potentially load unexpected classes if an attacker finds a way to register malicious drivers, or simply cause unhandled exceptions that might leak stack traces or cause Denial of Service.
 **Prevention:** Always validate dynamic path parameters that map to system configurations or drivers against a strict whitelist (e.g., `ALLOWED_PROVIDERS = ['github', 'google', 'apple']`) before instantiation.
+
+## 2024-05-19 - DoS Risk via Missing Length Limits on Hashed Fields
+**Vulnerability:** Authentication-related FormRequests (`LoginRequest`, `ConfirmPasswordRequest`, `UpdatePasswordRequest`, `DeleteUserRequest`) lacked maximum length constraints on `email`, `password`, and `current_password` fields.
+**Learning:** While Laravel handles validation, missing `max` limits on fields that are subsequently hashed (like passwords) or used in database queries can be exploited for ReDoS or CPU-exhaustion DoS attacks. Hashing an extremely long string is computationally expensive.
+**Prevention:** Always enforce a reasonable `max` limit (e.g., `max:255`) on all sensitive string inputs, especially those that will be hashed or used in intensive operations, to prevent resource exhaustion.

--- a/app/Http/Requests/Auth/ConfirmPasswordRequest.php
+++ b/app/Http/Requests/Auth/ConfirmPasswordRequest.php
@@ -26,7 +26,7 @@ class ConfirmPasswordRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'password' => ['required', 'string'],
+            'password' => ['required', 'string', 'max:255'],
         ];
     }
 

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -29,8 +29,8 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => ['required', 'string', 'email'],
-            'password' => ['required', 'string'],
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'password' => ['required', 'string', 'max:255'],
         ];
     }
 

--- a/app/Http/Requests/Auth/UpdatePasswordRequest.php
+++ b/app/Http/Requests/Auth/UpdatePasswordRequest.php
@@ -27,7 +27,7 @@ class UpdatePasswordRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'current_password' => ['required', 'current_password'],
+            'current_password' => ['required', 'current_password', 'max:255'],
             'password' => ['required', Password::defaults(), 'confirmed'],
         ];
     }

--- a/app/Http/Requests/DeleteUserRequest.php
+++ b/app/Http/Requests/DeleteUserRequest.php
@@ -26,7 +26,7 @@ class DeleteUserRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'password' => ['required', 'current_password'],
+            'password' => ['required', 'current_password', 'max:255'],
         ];
     }
 


### PR DESCRIPTION
### 🛡️ Sentinel: [security improvement]
Enforce a `max:255` character limit on sensitive authentication fields.

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing input length limits on fields used for hashing (passwords) or database queries (emails).
🎯 **Impact:** Potential Resource Exhaustion / DoS. Hashing extremely large strings is computationally expensive and can be exploited to tie up server resources.
🔧 **Fix:** Added `max:255` validation rule to `LoginRequest`, `ConfirmPasswordRequest`, `UpdatePasswordRequest`, and `DeleteUserRequest`.
✅ **Verification:** Ran `php artisan test` to ensure no legitimate login/confirmation flows are broken. 255 characters is ample for any valid email or password.

---
*PR created automatically by Jules for task [10522465506413821076](https://jules.google.com/task/10522465506413821076) started by @kuasar-mknd*