### PR TITLE
🎨 Palette: Add progressbar role and ARIA attributes to goal progress bars

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2026-04-18 - Enhanced Supplement Interaction & Toast Accessibility
 **Learning:** Adding localized loading states to list items (e.g., supplement consumption) significantly improves perceived performance and prevents duplicate actions. Standardizing these interactions with `GlassButton` ensures consistent haptic feedback and accessibility patterns. Global toast notifications benefit from explicit ARIA roles and live regions to ensure they are announced to screen reader users immediately.
 **Action:** Always implement `consumingId` or similar state for per-item async actions in lists. Ensure all flash messages use `role="alert"` and appropriate `aria-live` settings based on severity.
+## 2026-04-21 - Accessible custom progress indicators
+**Learning:** Custom UI progress bars built with `div` elements and dynamic inline styles (like those in `GoalCard` and `GoalsSummary`) lack semantic meaning. Screen reader users cannot interpret them as progress indicators without explicit ARIA roles and values.
+**Action:** Always add `role="progressbar"`, `aria-valuemin="0"`, `aria-valuemax="100"`, and dynamically bind `:aria-valuenow="currentValue"` to the parent container of any custom `div`-based progress bar to ensure assistive technologies can correctly announce progress updates.

--- a/resources/js/Components/Dashboard/GoalsSummary.vue
+++ b/resources/js/Components/Dashboard/GoalsSummary.vue
@@ -26,7 +26,13 @@ defineProps({
                             >{{ Math.round(goal.progress_pct) }}%</span
                         >
                     </div>
-                    <div class="h-2 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-slate-700">
+                    <div
+                        class="h-2 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-slate-700"
+                        role="progressbar"
+                        :aria-valuenow="goal.progress_pct"
+                        aria-valuemin="0"
+                        aria-valuemax="100"
+                    >
                         <div
                             class="glow-orange bg-gradient-main h-full transition-all duration-1000"
                             :style="{ width: goal.progress_pct + '%' }"

--- a/resources/js/Components/Goals/GoalCard.vue
+++ b/resources/js/Components/Goals/GoalCard.vue
@@ -102,6 +102,10 @@ const statusColor = computed(() => {
                 </div>
                 <div
                     class="h-2 w-full overflow-hidden rounded-full border border-white/20 bg-white/10 shadow-inner backdrop-blur-md"
+                    role="progressbar"
+                    :aria-valuenow="progress"
+                    aria-valuemin="0"
+                    aria-valuemax="100"
                 >
                     <div
                         class="relative h-full transition-all duration-1000 ease-out"

--- a/resources/js/Components/UI/GlassSection.vue
+++ b/resources/js/Components/UI/GlassSection.vue
@@ -30,7 +30,7 @@ defineProps({
 <template>
     <component
         :is="as"
-        class="bg-white/10 backdrop-blur-md rounded-3xl border border-white/20 p-6 transition-all duration-300 hover:bg-white/20 hover:-translate-y-1 hover:shadow-xl active:scale-[0.98]"
+        class="rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-xl active:scale-[0.98]"
     >
         <header class="mb-6">
             <h2 class="text-text-main text-lg font-medium dark:text-white">


### PR DESCRIPTION
💡 **What:**
Added `role="progressbar"` along with corresponding ARIA attributes (`aria-valuenow`, `aria-valuemin`, `aria-valuemax`) to the custom progress bar containers in `GoalCard.vue` and `GoalsSummary.vue`.

🎯 **Why:**
The application uses custom `div`-based progress bars to visualize goal completion. Without explicit semantic roles, these elements are entirely ignored by screen readers, meaning visually impaired users miss out on critical goal progress context.

📸 **Before/After:**
*   **Before:** `<div class="h-2 w-full overflow-hidden rounded-full...">`
*   **After:** `<div class="h-2 w-full overflow-hidden rounded-full..." role="progressbar" :aria-valuenow="progress" aria-valuemin="0" aria-valuemax="100">`

♿ **Accessibility:**
*   Ensures custom visual progress bars are semantically recognized by assistive technologies.
*   Dynamically binds the current progress percentage to `aria-valuenow` so screen readers can announce the exact completion status.

---
*PR created automatically by Jules for task [4308871782100357111](https://jules.google.com/task/4308871782100357111) started by @kuasar-mknd*