### PR TITLE
⚡ Bolt: Batch many-to-many attach in AchievementService

### DIFF
--- a/app/Services/AchievementService.php
+++ b/app/Services/AchievementService.php
@@ -36,32 +36,42 @@ final class AchievementService
 
         $metrics = $this->preCalculateMetrics($user, $locked);
 
+        $toUnlockIds = [];
+        $unlockedAchievements = [];
+
         foreach ($locked as $achievement) {
-            $this->checkAndUnlock($user, $achievement, $metrics);
+            if ($this->isUnlocked($achievement, $metrics)) {
+                $toUnlockIds[] = $achievement->id;
+                $unlockedAchievements[] = $achievement;
+            }
+        }
+
+        if (count($toUnlockIds) > 0) {
+            // ⚡ Bolt Optimization: Batch multiple many-to-many attach operations into a single query.
+            // Impact: Reduces database writes from O(N) to O(1) when multiple achievements are unlocked at once.
+            $user->achievements()->attach($toUnlockIds, ['achieved_at' => now()]);
+
+            foreach ($unlockedAchievements as $achievement) {
+                $user->notify(new \App\Notifications\AchievementUnlocked($achievement));
+            }
         }
     }
 
     /**
-     * Check if an achievement is unlocked based on calculated metrics and unlock it if so.
+     * Check if an achievement should be unlocked based on calculated metrics.
      *
-     * @param  User  $user  The user to check the achievement for.
      * @param  Achievement  $achievement  The achievement to check.
      * @param  array<string, int|float>  $metrics  The pre-calculated metrics.
      */
-    private function checkAndUnlock(User $user, Achievement $achievement, array $metrics): void
+    private function isUnlocked(Achievement $achievement, array $metrics): bool
     {
-        $isUnlocked = match ($achievement->type) {
+        return match ($achievement->type) {
             'count' => ($metrics['count'] ?? 0) >= $achievement->threshold,
             'weight_record' => ($metrics['max_weight'] ?? 0) >= $achievement->threshold,
             'volume_total' => ($metrics['total_volume'] ?? 0) >= $achievement->threshold,
             'streak' => ($metrics['max_streak'] ?? 0) >= $achievement->threshold,
             default => false,
         };
-
-        if ($isUnlocked) {
-            $user->achievements()->attach($achievement->id, ['achieved_at' => now()]);
-            $user->notify(new \App\Notifications\AchievementUnlocked($achievement));
-        }
     }
 
     /**
@@ -77,7 +87,9 @@ final class AchievementService
         $metrics = [];
 
         if ($types->contains('count')) {
-            $metrics['count'] = $user->workouts()->count();
+            // ⚡ Bolt: PERFORMANCE OPTIMIZATION
+            // Use toBase() to avoid hydrating Eloquent models just for a count.
+            $metrics['count'] = $user->workouts()->toBase()->count();
         }
 
         if ($types->contains('weight_record')) {
@@ -105,6 +117,9 @@ final class AchievementService
     {
         /** @var float|null $maxWeight */
         $maxWeight = $user->personalRecords()
+            // ⚡ Bolt: PERFORMANCE OPTIMIZATION
+            // Use toBase() to bypass Eloquent model hydration and overhead.
+            ->toBase()
             ->where('type', 'max_weight')
             ->max('value');
 

--- a/tests/Feature/Services/AchievementServiceTest.php
+++ b/tests/Feature/Services/AchievementServiceTest.php
@@ -213,3 +213,41 @@ test('it does not duplicate achievement assignments', function (): void {
 
     Notification::assertSentTimes(\App\Notifications\AchievementUnlocked::class, 1);
 });
+
+test('it awards multiple achievements at once', function (): void {
+    $user = User::factory()->create();
+
+    $achievement1 = Achievement::factory()->create([
+        'type' => 'count',
+        'threshold' => 1,
+        'slug' => 'first-workout',
+    ]);
+
+    $achievement2 = Achievement::factory()->create([
+        'type' => 'weight_record',
+        'threshold' => 100,
+        'slug' => 'heavy-lifter',
+    ]);
+
+    $workout = Workout::factory()->create(['user_id' => $user->id]);
+    $line = WorkoutLine::factory()->create(['workout_id' => $workout->id]);
+    Set::factory()->create([
+        'workout_line_id' => $line->id,
+        'weight' => 100,
+        'reps' => 1,
+    ]);
+
+    $this->service->syncAchievements($user);
+
+    assertDatabaseHas('user_achievements', [
+        'user_id' => $user->id,
+        'achievement_id' => $achievement1->id,
+    ]);
+
+    assertDatabaseHas('user_achievements', [
+        'user_id' => $user->id,
+        'achievement_id' => $achievement2->id,
+    ]);
+
+    Notification::assertSentTimes(\App\Notifications\AchievementUnlocked::class, 2);
+});


### PR DESCRIPTION
💡 **What:** Optimized the `syncAchievements` method in `AchievementService` to batch many-to-many relationship `attach()` calls. Also added `toBase()` to `count()` and `max()` queries.

🎯 **Why:** Individual `attach()` calls in a loop cause multiple database `INSERT` queries. Batching them into a single call reduces database roundtrips. `toBase()` reduces Eloquent overhead for simple aggregate values by bypassing model hydration and extra builder logic.

📊 **Impact:** Reduces database writes from O(N) to O(1) when multiple achievements are unlocked simultaneously (e.g., after syncing a heavy workout).

🔬 **Measurement:** Verified with a new test case in `AchievementServiceTest` that triggers multiple unlocks and confirms that all achievements are correctly persisted and notifications are dispatched.

---
*PR created automatically by Jules for task [1535083710472026500](https://jules.google.com/task/1535083710472026500) started by @kuasar-mknd*