### PR TITLE
🎨 Palette: Add keyboard focus states to dashboard links

### DIFF
--- a/resources/js/Components/Dashboard/ActiveWorkoutBanner.vue
+++ b/resources/js/Components/Dashboard/ActiveWorkoutBanner.vue
@@ -33,7 +33,7 @@ onUnmounted(() => {
     <Link
         v-press
         :href="route('workouts.show', { workout: workout.id })"
-        class="animate-fade-in group relative block overflow-hidden rounded-3xl border-2 border-emerald-400/40 transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl active:scale-[0.98]"
+        class="animate-fade-in group relative block overflow-hidden rounded-3xl border-2 border-emerald-400/40 transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 focus-visible:outline-none active:scale-[0.98]"
         dusk="active-workout-banner"
     >
         <!-- Animated gradient background -->

--- a/resources/js/Components/Dashboard/GoalsSummary.vue
+++ b/resources/js/Components/Dashboard/GoalsSummary.vue
@@ -12,13 +12,21 @@ defineProps({
     <section v-if="activeGoals.length > 0" class="animate-slide-up" style="animation-delay: 0.25s">
         <div class="mb-4 flex items-center justify-between px-1">
             <h3 class="text-text-muted text-xs font-black tracking-[0.2em] uppercase">Objectifs en cours</h3>
-            <Link :href="route('goals.index')" class="text-electric-orange text-xs font-bold tracking-wider uppercase">
+            <Link
+                :href="route('goals.index')"
+                class="text-electric-orange focus-visible:ring-electric-orange rounded-sm text-xs font-bold tracking-wider uppercase focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
                 Voir tout
             </Link>
         </div>
 
         <div class="space-y-3">
-            <Link v-for="goal in activeGoals" :key="goal.id" :href="route('goals.index')" class="block">
+            <Link
+                v-for="goal in activeGoals"
+                :key="goal.id"
+                :href="route('goals.index')"
+                class="focus-visible:ring-electric-orange block rounded-3xl focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
                 <GlassCard :hover="true" padding="p-4">
                     <div class="mb-2 flex items-center justify-between">
                         <span class="text-text-main line-clamp-1 text-sm font-bold">{{ goal.title }}</span>

--- a/resources/js/Components/Dashboard/RecentActivity.vue
+++ b/resources/js/Components/Dashboard/RecentActivity.vue
@@ -27,7 +27,7 @@ const colorForWorkout = (index) => {
             <h3 class="text-text-muted text-xs font-black tracking-[0.2em] uppercase">Activité Récente</h3>
             <Link
                 :href="route('workouts.index')"
-                class="text-electric-orange hover:text-vivid-violet text-xs font-bold tracking-wider uppercase transition-colors"
+                class="text-electric-orange hover:text-vivid-violet focus-visible:ring-electric-orange rounded-sm text-xs font-bold tracking-wider uppercase transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
             >
                 Voir tout
             </Link>
@@ -62,7 +62,7 @@ const colorForWorkout = (index) => {
                 :key="workout.id"
                 v-press
                 :href="route('workouts.show', { workout: workout.id })"
-                class="group relative flex items-center justify-between rounded-3xl border border-white/20 bg-white/10 p-4 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-lg active:scale-95"
+                class="group focus-visible:ring-electric-orange relative flex items-center justify-between rounded-3xl border border-white/20 bg-white/10 p-4 backdrop-blur-md transition-all duration-300 hover:-translate-y-1 hover:bg-white/20 hover:shadow-lg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-95"
             >
                 <!-- Color indicator -->
                 <div


### PR DESCRIPTION
💡 What: Added standard `focus-visible` CSS utilities (outline-none, ring-2, ring-offset-2, and color rings) to interactive `<Link>` elements across the dashboard components (ActiveWorkoutBanner, GoalsSummary, RecentActivity). Also appended `rounded` classes so the rings match the curvature of the components.
🎯 Why: Interactive components styled for visual appeal (like cards functioning as links) must remain usable for keyboard navigators. This provides a clear, high-contrast visual indicator when these links receive focus without interfering with mouse click styles.
♿ Accessibility: Improved keyboard navigation visibility by ensuring custom links mirror the focus outline behavior of standard system buttons.

---
*PR created automatically by Jules for task [16390310248121882932](https://jules.google.com/task/16390310248121882932) started by @kuasar-mknd*