### PR TITLE
fix(activity-log): journaliser les lignes de séance, dont le trait manquait

### DIFF
--- a/app/Models/WorkoutLine.php
+++ b/app/Models/WorkoutLine.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Services\RecommendedValuesService;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
 use Spatie\Activitylog\Support\LogOptions;
 
 /**
@@ -25,7 +26,7 @@ use Spatie\Activitylog\Support\LogOptions;
 class WorkoutLine extends Model
 {
     /** @use HasFactory<\Database\Factories\WorkoutLineFactory> */
-    use HasFactory;
+    use HasFactory, LogsActivity;
 
     #[\Override]
     protected $fillable = [

--- a/tests/Feature/WorkoutLineActivityLogTest.php
+++ b/tests/Feature/WorkoutLineActivityLogTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Exercise;
+use App\Models\WorkoutLine;
+use Spatie\Activitylog\Models\Activity;
+
+/**
+ * WorkoutLine declared getActivitylogOptions() without using the LogsActivity
+ * trait, so the options were never read and a session's exercises went
+ * unaudited while the workout around them was logged. These cover the write
+ * path the trait turns on; remove it and all three fail.
+ *
+ * Scoped to the subject, because creating a line creates a Workout and an
+ * Exercise through the factories, and both of those are logged too.
+ *
+ * @return \Illuminate\Database\Eloquent\Builder<\Spatie\Activitylog\Models\Activity>
+ */
+function activitiesFor(WorkoutLine $line): \Illuminate\Database\Eloquent\Builder
+{
+    return Activity::query()
+        ->where('subject_type', $line->getMorphClass())
+        ->where('subject_id', $line->getKey());
+}
+
+it('records a workout line change in the column v5 reads', function (): void {
+    $line = WorkoutLine::factory()->create(['order' => 1, 'notes' => null]);
+
+    $line->update(['order' => 2, 'notes' => 'Dernière série en échec']);
+
+    $activity = activitiesFor($line)->where('event', 'updated')->sole();
+
+    expect($activity->attribute_changes['attributes'])->toMatchArray([
+        'order' => 2,
+        'notes' => 'Dernière série en échec',
+    ])->and($activity->attribute_changes['old'])->toMatchArray([
+        'order' => 1,
+        'notes' => null,
+    ]);
+});
+
+/**
+ * logOnly() names 'exercise.name', not a column — the only entry in this app's
+ * options that resolves through a relation rather than off the model.
+ */
+it('resolves the exercise name through the relation when logging', function (): void {
+    $exercise = Exercise::factory()->create(['name' => 'Développé couché']);
+
+    $line = WorkoutLine::factory()->create(['exercise_id' => $exercise->id]);
+
+    $activity = activitiesFor($line)->where('event', 'created')->sole();
+
+    expect($activity->attribute_changes['attributes']['exercise.name'])->toBe('Développé couché');
+});
+
+/**
+ * logOnlyDirty + dontLogEmptyChanges: idempotency_key is outside logOnly, so
+ * writing it fires `updated` with nothing to record and must leave no row.
+ */
+it('does not log a change to an attribute outside logOnly', function (): void {
+    $line = WorkoutLine::factory()->create();
+
+    // Anchored on the create, so this still fails if logging stops altogether.
+    expect(activitiesFor($line)->count())->toBe(1);
+
+    $line->idempotency_key = 'replayed-create-attempt';
+    $line->save();
+
+    expect(activitiesFor($line)->count())->toBe(1);
+});


### PR DESCRIPTION
## Description

`WorkoutLine` déclarait `getActivitylogOptions()` sans utiliser le trait `LogsActivity`. La méthode n'était donc jamais appelée et **aucune ligne d'activité n'a jamais été écrite pour une ligne de séance** : ajouter ou retirer un exercice d'une séance, le réordonner ou l'annoter ne laissait aucune trace, alors que le `Workout` qui la contient — comme `Goal`, `Supplement`, `User`, `Achievement`, `Exercise` et `Admin` — journalise normalement.

Sur les huit modèles qui déclarent ces options, c'était le seul sans le trait.

Le passage à activitylog v5 (#1334) a renommé le contenu de la méthode sans jamais l'appeler — `LogOptions` vers `Support\`, `dontSubmitEmptyLogs()` vers `dontLogEmptyChanges()` — ce qui donne l'apparence d'une configuration vivante et entretenue.

**Journalisé plutôt que supprimé**, parce que le `Workout` parent l'est : dire qu'une séance a changé en taisant les exercices qu'elle a gagnés ou perdus ne décrit que la moitié d'une modification. La liste des champs — `exercise.name`, `order`, `notes` — est assez précise pour relever de l'intention et non d'un reste d'échafaudage.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Manual Verification

1. Suite complète sur la base fusionnée : **1522 passed** (1519 sur `main` seul + les 3 nouveaux).
2. Trait retiré → les 3 tests échouent ; remis → ils passent. Le test vérifie donc bien le correctif.
3. `pint` et `phpstan` (Larastan, niveau du projet) : aucune erreur.

## Performance Impact

Une ligne `activity_log` par création, modification et suppression de `WorkoutLine`, plus la requête `exercises` qui résout `exercise.name` à travers la relation.

C'est par exercice d'une séance — de l'ordre de cinq à huit — et non par série : `Set`, qui change à chaque répétition enregistrée, reste non journalisé.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

`ActivityLogUpgradeTest` couvrait le chemin d'écriture via `Exercise` ; rien ne cherchait de ligne pour `WorkoutLine`. Les trois nouveaux tests le font, dont l'attribut de relation — la seule entrée des `logOnly()` de l'application qui se résout à travers une relation plutôt que sur le modèle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
