### PR TITLE
fix(goals): retirer la route goals.show, qui répondait 500

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,10 @@ Route::middleware('auth')->group(function (): void {
 
     Route::resource('supplements', \App\Http\Controllers\SupplementController::class)->only(['index']);
     Route::resource('habits', \App\Http\Controllers\HabitController::class)->only(['index']);
-    Route::resource('goals', \App\Http\Controllers\GoalController::class)->only(['index', 'show']);
+    // 'show' is excluded for the same reason as 'create' below: there is no
+    // Goals/Show page and GoalController has no show() method, so the generated
+    // route answered 500. Goals are consulted from the index.
+    Route::resource('goals', \App\Http\Controllers\GoalController::class)->only(['index']);
     Route::resource('templates', \App\Http\Controllers\WorkoutTemplateController::class)->only(['index', 'show', 'create', 'edit']);
     Route::resource('exercises', \App\Http\Controllers\ExerciseController::class)->only(['index', 'show']);
     Route::resource('body-measurements', \App\Http\Controllers\BodyMeasurementController::class)->only(['index']);

--- a/tests/Unit/RouteIntegrityTest.php
+++ b/tests/Unit/RouteIntegrityTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Resolve the controller class and method a route dispatches to.
+ *
+ * @return array{0: string, 1: string}|null Null when the route is not backed by a first-party controller.
+ */
+function firstPartyControllerTarget(string $action): ?array
+{
+    if (! str_starts_with($action, 'App\\')) {
+        return null;
+    }
+
+    // Invokable controllers are reported without the "@method" suffix.
+    return str_contains($action, '@')
+        ? explode('@', $action, 2)
+        : [$action, '__invoke'];
+}
+
+it('dispatches every route to a controller method that exists', function (): void {
+    $broken = [];
+
+    foreach (Route::getRoutes() as $route) {
+        $target = firstPartyControllerTarget($route->getActionName());
+
+        if ($target === null) {
+            continue;
+        }
+
+        [$class, $method] = $target;
+
+        if (! class_exists($class)) {
+            $broken[] = sprintf('%s (%s) → classe %s introuvable', $route->uri(), $route->getName() ?? '-', $class);
+
+            continue;
+        }
+
+        // Livewire/Filament page classes are routed on the class alone and handle
+        // dispatch internally, so they legitimately have no __invoke.
+        if ($method === '__invoke' && is_subclass_of($class, Livewire\Component::class)) {
+            continue;
+        }
+
+        if (! method_exists($class, $method)) {
+            $broken[] = sprintf('%s (%s) → %s::%s() n\'existe pas', $route->uri(), $route->getName() ?? '-', $class, $method);
+        }
+    }
+
+    expect($broken)->toBe([]);
+});


### PR DESCRIPTION
Corrige #1338.

## Le bug

`GET /goals/{goal}` renvoyait une **HTTP 500** pour tout utilisateur authentifié.

```php
// routes/web.php:27 (avant)
Route::resource('goals', GoalController::class)->only(['index', 'show']);
```

`GoalController` expose `index`, `edit`, `store`, `update`, `destroy` — **pas de `show()`**. C'était la seule action cassée sur les 280 méthodes routées de l'application.

## Pourquoi retirer plutôt qu'implémenter

La route n'était utilisée par personne :

- pas de page `resources/js/Pages/Goals/Show.vue` (seulement `Index.vue` et `Edit.vue`)
- aucun appel `route('goals.show')` dans le front

Implémenter une page de détail dont aucun écran n'a besoin serait ajouter du code à maintenir pour rétablir une route morte. Elle est donc retirée.

À noter : **le même arbitrage avait déjà été fait pour `create`** dix lignes plus bas, avec exactement le même motif documenté en commentaire (« la route générée pointait vers une méthode de contrôleur inexistante »). `show` avait simplement été manqué au passage.

Les autres routes `goals` sont inchangées — `goals.edit`, utilisée par `tests/Browser/GoalManagementTest.php`, est toujours là :

```
GET     goals                goals.index
POST    goals                goals.store
PUT     goals/{goal}         goals.update
DELETE  goals/{goal}         goals.destroy
GET     goals/{goal}/edit    goals.edit
```

## Le test est la vraie valeur de cette PR

Le correctif fait une ligne. Ce qui compte, c'est `tests/Unit/RouteIntegrityTest.php` : il parcourt **toutes** les routes enregistrées et vérifie que chaque action pointe vers une classe et une méthode de contrôleur qui existent.

C'est ce qui empêche la classe entière de bugs de revenir — et c'est nécessaire, puisqu'elle s'est déjà produite deux fois sur la même ressource.

Vérifié dans les deux sens :

- **sur le code d'avant** : échoue, en signalant précisément `goals/{goal} (goals.show) → App\Http\Controllers\GoalController::show() n'existe pas`
- **sur le code d'après** : passe, **sans aucun faux positif** sur les 325 routes (vendor et Filament compris)

Le test se limite aux contrôleurs `App\` — on ne contrôle pas les routes de vendor, et les inclure exposerait le gate à leur évolution. Les composants Livewire/Filament, routés sur la classe seule, sont exclus explicitement puisqu'ils gèrent leur dispatch en interne.

## Pourquoi ça n'avait pas été vu

Aucun des 1510 tests ne visitait cette route, et la couverture (84 %) ne dit rien de la cohérence routes ↔ contrôleurs. C'est ce constat qui a motivé l'audit de #1318.

## Vérifications

| | |
|---|---|
| Suite backend complète | **1523 passés** (5501 assertions) — 1522 avant, +1 nouveau test |
| Pint | passé |
| PHPStan (level 9) | aucune erreur |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
