### PR TITLE
fix(env): documenter les variables manquantes qui cassaient push et Sentry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ APP_DEBUGBAR_ENABLED=false
 SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=1.0
 SENTRY_PROFILES_SAMPLE_RATE=1.0
+# Frontend DSN, read by resources/js/main.js. Distinct from SENTRY_DSN (backend):
+# it is inlined into the bundle at build time, so it must be a public-facing DSN.
+# Left empty, Sentry.init is skipped and no JS error is ever reported.
+VITE_SENTRY_DSN_PUBLIC=
 APP_URL=http://localhost
  
 # Admin Dashboard Security
@@ -95,6 +99,9 @@ OCTANE_SERVER=frankenphp
 # Run: npx web-push generate-vapid-keys
 VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
+# Identifies the sender to the push service. Must be a "mailto:" address or a
+# URL; web-push throws when it is missing. Defaults to APP_URL when left empty.
+VAPID_SUBJECT=
 
 # Database - Enlightn required vars
 DB_HOST=127.0.0.1

--- a/config/webpush.php
+++ b/config/webpush.php
@@ -7,7 +7,9 @@ return [
      * These keys must be safely stored and should not change.
      */
     'vapid' => [
-        'subject' => env('VAPID_SUBJECT'),
+        // web-push throws when the subject is missing (VAPID.php:49), so fall
+        // back to the app URL rather than let every push notification fail.
+        'subject' => env('VAPID_SUBJECT') ?: env('APP_URL'),
         'public_key' => env('VAPID_PUBLIC_KEY'),
         'private_key' => env('VAPID_PRIVATE_KEY'),
         'pem_file' => env('VAPID_PEM_FILE'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
                 "vite-plugin-pwa": "^1.3.0",
                 "vitest": "^4.1.10",
                 "vue": "^3.5.41",
+                "workbox-core": "^7.4.1",
                 "workbox-precaching": "^7.4.1",
                 "workbox-routing": "^7.4.1",
                 "workbox-strategies": "^7.4.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "vite-plugin-pwa": "^1.3.0",
         "vitest": "^4.1.10",
         "vue": "^3.5.41",
+        "workbox-core": "^7.4.1",
         "workbox-precaching": "^7.4.1",
         "workbox-routing": "^7.4.1",
         "workbox-strategies": "^7.4.1",

--- a/tests/Unit/EnvironmentTemplateTest.php
+++ b/tests/Unit/EnvironmentTemplateTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Finder\Finder;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Environment variable names declared in .env.example, commented-out ones included.
+ *
+ * @return list<string>
+ */
+function declaredInEnvExample(): array
+{
+    $contents = (string) file_get_contents(base_path('.env.example'));
+
+    preg_match_all('/^\s*#?\s*([A-Z][A-Z0-9_]*)=/m', $contents, $matches);
+
+    return array_values(array_unique($matches[1]));
+}
+
+it('declares every VITE_ variable the frontend reads in .env.example', function (): void {
+    $files = Finder::create()
+        ->files()
+        ->in(resource_path('js'))
+        ->name(['*.js', '*.vue']);
+
+    $referenced = [];
+
+    foreach ($files as $file) {
+        preg_match_all('/import\.meta\.env\.(VITE_[A-Z0-9_]*)/', $file->getContents(), $matches);
+
+        foreach ($matches[1] as $variable) {
+            $referenced[$variable][] = $file->getRelativePathname();
+        }
+    }
+
+    // Vite inlines these at build time: a variable absent from the template is
+    // simply undefined, so the feature behind it is silently skipped rather
+    // than failing loudly. That is how frontend Sentry stayed dark.
+    $undeclared = array_diff_key($referenced, array_flip(declaredInEnvExample()));
+
+    expect($undeclared)->toBe([]);
+});
+
+it('resolves a VAPID subject even when the variable is unset', function (): void {
+    // minishlink/web-push throws "[VAPID] You must provide a subject" when this
+    // is null, which fails every push notification at send time.
+    expect(config('webpush.vapid.subject'))->not->toBeEmpty();
+});
+
+it('documents the VAPID keys push notifications require', function (string $variable): void {
+    expect(declaredInEnvExample())->toContain($variable);
+})->with(['VAPID_SUBJECT', 'VAPID_PUBLIC_KEY', 'VAPID_PRIVATE_KEY']);


### PR DESCRIPTION
Corrige #1343.

Trois variables d'environnement lues par le code mais absentes de `.env.example`. Tout environnement provisionné depuis le template hérite donc de trois pannes silencieuses.

## 1. `VAPID_SUBJECT` — les notifications push lèvent une exception

Le plus grave des trois, et plus grave que « il manque un défaut » :

```php
// vendor/minishlink/web-push/src/VAPID.php:49
if (!isset($vapid['subject'])) {
    throw new \ErrorException('[VAPID] You must provide a subject that is either a mailto: or a URL.');
}
```

`config/webpush.php` lisait `env('VAPID_SUBJECT')` sans défaut, et la variable n'était pas dans `.env.example` — alors que `VAPID_PUBLIC_KEY` et `VAPID_PRIVATE_KEY` y étaient toutes les deux. Résultat : **chaque envoi de notification push échoue à l'exécution**.

Corrigé des deux côtés : la variable est documentée dans le template, et la config retombe sur `APP_URL` (la lib accepte « a mailto: or a URL ») plutôt que de laisser passer un `null`.

## 2. `VITE_SENTRY_DSN_PUBLIC` — Sentry front n'a jamais tourné

```js
// resources/js/main.js:64
if (import.meta.env.VITE_SENTRY_DSN_PUBLIC) { Sentry.init({ ... }) }
```

La variable n'apparaissait nulle part dans `.env.example`. `@sentry/vue` est installé, configuré avec un tracing et un replay complets — et le garde n'a jamais été franchi. **Aucune erreur front n'a jamais été remontée.**

C'est le pire type de panne : on croit avoir du monitoring. `SENTRY_DSN` (backend) existait bien dans le template, ce qui rendait l'absence de son pendant front d'autant plus difficile à remarquer.

À noter : la variable reste **vide** dans le template — on ne commite pas un DSN. Ce qui est corrigé, c'est qu'elle était *indécouvrable*.

## 3. `workbox-core` — importé sans être déclaré

```js
// resources/js/sw.js:1
import { clientsClaim } from 'workbox-core'
```

Absent de `package.json`. Il ne résolvait qu'en transitif via `workbox-precaching`. Le jour où cette transitive disparaît, le service worker casse au build. Déclaré explicitement, à la même version que ses trois voisins `workbox-*`.

`package-lock.json` a été régénéré **sous node 24 / npm 11** (la version de la CI, pas le npm 10 local) pour éviter tout écart de format : `lockfileVersion` reste à 3, une seule ligne ajoutée.

## Les tests

`tests/Unit/EnvironmentTemplateTest.php` couvre les trois, et surtout généralise le premier cas :

- **toute variable `VITE_*` lue dans `resources/js` doit être déclarée dans `.env.example`.** C'est la règle qui empêche un second Sentry-fantôme : une variable Vite absente n'est pas une erreur, elle est juste `undefined`, donc la fonctionnalité derrière est sautée en silence.
- le sujet VAPID résout à une valeur non vide même variable non définie
- les trois clés VAPID sont documentées dans le template

Vérifié dans les deux sens : sur le code d'avant, **3 des 5 échouent** (les 2 qui passent sont `VAPID_PUBLIC_KEY` et `VAPID_PRIVATE_KEY`, déjà documentées) ; après, les 5 passent.

### Sur la règle plus large

J'ai d'abord essayé la version balayante — « tout `env()` sans défaut doit être dans `.env.example` ». Elle remonte **49 variables**, presque toutes issues des configs Laravel d'origine (`cache.php`, `logging.php`, `mail.php`, `queue.php`, `database.php`…) où référencer des variables optionnelles est le fonctionnement normal du framework. Un gate là-dessus serait du bruit permanent, donc écarté au profit des deux règles ci-dessus, précises et sans faux positif.

## Vérifications

| | |
|---|---|
| Suite backend | **1527 passés** (5505 assertions) — 1522 de base, +5 nouveaux tests |
| Tests JS | 258 passés (25 fichiers) |
| `npm run build` | OK — 137 entrées précachées |
| `npm run lint:js` | OK |
| Pint | passé |
| PHPStan (level 9) | aucune erreur |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
