### PR TITLE
perf(tests): réparer les tests parallèles, cassés par un grant MySQL manquant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,15 @@ jobs:
                   cp .env.example .env
                   php artisan key:generate
 
+            # The service container grants `sail` access to gym_tracker_testing only.
+            # Paratest creates one shard database per process, so the user also needs
+            # rights over the gym_tracker_testing_test_N pattern or every Feature test
+            # fails with access denied. Underscores are GRANT wildcards, hence escaped.
+            - name: Grant Paratest Shard Databases
+              run: |
+                  # shellcheck disable=SC2016 # the backticks are MySQL identifier quotes, not a subshell
+                  php -r '(new PDO("mysql:host=127.0.0.1;port=3306", "root", "password"))->exec("GRANT ALL PRIVILEGES ON `gym\\_tracker\\_testing\\_test\\_%`.* TO \"sail\"@\"%\"");'
+
             - name: Execute tests
               env:
                   DB_CONNECTION: mysql
@@ -132,7 +141,7 @@ jobs:
                   DB_USERNAME: sail
                   DB_PASSWORD: password
                   TELESCOPE_ENABLED: false
-              run: php artisan test
+              run: php artisan test -p
 
     browser-tests:
         runs-on: ubuntu-latest

--- a/compose.yaml
+++ b/compose.yaml
@@ -41,6 +41,7 @@ services:
         volumes:
             - 'sail-mysql:/var/lib/mysql'
             - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+            - './docker/mysql/create-parallel-testing-databases.sh:/docker-entrypoint-initdb.d/20-create-parallel-testing-databases.sh'
         networks:
             - sail
         healthcheck:

--- a/docker/mysql/create-parallel-testing-databases.sh
+++ b/docker/mysql/create-parallel-testing-databases.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Sail ships create-testing-database.sh, which grants the application user
+# ALL PRIVILEGES ON `testing%`. That covers Sail's default test database name,
+# but this project uses `gym_tracker_testing` (see phpunit.xml), so the pattern
+# never matched and Paratest could not create its per-process shard databases
+# (`gym_tracker_testing_test_1`, `_test_2`, …). Every Feature test failed
+# instantly under `artisan test -p` with an access-denied error.
+#
+# Underscores are wildcards in GRANT patterns, hence the escaping: the grant is
+# restricted to the shard databases and nothing else.
+
+if [ -n "$MYSQL_USER" ]; then
+    mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
+        GRANT ALL PRIVILEGES ON \`gym\_tracker\_testing\_test\_%\`.* TO '$MYSQL_USER'@'%';
+	EOSQL
+fi

--- a/tests/Feature/Security/PasswordUpdateRateLimitTest.php
+++ b/tests/Feature/Security/PasswordUpdateRateLimitTest.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace Tests\Feature\Security;
 
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\RateLimiter;
 use Tests\TestCase;
 
 class PasswordUpdateRateLimitTest extends TestCase
 {
+    // tests/Pest.php applies RefreshDatabase through pest()->use(...)->in('Feature'),
+    // which only covers Pest files — not classic PHPUnit classes like this one. The
+    // class ran green anyway because sequential runs left a migrated database behind;
+    // under `test -p` each process gets its own database and the schema was missing.
+    use RefreshDatabase;
+
     public function test_password_update_is_rate_limited(): void
     {
         $user = User::factory()->create([

--- a/tests/Unit/FeatureTestIsolationTest.php
+++ b/tests/Unit/FeatureTestIsolationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Finder\Finder;
+
+uses(Tests\TestCase::class);
+
+it('gives every database-touching PHPUnit class in tests/Feature its own database', function (): void {
+    $files = Finder::create()
+        ->files()
+        ->in(base_path('tests/Feature'))
+        ->name('*.php');
+
+    $unisolated = [];
+
+    foreach ($files as $file) {
+        $source = $file->getContents();
+
+        // tests/Pest.php wires RefreshDatabase with pest()->use(...)->in('Feature'),
+        // which reaches Pest files only. Classic PHPUnit classes are skipped silently,
+        // and a sequential run hides it: they inherit the schema another test migrated.
+        // Under `artisan test -p` each process gets its own database and they break.
+        if (! preg_match('/^class \w+ extends TestCase$/m', $source)) {
+            continue;
+        }
+
+        $touchesDatabase = preg_match('/::factory\(\)|->create\(|actingAs\(/', $source) === 1;
+
+        if ($touchesDatabase && ! str_contains($source, 'use RefreshDatabase;')) {
+            $unisolated[] = $file->getRelativePathname();
+        }
+    }
+
+    expect($unisolated)->toBe([]);
+});


### PR DESCRIPTION
Corrige #1345.

## La cause racine

`php artisan test -p` échouait sur **1475 tests instantanément**. Ce n'était pas un problème de conception des tests, mais un motif de grant qui ne correspond plus.

Sail monte son propre script d'init, qui accorde :

```sql
GRANT ALL PRIVILEGES ON `testing%`.* TO 'sail'@'%';
```

Ce motif couvre le nom de base de test **par défaut de Sail**. Or ce projet a renommé la sienne en `gym_tracker_testing` (`phpunit.xml`). Les bases de shard que Paratest crée — `gym_tracker_testing_test_1`, `_test_2`, … — ne correspondent donc à aucun grant.

Les droits réels de l'utilisateur, avant correctif :

```
GRANT ALL PRIVILEGES ON `gym_tracker_testing`.* TO `sail`@`%`   ← la base seule, sans joker
GRANT ALL PRIVILEGES ON `testing%`.*            TO `sail`@`%`   ← le motif Sail, hors sujet ici
```

Rien ne couvrait les shards. Chaque processus Paratest se heurtait à un accès refusé dès la création de sa base.

## Le correctif

**En local** : `docker/mysql/create-parallel-testing-databases.sh`, monté en `20-` juste après le `10-` de Sail, accorde les droits sur le motif des shards.

**En CI** : le service MySQL de GitHub Actions ne joue aucun script d'init, donc le grant est appliqué par une étape dédiée avant les tests. Elle passe par PHP + PDO plutôt que par un client `mysql`, parce que le job dispose déjà de PHP avec `pdo_mysql` — aucune dépendance nouvelle, aucune hypothèse sur ce que l'image du runner contient.

Les underscores étant des **jokers** dans un `GRANT`, ils sont échappés : la portée reste strictement limitée aux bases de shard, elle ne déborde pas sur d'autres schémas.

Le job `laravel-tests` passe ensuite à `php artisan test -p`.

## Le gain, mesuré des deux côtés

**En local** (10 processus), suite complète, à nombre de tests et d'assertions identiques :

| | Durée |
|---|---|
| `artisan test` (séquentiel) | 91,73 s |
| `artisan test -p` | **21,45 s** |

**En CI**, job `laravel-tests` de bout en bout, relevé sur des PR réelles :

| | Durée |
|---|---|
| séquentiel (#1348, #1349) | 1m58s, 2m12s |
| parallèle (cette PR) | **1m18s** |

Soit **~1,6× en CI**, nettement moins que le 4,3× local : les runners GitHub ont bien moins de cœurs, et la durée du job inclut une part fixe (checkout, setup PHP, restauration du vendor, téléchargement des artefacts) que le parallélisme ne touche pas.

**À noter, pour ne pas survendre :** le chemin critique de la CI reste `browser-tests` (~6-7 min), donc cette PR ne réduit pas la durée totale d'un run. Ses deux vrais bénéfices sont ailleurs :

1. **Le confort local** — 92 s → 21 s change la façon dont on lance la suite pendant qu'on développe.
2. **Le déblocage du mutation testing de #1318.** Chaque mutant relance la suite ; sans parallélisme le coût était rédhibitoire. C'était le premier des bloqueurs qui rendaient Infection irréalisable.

## Un second bug, révélé par la CI

La première version de cette PR a été **rejetée par la CI**, et à juste titre. Le grant fonctionnait ; deux tests échouaient sur `Table 'gym_tracker_testing.users' doesn't exist` — en visant la base **par défaut**, pas leur shard.

`tests/Pest.php` applique `RefreshDatabase` ainsi :

```php
pest()->extend(TestCase::class)->use(RefreshDatabase::class)->in('Feature');
```

Cela ne couvre **que les fichiers Pest**. `PasswordUpdateRateLimitTest` est une classe PHPUnit classique (`class … extends TestCase`) : elle n'a jamais reçu `RefreshDatabase`. En séquentiel elle passait par accident, en héritant du schéma qu'un autre test avait migré dans la base par défaut. En parallèle, chaque processus a la sienne — et le schéma n'y était pas.

Sur les 57 classes PHPUnit de `tests/Feature`, **3 seulement** n'avaient pas `RefreshDatabase`. Les deux autres (`CustomPolicyTest`, `PasswordPolicyTest`) ne touchent pas la base : elles n'en ont légitimement pas besoin.

`tests/Unit/FeatureTestIsolationTest.php` ferme la porte : toute classe PHPUnit de `tests/Feature` qui crée des modèles doit déclarer `RefreshDatabase`. Vérifié dans les deux sens — en retirant le correctif, il échoue en nommant précisément `Security/PasswordUpdateRateLimitTest.php`.

## ⚠️ Ma première vérification locale était un faux vert

Elle mérite d'être signalée, parce que c'est le piège de ce genre de correctif : en local, la base par défaut était **déjà migrée** par mes exécutions séquentielles antérieures, donc le test trouvait ses tables. La CI part d'une base vierge et l'a vu tout de suite.

Revérifié depuis une base vidée, dans les conditions de la CI : **1523 passés en 21,45 s** sur 10 processus.

## Vérifications

- **Volume vierge** : conteneur `mysql:8.4` neuf avec les deux scripts d'init montés → le grant des shards est présent, et l'utilisateur `sail` crée puis supprime `gym_tracker_testing_test_3` sans erreur. C'est le chemin que suivra un nouveau poste.
- **Snippet CI** : exécuté tel quel contre le MySQL du projet, après avoir révoqué le grant pour repartir à blanc. Réapplique correctement.
- **Suite parallèle, base par défaut vidée au préalable** : 1523 passés (5501 assertions) en 21,45 s.
- **actionlint** : les workflows en comptent 3 findings préexistants (documentés dans #1318 item 4) ; **cette PR n'en ajoute aucun**. Le `# shellcheck disable=SC2016` sur la nouvelle étape est délibéré et commenté — les backticks sont des quotes d'identifiant MySQL, pas une substitution shell.
- Pint et PHPStan : verts.

## ⚠️ Pour les postes existants

Les scripts de `docker-entrypoint-initdb.d` **ne s'exécutent que sur un volume de données vide**. Un poste dont le volume `sail-mysql` existe déjà ne recevra pas le grant au simple `git pull` — il faut l'appliquer une fois à la main :

```bash
docker exec gym-tracker-mysql-1 mysql -uroot -ppassword \
  -e "GRANT ALL PRIVILEGES ON \`gym\_tracker\_testing\_test\_%\`.* TO 'sail'@'%';"
```

Sans quoi `artisan test -p` continuera d'échouer en local, alors qu'il passera en CI.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
