### PR TITLE
fix(security): empêcher un admin d'agir sur l'utilisateur portant son id

### DIFF
--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -12,6 +12,19 @@ final class UserPolicy
 {
     use HandlesAuthorization;
 
+    /**
+     * Whether the authenticated identity is the very user being acted upon.
+     *
+     * The instanceof check is load-bearing: the back-office authenticates
+     * App\Models\Admin on the "admin" guard, a separate table with its own id
+     * sequence. Comparing identifiers alone let an admin holding no permission
+     * act on the User that happened to share their id.
+     */
+    private function isSelf(AuthUser $authUser, User $user): bool
+    {
+        return $authUser instanceof User && $authUser->getKey() === $user->getKey();
+    }
+
     public function viewAny(AuthUser $authUser): bool
     {
         return $authUser->can('ViewAny:User');
@@ -19,7 +32,7 @@ final class UserPolicy
 
     public function view(AuthUser $authUser, User $user): bool
     {
-        return $authUser->getAuthIdentifier() === $user->getAuthIdentifier() || $authUser->can('View:User');
+        return $this->isSelf($authUser, $user) || $authUser->can('View:User');
     }
 
     public function create(AuthUser $authUser): bool
@@ -29,22 +42,22 @@ final class UserPolicy
 
     public function update(AuthUser $authUser, User $user): bool
     {
-        return $authUser->getAuthIdentifier() === $user->getAuthIdentifier() || $authUser->can('Update:User');
+        return $this->isSelf($authUser, $user) || $authUser->can('Update:User');
     }
 
     public function delete(AuthUser $authUser, User $user): bool
     {
-        return $authUser->getAuthIdentifier() === $user->getAuthIdentifier() || $authUser->can('Delete:User');
+        return $this->isSelf($authUser, $user) || $authUser->can('Delete:User');
     }
 
     public function restore(AuthUser $authUser, User $user): bool
     {
-        return $authUser->getAuthIdentifier() === $user->getAuthIdentifier() || $authUser->can('Restore:User');
+        return $this->isSelf($authUser, $user) || $authUser->can('Restore:User');
     }
 
     public function forceDelete(AuthUser $authUser, User $user): bool
     {
-        return $authUser->getAuthIdentifier() === $user->getAuthIdentifier() || $authUser->can('ForceDelete:User');
+        return $this->isSelf($authUser, $user) || $authUser->can('ForceDelete:User');
     }
 
     public function forceDeleteAny(AuthUser $authUser): bool
@@ -59,7 +72,7 @@ final class UserPolicy
 
     public function replicate(AuthUser $authUser, User $user): bool
     {
-        return $authUser->getAuthIdentifier() === $user->getAuthIdentifier() || $authUser->can('Replicate:User');
+        return $this->isSelf($authUser, $user) || $authUser->can('Replicate:User');
     }
 
     public function reorder(AuthUser $authUser): bool

--- a/tests/Feature/Security/UserPolicyCrossGuardTest.php
+++ b/tests/Feature/Security/UserPolicyCrossGuardTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Admin;
+use App\Models\User;
+use App\Policies\UserPolicy;
+
+/**
+ * The back-office authenticates App\Models\Admin on the "admin" guard, a table
+ * with its own id sequence. UserPolicy used to compare getAuthIdentifier()
+ * without checking the type, so an Admin holding no permission whatsoever was
+ * granted view/update/delete/restore/forceDelete/replicate over the User that
+ * happened to share their id — and admin ids being small integers, that meant
+ * the earliest registered users.
+ *
+ * The five sibling policies reachable from the panel (Workout, Goal, Exercise,
+ * Achievement, Supplement) all guard with `instanceof User`; UserPolicy was the
+ * only one that did not.
+ */
+it('denies an admin every self-granted right over the user sharing its id', function (string $ability): void {
+    $admin = Admin::factory()->create();
+    $user = User::factory()->create(['id' => $admin->getKey()]);
+
+    expect($user->getKey())->toBe($admin->getKey())
+        ->and((new UserPolicy())->{$ability}($admin, $user))->toBeFalse();
+})->with(['view', 'update', 'delete', 'restore', 'forceDelete', 'replicate']);
+
+it('still lets a user act on their own record', function (string $ability): void {
+    $user = User::factory()->create();
+
+    expect((new UserPolicy())->{$ability}($user, $user))->toBeTrue();
+})->with(['view', 'update', 'delete', 'restore', 'forceDelete', 'replicate']);
+
+it('still denies a user acting on somebody else', function (string $ability): void {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    expect((new UserPolicy())->{$ability}($user, $other))->toBeFalse();
+})->with(['view', 'update', 'delete', 'restore', 'forceDelete', 'replicate']);

--- a/tests/Feature/Security/UserPolicyCrossGuardTest.php
+++ b/tests/Feature/Security/UserPolicyCrossGuardTest.php
@@ -22,19 +22,25 @@ it('denies an admin every self-granted right over the user sharing its id', func
     $admin = Admin::factory()->create();
     $user = User::factory()->create(['id' => $admin->getKey()]);
 
+    $policy = new UserPolicy();
+
     expect($user->getKey())->toBe($admin->getKey())
-        ->and((new UserPolicy())->{$ability}($admin, $user))->toBeFalse();
+        ->and($policy->{$ability}($admin, $user))->toBeFalse();
 })->with(['view', 'update', 'delete', 'restore', 'forceDelete', 'replicate']);
 
 it('still lets a user act on their own record', function (string $ability): void {
     $user = User::factory()->create();
 
-    expect((new UserPolicy())->{$ability}($user, $user))->toBeTrue();
+    $policy = new UserPolicy();
+
+    expect($policy->{$ability}($user, $user))->toBeTrue();
 })->with(['view', 'update', 'delete', 'restore', 'forceDelete', 'replicate']);
 
 it('still denies a user acting on somebody else', function (string $ability): void {
     $user = User::factory()->create();
     $other = User::factory()->create();
 
-    expect((new UserPolicy())->{$ability}($user, $other))->toBeFalse();
+    $policy = new UserPolicy();
+
+    expect($policy->{$ability}($user, $other))->toBeFalse();
 })->with(['view', 'update', 'delete', 'restore', 'forceDelete', 'replicate']);


### PR DESCRIPTION
Trouvé en écrivant les tests de couverture Filament de #1346.

## Le défaut

`UserPolicy` comparait les identités ainsi :

```php
return $authUser->getAuthIdentifier() === $user->getAuthIdentifier() || $authUser->can('View:User');
```

Sans vérification de type. Or le back-office authentifie un `App\Models\Admin` sur le guard `admin` — **une table distincte, avec sa propre séquence d'id**. La comparaison est donc vraie dès que les deux entiers coïncident, alors qu'ils désignent deux entités sans rapport.

Conséquence : un admin **ne détenant aucune permission** se voyait accorder `view`, `update`, `delete`, `restore`, `forceDelete` et `replicate` sur l'utilisateur portant le même id que lui. Les id d'admins étant de petits entiers, cela visait les premiers inscrits.

Six méthodes concernées, pas une.

## Pourquoi ce correctif et pas un autre

Ce n'est pas un motif à inventer : **les cinq policies sœurs atteignables depuis le panel le font déjà correctement.**

```php
// app/Policies/WorkoutPolicy.php, et idem Goal, Exercise, Achievement, Supplement
if ($authUser instanceof \App\Models\User) {
    return $authUser->id === $workout->user_id;
}
```

`UserPolicy` était **la seule** à ne pas garder sa comparaison derrière un `instanceof`. Le correctif l'aligne sur la convention existante, via un helper privé `isSelf()` partagé par les six méthodes plutôt que six `instanceof` recopiés.

J'ai vérifié l'ensemble du répertoire : `getAuthIdentifier()` n'apparaît plus nulle part dans `app/`, et aucune autre policy ne compare des identités sans garde de type.

## Le test, vérifié dans les deux sens

`tests/Feature/Security/UserPolicyCrossGuardTest.php` couvre trois cas, chacun sur les six méthodes :

1. un admin **ne peut pas** agir sur l'utilisateur qui partage son id ;
2. un utilisateur **peut** toujours agir sur son propre enregistrement ;
3. un utilisateur **ne peut pas** agir sur autrui.

Le point qui compte : sur le code d'avant, **exactement 6 tests échouent** — un par méthode vulnérable — pendant que les **12 assertions de comportement légitime restent vertes**. Le test isole la faille sans figer autre chose.

```
sans le correctif :  Tests: 6 failed, 12 passed (24 assertions)
avec le correctif :  Tests: 18 passed (24 assertions)
```

## Portée du risque

À relativiser honnêtement : l'exploitation demande **un compte admin déjà valide** avec accès au panel. Il s'agit d'une élévation *au sein* du périmètre admin — un admin volontairement dépourvu de permissions en récupère six sur une cible précise — et non d'un accès depuis l'extérieur.

Cela reste un contournement d'autorisation : la promesse du modèle de permissions Shield est qu'un admin sans permission ne peut rien, et elle n'était pas tenue.

## Vérifications

| | |
|---|---|
| Suite complète | verte, couverture 84,1 % |
| Test ciblé sur le code vulnérable | 6 échecs, exactement les 6 méthodes |
| `getAuthIdentifier()` résiduel dans `app/` | aucun |
| Autres policies sans garde de type | aucune |
| Pint / PHPStan | verts |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
