### PR TITLE
test: couvrir les zones backend laissées à zéro — 84,0 % → 94,3 %

### DIFF
--- a/tests/Feature/Actions/Fortify/CreateNewUserTest.php
+++ b/tests/Feature/Actions/Fortify/CreateNewUserTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Fortify\CreateNewUser;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+beforeEach(function (): void {
+    $this->createNewUser = app(CreateNewUser::class);
+});
+
+it('creates the user and never stores the password in clear text', function (): void {
+    $user = $this->createNewUser->create([
+        'name' => 'Sam Dulex',
+        'email' => 'sam@example.com',
+        'password' => 'correct-horse-8',
+        'password_confirmation' => 'correct-horse-8',
+    ]);
+
+    $stored = DB::table('users')->where('id', $user->id)->value('password');
+
+    expect($user)->toBeInstanceOf(User::class)
+        ->and($user->exists)->toBeTrue()
+        ->and($stored)->toBeString()
+        ->and($stored)->not->toBe('correct-horse-8')
+        ->and($stored)->toStartWith('$')
+        ->and(Hash::check('correct-horse-8', $stored))->toBeTrue();
+
+    $this->assertDatabaseHas('users', [
+        'id' => $user->id,
+        'name' => 'Sam Dulex',
+        'email' => 'sam@example.com',
+        'email_verified_at' => null,
+    ]);
+});
+
+it('rejects an e-mail that is already registered', function (): void {
+    User::factory()->create(['email' => 'taken@example.com']);
+
+    expect(fn () => $this->createNewUser->create([
+        'name' => 'Imposteur',
+        'email' => 'taken@example.com',
+        'password' => 'correct-horse-8',
+        'password_confirmation' => 'correct-horse-8',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errors())->toHaveKey('email');
+    });
+
+    expect(User::query()->where('email', 'taken@example.com')->count())->toBe(1);
+    expect(User::query()->where('name', 'Imposteur')->exists())->toBeFalse();
+});
+
+it('rejects a registration without a name', function (): void {
+    expect(fn () => $this->createNewUser->create([
+        'name' => '',
+        'email' => 'nameless@example.com',
+        'password' => 'correct-horse-8',
+        'password_confirmation' => 'correct-horse-8',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errors())->toHaveKey('name');
+    });
+
+    $this->assertDatabaseMissing('users', ['email' => 'nameless@example.com']);
+});
+
+it('rejects a malformed e-mail address', function (): void {
+    expect(fn () => $this->createNewUser->create([
+        'name' => 'Sam Dulex',
+        'email' => 'not-an-email',
+        'password' => 'correct-horse-8',
+        'password_confirmation' => 'correct-horse-8',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errors())->toHaveKey('email');
+    });
+
+    expect(User::query()->count())->toBe(0);
+});
+
+it('accepts a 255 character name but rejects a 256 character one', function (): void {
+    $accepted = str_repeat('a', 255);
+    $rejected = str_repeat('a', 256);
+
+    $user = $this->createNewUser->create([
+        'name' => $accepted,
+        'email' => 'long-but-ok@example.com',
+        'password' => 'correct-horse-8',
+        'password_confirmation' => 'correct-horse-8',
+    ]);
+
+    expect(DB::table('users')->where('id', $user->id)->value('name'))->toBe($accepted);
+
+    expect(fn () => $this->createNewUser->create([
+        'name' => $rejected,
+        'email' => 'too-long@example.com',
+        'password' => 'correct-horse-8',
+        'password_confirmation' => 'correct-horse-8',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errors())->toHaveKey('name');
+    });
+
+    $this->assertDatabaseMissing('users', ['email' => 'too-long@example.com']);
+});
+
+it('applies the shared password policy at registration', function (): void {
+    expect(fn () => $this->createNewUser->create([
+        'name' => 'Sam Dulex',
+        'email' => 'weak@example.com',
+        'password' => 'short7c',
+        'password_confirmation' => 'short7c',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errors())->toHaveKey('password');
+    });
+
+    $this->assertDatabaseMissing('users', ['email' => 'weak@example.com']);
+});
+
+it('rejects a registration whose password confirmation does not match', function (): void {
+    expect(fn () => $this->createNewUser->create([
+        'name' => 'Sam Dulex',
+        'email' => 'mismatch@example.com',
+        'password' => 'correct-horse-8',
+        'password_confirmation' => 'correct-horse-9',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errors())->toHaveKey('password');
+    });
+
+    $this->assertDatabaseMissing('users', ['email' => 'mismatch@example.com']);
+});

--- a/tests/Feature/Actions/Fortify/FortifyActionBindingsTest.php
+++ b/tests/Feature/Actions/Fortify/FortifyActionBindingsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Fortify\CreateNewUser;
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Actions\Fortify\UpdateUserProfileInformation;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Laravel\Fortify\Contracts\CreatesNewUsers;
+use Laravel\Fortify\Contracts\ResetsUserPasswords;
+use Laravel\Fortify\Contracts\UpdatesUserPasswords;
+use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
+
+it('resolves the application actions for every Fortify contract', function (): void {
+    expect(app(CreatesNewUsers::class))->toBeInstanceOf(CreateNewUser::class)
+        ->and(app(UpdatesUserProfileInformation::class))->toBeInstanceOf(UpdateUserProfileInformation::class)
+        ->and(app(UpdatesUserPasswords::class))->toBeInstanceOf(UpdateUserPassword::class)
+        ->and(app(ResetsUserPasswords::class))->toBeInstanceOf(ResetUserPassword::class);
+});
+
+it('throttles login to five attempts per minute per lowercased e-mail and ip', function (): void {
+    $request = Request::create('/login', 'POST', ['email' => 'Sam@Example.COM'], [], [], [
+        'REMOTE_ADDR' => '10.0.0.7',
+    ]);
+
+    $limit = RateLimiter::limiter('login')($request);
+
+    expect($limit)->toBeInstanceOf(Limit::class)
+        ->and($limit->maxAttempts)->toBe(5)
+        ->and($limit->decaySeconds)->toBe(60)
+        ->and($limit->key)->toBe('sam@example.com|10.0.0.7');
+});
+
+it('builds a login throttling key even when no e-mail is submitted', function (): void {
+    $request = Request::create('/login', 'POST', [], [], [], [
+        'REMOTE_ADDR' => '10.0.0.8',
+    ]);
+
+    $limit = RateLimiter::limiter('login')($request);
+
+    expect($limit->key)->toBe('|10.0.0.8');
+});

--- a/tests/Feature/Actions/Fortify/PasswordValidationRulesTest.php
+++ b/tests/Feature/Actions/Fortify/PasswordValidationRulesTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Fortify\PasswordValidationRules;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
+
+/**
+ * Expose the trait's protected rule set through a throwaway consumer, so the
+ * policy is asserted on the real rule objects rather than on a copy of them.
+ *
+ * @return array<int, mixed>
+ */
+function fortifyPasswordRules(): array
+{
+    return (new class()
+    {
+        use PasswordValidationRules;
+
+        /**
+         * @return array<int, mixed>
+         */
+        public function expose(): array
+        {
+            return $this->passwordRules();
+        }
+    })->expose();
+}
+
+/**
+ * @param  array<string, mixed>  $data
+ */
+function fortifyPasswordFails(array $data): bool
+{
+    return Validator::make($data, ['password' => fortifyPasswordRules()])->fails();
+}
+
+/**
+ * The rule names that actually failed, e.g. "Required", "String",
+ * "Illuminate\Validation\Rules\Password".
+ *
+ * @param  array<string, mixed>  $data
+ * @return array<int, string>
+ */
+function fortifyPasswordFailedRules(array $data): array
+{
+    $validator = Validator::make($data, ['password' => fortifyPasswordRules()]);
+    $validator->fails();
+
+    /** @var array<string, array<string, mixed>> $failed */
+    $failed = $validator->failed();
+
+    return array_keys($failed['password'] ?? []);
+}
+
+/**
+ * @return array<string, string>
+ */
+function fortifyPasswordPayload(string $password): array
+{
+    return [
+        'password' => $password,
+        'password_confirmation' => $password,
+    ];
+}
+
+it('requires a password to be present', function (): void {
+    expect(fortifyPasswordFailedRules([]))->toContain('Required')
+        ->and(fortifyPasswordFailedRules(['password' => '']))->toContain('Required');
+});
+
+it('requires the password to be a string', function (): void {
+    expect(fortifyPasswordFailedRules([
+        'password' => 12345678,
+        'password_confirmation' => 12345678,
+    ]))->toContain('String');
+});
+
+it('rejects a 7 character password and accepts an 8 character one', function (): void {
+    expect(fortifyPasswordFails(fortifyPasswordPayload(str_repeat('a', 7))))->toBeTrue()
+        ->and(fortifyPasswordFailedRules(fortifyPasswordPayload(str_repeat('a', 7))))
+        ->toContain(Password::class)
+        ->and(fortifyPasswordFails(fortifyPasswordPayload(str_repeat('a', 8))))->toBeFalse();
+});
+
+it('requires the password to be confirmed', function (): void {
+    expect(fortifyPasswordFailedRules([
+        'password' => 'correct-horse-8',
+        'password_confirmation' => 'correct-horse-9',
+    ]))->toContain('Confirmed');
+
+    expect(fortifyPasswordFailedRules(['password' => 'correct-horse-8']))->toContain('Confirmed');
+});
+
+it('only demands mixed case once the application runs in production', function (): void {
+    $lowercaseOnly = 'lowercaseonly1';
+
+    expect(fortifyPasswordFails(fortifyPasswordPayload($lowercaseOnly)))->toBeFalse();
+
+    config(['app.env' => 'production']);
+    Http::fake(['api.pwnedpasswords.com/*' => Http::response('')]);
+
+    expect(fortifyPasswordFails(fortifyPasswordPayload($lowercaseOnly)))->toBeTrue()
+        ->and(fortifyPasswordFails(fortifyPasswordPayload('LowercaseOnly1')))->toBeFalse();
+});
+
+it('rejects a password found in a public breach when running in production', function (): void {
+    config(['app.env' => 'production']);
+
+    $password = 'Str0ngButLeaked';
+    $hash = strtoupper(sha1($password));
+
+    Http::fake([
+        'api.pwnedpasswords.com/*' => Http::response(substr($hash, 5).':17'),
+    ]);
+
+    expect(fortifyPasswordFails(fortifyPasswordPayload($password)))->toBeTrue();
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://api.pwnedpasswords.com/range/'.substr($hash, 0, 5));
+});
+
+it('accepts a password absent from public breaches when running in production', function (): void {
+    config(['app.env' => 'production']);
+
+    Http::fake([
+        'api.pwnedpasswords.com/*' => Http::response('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF:3'),
+    ]);
+
+    expect(fortifyPasswordFails(fortifyPasswordPayload('Str0ngButLeaked')))->toBeFalse();
+});

--- a/tests/Feature/Actions/Fortify/ResetUserPasswordTest.php
+++ b/tests/Feature/Actions/Fortify/ResetUserPasswordTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Fortify\ResetUserPassword;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+beforeEach(function (): void {
+    $this->resetUserPassword = app(ResetUserPassword::class);
+    $this->user = User::factory()->create();
+});
+
+it('rehashes the password without asking for the current one', function (): void {
+    $this->resetUserPassword->reset($this->user, [
+        'password' => 'reset-secret-1',
+        'password_confirmation' => 'reset-secret-1',
+    ]);
+
+    $stored = DB::table('users')->where('id', $this->user->id)->value('password');
+
+    expect($stored)->toBeString()
+        ->and($stored)->not->toBe('reset-secret-1')
+        ->and($stored)->toStartWith('$')
+        ->and(Hash::check('reset-secret-1', $stored))->toBeTrue()
+        ->and(Hash::check('password', $stored))->toBeFalse();
+});
+
+it('applies the shared password policy on reset', function (): void {
+    expect(fn () => $this->resetUserPassword->reset($this->user, [
+        'password' => 'short7c',
+        'password_confirmation' => 'short7c',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errors())->toHaveKey('password');
+    });
+
+    expect(Hash::check('password', $this->user->fresh()->password))->toBeTrue();
+});
+
+it('requires the reset password to be confirmed', function (): void {
+    expect(fn () => $this->resetUserPassword->reset($this->user, [
+        'password' => 'reset-secret-1',
+        'password_confirmation' => 'reset-secret-2',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errors())->toHaveKey('password');
+    });
+
+    expect(Hash::check('password', $this->user->fresh()->password))->toBeTrue();
+});
+
+it('requires a password to be supplied', function (): void {
+    expect(fn () => $this->resetUserPassword->reset($this->user, []))
+        ->toThrow(function (ValidationException $exception): void {
+            expect($exception->errors())->toHaveKey('password');
+        });
+
+    expect(Hash::check('password', $this->user->fresh()->password))->toBeTrue();
+});

--- a/tests/Feature/Actions/Fortify/UpdateUserPasswordTest.php
+++ b/tests/Feature/Actions/Fortify/UpdateUserPasswordTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+beforeEach(function (): void {
+    $this->updateUserPassword = app(UpdateUserPassword::class);
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+it('replaces the password with a new hash when the current password is correct', function (): void {
+    $this->updateUserPassword->update($this->user, [
+        'current_password' => 'password',
+        'password' => 'brand-new-secret',
+        'password_confirmation' => 'brand-new-secret',
+    ]);
+
+    $stored = DB::table('users')->where('id', $this->user->id)->value('password');
+
+    expect($stored)->toBeString()
+        ->and($stored)->not->toBe('brand-new-secret')
+        ->and($stored)->toStartWith('$')
+        ->and(Hash::check('brand-new-secret', $stored))->toBeTrue()
+        ->and(Hash::check('password', $stored))->toBeFalse();
+});
+
+it('refuses to change the password when the current password is wrong', function (): void {
+    expect(fn () => $this->updateUserPassword->update($this->user, [
+        'current_password' => 'not-my-password',
+        'password' => 'brand-new-secret',
+        'password_confirmation' => 'brand-new-secret',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errorBag)->toBe('updatePassword')
+            ->and($exception->errors())->toHaveKey('current_password')
+            ->and($exception->errors()['current_password'][0])
+            ->not->toBe(trans('validation.current_password'));
+    });
+
+    expect(Hash::check('password', $this->user->fresh()->password))->toBeTrue();
+});
+
+it('refuses to change the password when the current password is missing', function (): void {
+    expect(fn () => $this->updateUserPassword->update($this->user, [
+        'password' => 'brand-new-secret',
+        'password_confirmation' => 'brand-new-secret',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errors())->toHaveKey('current_password');
+    });
+
+    expect(Hash::check('password', $this->user->fresh()->password))->toBeTrue();
+});
+
+it('applies the shared password policy to the new password', function (): void {
+    expect(fn () => $this->updateUserPassword->update($this->user, [
+        'current_password' => 'password',
+        'password' => 'short7c',
+        'password_confirmation' => 'short7c',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errorBag)->toBe('updatePassword')
+            ->and($exception->errors())->toHaveKey('password');
+    });
+
+    expect(Hash::check('password', $this->user->fresh()->password))->toBeTrue();
+});
+
+it('requires the new password to be confirmed', function (): void {
+    expect(fn () => $this->updateUserPassword->update($this->user, [
+        'current_password' => 'password',
+        'password' => 'brand-new-secret',
+        'password_confirmation' => 'a-different-secret',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errors())->toHaveKey('password');
+    });
+
+    expect(Hash::check('password', $this->user->fresh()->password))->toBeTrue();
+});

--- a/tests/Feature/Actions/Fortify/UpdateUserProfileInformationTest.php
+++ b/tests/Feature/Actions/Fortify/UpdateUserProfileInformationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Fortify\UpdateUserProfileInformation;
+use App\Models\User;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Validation\ValidationException;
+
+beforeEach(function (): void {
+    $this->updateProfile = app(UpdateUserProfileInformation::class);
+    Notification::fake();
+});
+
+it('resets the e-mail verification and notifies the user when the e-mail changes', function (): void {
+    $user = User::factory()->create([
+        'name' => 'Ancien Nom',
+        'email' => 'old@example.com',
+    ]);
+
+    expect($user->email_verified_at)->not->toBeNull();
+
+    $this->updateProfile->update($user, [
+        'name' => 'Nouveau Nom',
+        'email' => 'new@example.com',
+    ]);
+
+    $this->assertDatabaseHas('users', [
+        'id' => $user->id,
+        'name' => 'Nouveau Nom',
+        'email' => 'new@example.com',
+        'email_verified_at' => null,
+    ]);
+
+    Notification::assertSentTo($user, VerifyEmail::class);
+});
+
+it('keeps the verification timestamp and sends nothing when the e-mail is unchanged', function (): void {
+    $user = User::factory()->create([
+        'name' => 'Ancien Nom',
+        'email' => 'same@example.com',
+    ]);
+
+    $verifiedAt = $user->email_verified_at;
+
+    $this->updateProfile->update($user, [
+        'name' => 'Nouveau Nom',
+        'email' => 'same@example.com',
+    ]);
+
+    $fresh = $user->fresh();
+
+    expect($fresh->name)->toBe('Nouveau Nom')
+        ->and($fresh->email)->toBe('same@example.com')
+        ->and($fresh->email_verified_at)->not->toBeNull()
+        ->and($fresh->email_verified_at->equalTo($verifiedAt))->toBeTrue();
+
+    Notification::assertNothingSentTo($user);
+});
+
+it('rejects an e-mail already taken by another user and changes nothing', function (): void {
+    User::factory()->create(['email' => 'taken@example.com']);
+
+    $user = User::factory()->create([
+        'name' => 'Ancien Nom',
+        'email' => 'mine@example.com',
+    ]);
+
+    expect(fn () => $this->updateProfile->update($user, [
+        'name' => 'Nouveau Nom',
+        'email' => 'taken@example.com',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errorBag)->toBe('updateProfileInformation')
+            ->and($exception->errors())->toHaveKey('email');
+    });
+
+    $this->assertDatabaseHas('users', [
+        'id' => $user->id,
+        'name' => 'Ancien Nom',
+        'email' => 'mine@example.com',
+    ]);
+
+    Notification::assertNothingSentTo($user);
+});
+
+it('rejects an empty name and a malformed e-mail', function (): void {
+    $user = User::factory()->create([
+        'name' => 'Ancien Nom',
+        'email' => 'mine@example.com',
+    ]);
+
+    expect(fn () => $this->updateProfile->update($user, [
+        'name' => '',
+        'email' => 'not-an-email',
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errors())->toHaveKeys(['name', 'email']);
+    });
+
+    $this->assertDatabaseHas('users', [
+        'id' => $user->id,
+        'name' => 'Ancien Nom',
+        'email' => 'mine@example.com',
+    ]);
+});
+
+it('rejects a name longer than 255 characters', function (): void {
+    $user = User::factory()->create(['name' => 'Ancien Nom']);
+
+    expect(fn () => $this->updateProfile->update($user, [
+        'name' => str_repeat('a', 256),
+        'email' => $user->email,
+    ]))->toThrow(function (ValidationException $exception): void {
+        expect($exception->errors())->toHaveKey('name');
+    });
+
+    expect($user->fresh()->name)->toBe('Ancien Nom');
+});

--- a/tests/Feature/Enums/ExerciseCategoryTest.php
+++ b/tests/Feature/Enums/ExerciseCategoryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ExerciseCategory;
+use App\Models\Exercise;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * exercises.category est un varchar : rien dans la base ne contraint la valeur.
+ * Renommer une valeur de backing ici est donc une migration de données
+ * silencieuse — les lignes déjà écrites gardent l'ancienne chaîne et le cast
+ * lève un ValueError à l'hydratation, loin du commit fautif. La migration
+ * 2026_03_25_092024_fix_exercises_abdos_category en est la trace.
+ */
+describe('ExerciseCategory : valeurs persistées', function (): void {
+    it('garde la valeur stockée de chaque catégorie', function (): void {
+        expect(ExerciseCategory::Pectoraux->value)->toBe('Pectoraux')
+            ->and(ExerciseCategory::Epaules->value)->toBe('Épaules')
+            ->and(ExerciseCategory::Dos->value)->toBe('Dos')
+            ->and(ExerciseCategory::Jambes->value)->toBe('Jambes')
+            ->and(ExerciseCategory::Bras->value)->toBe('Bras')
+            ->and(ExerciseCategory::Abdominaux->value)->toBe('Abdominaux')
+            ->and(ExerciseCategory::Cardio->value)->toBe('Cardio');
+    });
+
+    it('ne déclare que ces sept catégories, dans cet ordre', function (): void {
+        expect(array_map(
+            fn (ExerciseCategory $category): string => $category->value,
+            ExerciseCategory::cases(),
+        ))->toBe(['Pectoraux', 'Épaules', 'Dos', 'Jambes', 'Bras', 'Abdominaux', 'Cardio']);
+    });
+
+    it('ne reconnaît plus la valeur héritée « Abdos »', function (): void {
+        expect(ExerciseCategory::tryFrom('Abdos'))->toBeNull()
+            ->and(ExerciseCategory::tryFrom('Abdominaux'))->toBe(ExerciseCategory::Abdominaux);
+    });
+});
+
+describe('ExerciseCategory : libellés', function (): void {
+    it('affiche le libellé accentué de chaque catégorie', function (): void {
+        expect(ExerciseCategory::Pectoraux->label())->toBe('Pectoraux')
+            ->and(ExerciseCategory::Epaules->label())->toBe('Épaules')
+            ->and(ExerciseCategory::Dos->label())->toBe('Dos')
+            ->and(ExerciseCategory::Jambes->label())->toBe('Jambes')
+            ->and(ExerciseCategory::Bras->label())->toBe('Bras')
+            ->and(ExerciseCategory::Abdominaux->label())->toBe('Abdominaux')
+            ->and(ExerciseCategory::Cardio->label())->toBe('Cardio');
+    });
+});
+
+describe('ExerciseCategory : aller-retour par le cast du modèle', function (): void {
+    it('écrit la valeur de backing et relit une instance d\'enum', function (ExerciseCategory $category): void {
+        $user = User::factory()->create();
+        $exercise = Exercise::factory()->create([
+            'user_id' => $user->id,
+            'category' => $category,
+        ]);
+
+        // La colonne porte la valeur de backing, jamais le nom du case.
+        expect(DB::table('exercises')->where('id', $exercise->id)->value('category'))
+            ->toBe($category->value);
+
+        $reloaded = Exercise::findOrFail($exercise->id);
+
+        // toBe() compare par identité : sans le cast on récupérerait une string.
+        expect($reloaded->category)->toBe($category)
+            ->and($reloaded->toArray()['category'])->toBe($category->value);
+    })->with([
+        'Pectoraux' => [ExerciseCategory::Pectoraux],
+        'Épaules' => [ExerciseCategory::Epaules],
+        'Dos' => [ExerciseCategory::Dos],
+        'Jambes' => [ExerciseCategory::Jambes],
+        'Bras' => [ExerciseCategory::Bras],
+        'Abdominaux' => [ExerciseCategory::Abdominaux],
+        'Cardio' => [ExerciseCategory::Cardio],
+    ]);
+});

--- a/tests/Feature/Enums/GoalTypeTest.php
+++ b/tests/Feature/Enums/GoalTypeTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\GoalType;
+use App\Models\Goal;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * goals.type est une colonne ENUM MySQL : la valeur de backing n'est pas
+ * seulement affichée, elle doit exister côté base. Renommer un case sans
+ * migration fait échouer l'INSERT en production ; en ajouter un sans migration
+ * aussi. Ces tests verrouillent les deux côtés du contrat.
+ */
+describe('GoalType : valeurs persistées', function (): void {
+    it('garde la valeur stockée de chaque type', function (): void {
+        expect(GoalType::Weight->value)->toBe('weight')
+            ->and(GoalType::Volume->value)->toBe('volume')
+            ->and(GoalType::Frequency->value)->toBe('frequency')
+            ->and(GoalType::Measurement->value)->toBe('measurement');
+    });
+
+    it('ne déclare que ces quatre types, dans cet ordre', function (): void {
+        expect(array_map(
+            fn (GoalType $type): string => $type->value,
+            GoalType::cases(),
+        ))->toBe(['weight', 'volume', 'frequency', 'measurement']);
+    });
+
+    it('correspond exactement à la définition ENUM de la colonne goals.type', function (): void {
+        /** @var object{Type: string} $column */
+        $column = DB::selectOne("SHOW COLUMNS FROM goals WHERE Field = 'type'");
+
+        preg_match_all("/'([^']+)'/", $column->Type, $matches);
+
+        $inDatabase = $matches[1];
+        sort($inDatabase);
+
+        $inPhp = array_map(fn (GoalType $type): string => $type->value, GoalType::cases());
+        sort($inPhp);
+
+        expect($inDatabase)->toBe($inPhp);
+    });
+});
+
+describe('GoalType : libellés', function (): void {
+    it('traduit chaque type en français', function (): void {
+        expect(GoalType::Weight->label())->toBe('Poids')
+            ->and(GoalType::Volume->label())->toBe('Volume')
+            ->and(GoalType::Frequency->label())->toBe('Fréquence')
+            ->and(GoalType::Measurement->label())->toBe('Mensuration');
+    });
+});
+
+describe('GoalType : aller-retour par le cast du modèle', function (): void {
+    it('écrit la valeur de backing et relit une instance d\'enum', function (GoalType $type): void {
+        $user = User::factory()->create();
+        $goal = Goal::factory()->create([
+            'user_id' => $user->id,
+            'type' => $type,
+            'measurement_type' => $type === GoalType::Measurement ? 'waist' : null,
+        ]);
+
+        expect(DB::table('goals')->where('id', $goal->id)->value('type'))
+            ->toBe($type->value);
+
+        $reloaded = Goal::findOrFail($goal->id);
+
+        expect($reloaded->type)->toBe($type)
+            ->and($reloaded->toArray()['type'])->toBe($type->value);
+    })->with([
+        'weight' => [GoalType::Weight],
+        'volume' => [GoalType::Volume],
+        'frequency' => [GoalType::Frequency],
+        'measurement' => [GoalType::Measurement],
+    ]);
+});
+
+/**
+ * Goal::getUnitAttribute() est un match sans branche par défaut sur GoalType :
+ * ajouter un case sans le compléter fait exploser la page Objectifs avec un
+ * UnhandledMatchError. L'unité est aussi ce qui s'affiche derrière chaque
+ * chiffre de la carte d'objectif.
+ */
+describe('GoalType pilote l\'unité affichée sur l\'objectif', function (): void {
+    it('donne l\'unité attendue pour chaque type', function (): void {
+        $user = User::factory()->create();
+
+        $unitFor = function (GoalType $type, ?string $measurementType = null) use ($user): string {
+            /** @var Goal $goal */
+            $goal = Goal::factory()->create([
+                'user_id' => $user->id,
+                'type' => $type,
+                'measurement_type' => $measurementType,
+            ]);
+
+            return Goal::findOrFail($goal->id)->unit;
+        };
+
+        expect($unitFor(GoalType::Weight))->toBe('kg')
+            ->and($unitFor(GoalType::Volume))->toBe('kg')
+            ->and($unitFor(GoalType::Frequency))->toBe('séances')
+            ->and($unitFor(GoalType::Measurement, 'body_fat'))->toBe('%')
+            ->and($unitFor(GoalType::Measurement, 'waist'))->toBe('cm');
+    });
+});

--- a/tests/Feature/Enums/PersonalRecordTypeTest.php
+++ b/tests/Feature/Enums/PersonalRecordTypeTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PersonalRecordType;
+use App\Models\Exercise;
+use App\Models\PersonalRecord;
+use App\Models\User;
+use App\Notifications\PersonalRecordAchieved;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * personal_records.type est un varchar sans contrainte, et l'enum traîne
+ * quatre valeurs héritées ('1RM', 'strength', 'cardio', 'volume') encore
+ * présentes dans les bases existantes. Supprimer ou renommer l'un de ces cases
+ * ne casse rien à l'écriture : ça casse à la relecture, quand le cast
+ * rencontre une ligne historique et lève un ValueError.
+ */
+describe('PersonalRecordType : valeurs persistées', function (): void {
+    it('garde la valeur stockée de chaque type courant', function (): void {
+        expect(PersonalRecordType::MaxWeight->value)->toBe('max_weight')
+            ->and(PersonalRecordType::Max1RM->value)->toBe('max_1rm')
+            ->and(PersonalRecordType::MaxVolumeSet->value)->toBe('max_volume_set');
+    });
+
+    it('garde les valeurs héritées encore présentes en base', function (): void {
+        expect(PersonalRecordType::OneRM->value)->toBe('1RM')
+            ->and(PersonalRecordType::Strength->value)->toBe('strength')
+            ->and(PersonalRecordType::Cardio->value)->toBe('cardio')
+            ->and(PersonalRecordType::Volume->value)->toBe('volume');
+    });
+
+    it('ne déclare que ces sept types, dans cet ordre', function (): void {
+        expect(array_map(
+            fn (PersonalRecordType $type): string => $type->value,
+            PersonalRecordType::cases(),
+        ))->toBe(['max_weight', 'max_1rm', 'max_volume_set', '1RM', 'strength', 'cardio', 'volume']);
+    });
+});
+
+describe('PersonalRecordType : libellés', function (): void {
+    it('replie les valeurs héritées sur le même libellé que les valeurs courantes', function (): void {
+        expect(PersonalRecordType::MaxWeight->label())->toBe('Poids Max')
+            ->and(PersonalRecordType::Strength->label())->toBe('Poids Max')
+            ->and(PersonalRecordType::Max1RM->label())->toBe('1RM Estimé')
+            ->and(PersonalRecordType::OneRM->label())->toBe('1RM Estimé')
+            ->and(PersonalRecordType::MaxVolumeSet->label())->toBe('Volume Max')
+            ->and(PersonalRecordType::Volume->label())->toBe('Volume Max')
+            ->and(PersonalRecordType::Cardio->label())->toBe('Cardio');
+    });
+});
+
+describe('PersonalRecordType : aller-retour par le cast du modèle', function (): void {
+    it('écrit la valeur de backing et relit une instance d\'enum', function (PersonalRecordType $type): void {
+        $user = User::factory()->create();
+        $record = PersonalRecord::factory()->create([
+            'user_id' => $user->id,
+            'type' => $type,
+        ]);
+
+        expect(DB::table('personal_records')->where('id', $record->id)->value('type'))
+            ->toBe($type->value);
+
+        $reloaded = PersonalRecord::findOrFail($record->id);
+
+        expect($reloaded->type)->toBe($type)
+            ->and($reloaded->toArray()['type'])->toBe($type->value);
+    })->with([
+        'max_weight' => [PersonalRecordType::MaxWeight],
+        'max_1rm' => [PersonalRecordType::Max1RM],
+        'max_volume_set' => [PersonalRecordType::MaxVolumeSet],
+        '1RM' => [PersonalRecordType::OneRM],
+        'strength' => [PersonalRecordType::Strength],
+        'cardio' => [PersonalRecordType::Cardio],
+        'volume' => [PersonalRecordType::Volume],
+    ]);
+});
+
+/**
+ * La notification de record lit l'enum pour construire le message poussé sur
+ * le téléphone. C'est le seul endroit où le libellé n'est pas celui de
+ * l'enum : il est réécrit en toutes lettres.
+ */
+describe('PersonalRecordType nomme le record dans la notification', function (): void {
+    it('écrit le libellé long du type dans le message', function (PersonalRecordType $type, string $expectedLabel): void {
+        $user = User::factory()->create();
+        $exercise = Exercise::factory()->create(['user_id' => $user->id, 'name' => 'Développé couché']);
+        $record = PersonalRecord::factory()->create([
+            'user_id' => $user->id,
+            'exercise_id' => $exercise->id,
+            'type' => $type,
+            'value' => 102.5,
+        ]);
+
+        $payload = new PersonalRecordAchieved(PersonalRecord::with('exercise')->findOrFail($record->id))
+            ->toArray($user);
+
+        expect($payload['message'])
+            ->toBe("Félicitations ! Tu as battu ton record de {$expectedLabel} sur l'exercice Développé couché avec 102.50kg.")
+            ->and($payload['exercise_id'])->toBe($exercise->id);
+    })->with([
+        'max_weight' => [PersonalRecordType::MaxWeight, 'Poids Maximum'],
+        'max_1rm' => [PersonalRecordType::Max1RM, '1RM Estimé'],
+        'max_volume_set' => [PersonalRecordType::MaxVolumeSet, 'Volume par Série'],
+        // Les valeurs héritées retombent sur la branche par défaut du match.
+        'strength' => [PersonalRecordType::Strength, 'Record Personnel'],
+    ]);
+});

--- a/tests/Feature/Filament/AchievementResourceTest.php
+++ b/tests/Feature/Filament/AchievementResourceTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\Achievements\AchievementResource;
+use App\Filament\Resources\Achievements\Pages\CreateAchievement;
+use App\Filament\Resources\Achievements\Pages\EditAchievement;
+use App\Filament\Resources\Achievements\Pages\ListAchievements;
+use App\Models\Achievement;
+use Livewire\Livewire;
+use Tests\Support\FilamentAdminPanel;
+
+beforeEach(function (): void {
+    $this->actingAs(FilamentAdminPanel::admin(FilamentAdminPanel::crudPermissions('Achievement')), 'admin');
+});
+
+it('liste les badges avec leur slug, leur type et leur seuil', function (): void {
+    $badge = Achievement::factory()->create([
+        'slug' => 'dix-seances',
+        'name' => 'Dix séances',
+        'icon' => '🏆',
+        'type' => 'workout_count',
+        'threshold' => 10,
+        'category' => 'beginner',
+    ]);
+    $other = Achievement::factory()->create(['slug' => 'cent-seances', 'threshold' => 100]);
+
+    Livewire::test(ListAchievements::class)
+        ->assertCanSeeTableRecords([$badge, $other])
+        ->assertTableColumnStateSet('slug', 'dix-seances', $badge)
+        ->assertTableColumnStateSet('type', 'workout_count', $badge)
+        ->assertTableColumnStateSet('threshold', 10, $badge)
+        ->assertTableColumnStateSet('threshold', 100, $other)
+        ->assertTableColumnStateSet('category', 'beginner', $badge);
+});
+
+it('cherche un badge par son slug', function (): void {
+    $wanted = Achievement::factory()->create(['slug' => 'marathonien']);
+    $unwanted = Achievement::factory()->create(['slug' => 'sprinteur']);
+
+    Livewire::test(ListAchievements::class)
+        ->searchTable('marathonien')
+        ->assertCanSeeTableRecords([$wanted])
+        ->assertCanNotSeeTableRecords([$unwanted]);
+});
+
+it('crée un badge avec tous ses attributs', function (): void {
+    Livewire::test(CreateAchievement::class)
+        ->fillForm([
+            'slug' => 'premier-pas',
+            'name' => 'Premier pas',
+            'description' => 'Terminer sa toute première séance.',
+            'icon' => '🥇',
+            'type' => 'workout_count',
+            'threshold' => 1,
+            'category' => 'beginner',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $created = Achievement::query()->where('slug', 'premier-pas')->sole();
+
+    expect($created->name)->toBe('Premier pas')
+        ->and($created->description)->toBe('Terminer sa toute première séance.')
+        ->and($created->icon)->toBe('🥇')
+        ->and($created->type)->toBe('workout_count')
+        ->and((int) $created->threshold)->toBe(1)
+        ->and($created->category)->toBe('beginner');
+});
+
+it('applique la catégorie general par défaut quand elle est laissée telle quelle', function (): void {
+    Livewire::test(CreateAchievement::class)
+        ->fillForm([
+            'slug' => 'sans-categorie',
+            'name' => 'Sans catégorie',
+            'description' => 'Une description.',
+            'icon' => '⭐',
+            'type' => 'streak',
+            'threshold' => 3,
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    expect(Achievement::query()->where('slug', 'sans-categorie')->value('category'))->toBe('general');
+});
+
+it('refuse un badge auquel il manque les champs obligatoires', function (): void {
+    $before = Achievement::query()->count();
+
+    Livewire::test(CreateAchievement::class)
+        ->fillForm([
+            'slug' => null,
+            'name' => null,
+            'description' => null,
+            'icon' => null,
+            'type' => null,
+            'threshold' => null,
+        ])
+        ->call('create')
+        ->assertHasFormErrors([
+            'slug' => 'required',
+            'name' => 'required',
+            'description' => 'required',
+            'icon' => 'required',
+            'type' => 'required',
+            'threshold' => 'required',
+        ]);
+
+    expect(Achievement::query()->count())->toBe($before);
+});
+
+it('refuse un seuil non numérique', function (): void {
+    Livewire::test(CreateAchievement::class)
+        ->fillForm([
+            'slug' => 'seuil-invalide',
+            'name' => 'Seuil invalide',
+            'description' => 'Une description.',
+            'icon' => '⭐',
+            'type' => 'volume',
+            'threshold' => 'énorme',
+            'category' => 'advanced',
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['threshold' => 'numeric']);
+
+    expect(Achievement::query()->where('slug', 'seuil-invalide')->exists())->toBeFalse();
+});
+
+it('charge le badge existant dans le formulaire et enregistre la modification', function (): void {
+    $badge = Achievement::factory()->create([
+        'slug' => 'ancien-slug',
+        'name' => 'Ancien nom',
+        'description' => 'Ancienne description.',
+        'icon' => '🥉',
+        'type' => 'streak',
+        'threshold' => 5,
+        'category' => 'beginner',
+    ]);
+
+    Livewire::test(EditAchievement::class, ['record' => $badge->getKey()])
+        ->assertFormFieldExists('slug')
+        ->assertFormFieldExists('name')
+        ->assertFormFieldExists('description')
+        ->assertFormFieldExists('icon')
+        ->assertFormFieldExists('type')
+        ->assertFormFieldExists('threshold')
+        ->assertFormFieldExists('category')
+        ->assertFormSet([
+            'slug' => 'ancien-slug',
+            'name' => 'Ancien nom',
+            'description' => 'Ancienne description.',
+            'icon' => '🥉',
+            'type' => 'streak',
+            'threshold' => '5',
+            'category' => 'beginner',
+        ])
+        ->fillForm([
+            'name' => 'Nom corrigé',
+            'threshold' => 25,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $badge->refresh();
+
+    expect($badge->name)->toBe('Nom corrigé')
+        ->and((int) $badge->threshold)->toBe(25)
+        ->and($badge->slug)->toBe('ancien-slug');
+});
+
+it('interdit la gestion des badges à un admin sans les permissions Achievement', function (): void {
+    $badge = Achievement::factory()->create();
+
+    $this->actingAs(FilamentAdminPanel::admin(['ViewAny:User']), 'admin');
+
+    expect(AchievementResource::canViewAny())->toBeFalse()
+        ->and(AchievementResource::canCreate())->toBeFalse()
+        ->and(AchievementResource::canEdit($badge))->toBeFalse()
+        ->and(AchievementResource::canDelete($badge))->toBeFalse();
+});

--- a/tests/Feature/Filament/DashboardWidgetsTest.php
+++ b/tests/Feature/Filament/DashboardWidgetsTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Widgets\RecentUsersTable;
+use App\Filament\Widgets\StatsOverview;
+use App\Filament\Widgets\UserActivityChart;
+use App\Models\Exercise;
+use App\Models\User;
+use App\Models\Workout;
+use Illuminate\Support\Carbon;
+use Livewire\Livewire;
+use Tests\Support\FilamentAdminPanel;
+
+beforeEach(function (): void {
+    $this->actingAs(FilamentAdminPanel::admin(), 'admin');
+});
+
+/**
+ * getStats() est protégé : on l'appelle depuis une closure liée à l'instance du
+ * widget, ce qui exécute le vrai calcul sans passer par du mock.
+ *
+ * @return array<string, int|string>
+ */
+function filamentStatsOverviewValues(): array
+{
+    $widget = Livewire::test(StatsOverview::class)->instance();
+
+    /** @var array<int, \Filament\Widgets\StatsOverviewWidget\Stat> $stats */
+    $stats = (fn () => $this->getStats())->call($widget);
+
+    $values = [];
+    foreach ($stats as $stat) {
+        $values[(string) $stat->getLabel()] = $stat->getValue();
+    }
+
+    return $values;
+}
+
+it('compte le total des utilisateurs et ceux inscrits dans les 7 derniers jours', function (): void {
+    Carbon::setTestNow(Carbon::parse('2026-05-20 12:00:00'));
+
+    User::factory()->count(4)->create(['created_at' => Carbon::parse('2026-05-19 09:00:00')]); // dans la fenêtre
+    User::factory()->create(['created_at' => Carbon::parse('2026-05-13 13:00:00')]);           // pile dans la fenêtre
+    User::factory()->count(3)->create(['created_at' => Carbon::parse('2026-05-12 09:00:00')]); // hors fenêtre, de peu
+
+    $values = filamentStatsOverviewValues();
+
+    expect($values['Total Users'])->toBe(8)
+        ->and($values['New Users (7d)'])->toBe(5);
+});
+
+it('compte les séances démarrées aujourd’hui, et elles seules', function (): void {
+    Carbon::setTestNow(Carbon::parse('2026-05-20 12:00:00'));
+
+    $user = User::factory()->create();
+    Workout::factory()->count(2)->create([
+        'user_id' => $user->getKey(),
+        'started_at' => Carbon::parse('2026-05-20 07:15:00'),
+    ]);
+    Workout::factory()->create([
+        'user_id' => $user->getKey(),
+        'started_at' => Carbon::parse('2026-05-20 23:59:59'),
+    ]);
+    Workout::factory()->create([
+        'user_id' => $user->getKey(),
+        'started_at' => Carbon::parse('2026-05-19 23:59:59'),
+    ]);
+    Workout::factory()->create([
+        'user_id' => $user->getKey(),
+        'started_at' => Carbon::parse('2026-05-21 00:00:01'),
+    ]);
+
+    expect(filamentStatsOverviewValues()['Workouts Today'])->toBe(3);
+});
+
+it('ne compte comme exercices système que ceux sans propriétaire', function (): void {
+    $owner = User::factory()->create();
+    Exercise::factory()->count(5)->create(['user_id' => null]);
+    Exercise::factory()->count(2)->create(['user_id' => $owner->getKey()]);
+
+    expect(filamentStatsOverviewValues()['System Exercises'])->toBe(5);
+});
+
+it('rend les quatre tuiles de statistiques avec leurs libellés', function (): void {
+    User::factory()->create();
+
+    Livewire::test(StatsOverview::class)
+        ->assertSee('Total Users')
+        ->assertSee('New Users (7d)')
+        ->assertSee('Workouts Today')
+        ->assertSee('System Exercises')
+        ->assertSee('Total registered users');
+});
+
+it('ventile les inscriptions par mois sur les douze mois de l’année en cours', function (): void {
+    Carbon::setTestNow(Carbon::parse('2026-05-20 12:00:00'));
+
+    User::factory()->count(2)->create(['created_at' => Carbon::parse('2026-01-10 09:00:00')]);
+    User::factory()->count(3)->create(['created_at' => Carbon::parse('2026-03-05 09:00:00')]);
+    User::factory()->create(['created_at' => Carbon::parse('2026-12-31 23:00:00')]);
+    // Hors de l'année en cours : ne doit apparaître dans aucune barre.
+    User::factory()->count(4)->create(['created_at' => Carbon::parse('2025-03-05 09:00:00')]);
+
+    $widget = Livewire::test(UserActivityChart::class)->instance();
+    $data = (fn () => $this->getData())->call($widget);
+
+    expect($data['datasets'][0]['data'])->toBe([2, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+        ->and($data['datasets'][0]['label'])->toBe('New Users')
+        ->and($data['labels'])->toBe(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']);
+});
+
+it('renvoie douze barres à zéro quand aucun utilisateur n’est inscrit', function (): void {
+    $widget = Livewire::test(UserActivityChart::class)->instance();
+    $data = (fn () => $this->getData())->call($widget);
+
+    expect($data['datasets'][0]['data'])->toBe(array_fill(0, 12, 0));
+});
+
+it('affiche les inscrits du plus récent au plus ancien', function (): void {
+    // Inscrits du plus récent (index 0) au plus ancien (index 11).
+    $users = collect(range(0, 11))->map(fn (int $index): User => User::factory()->create([
+        'created_at' => Carbon::now()->subDays($index),
+    ]));
+
+    // Seul l'ORDRE est asserté ici. Vérifier que les deux plus anciens sont
+    // absents ne prouverait rien : la pagination par défaut de Filament s'arrête
+    // à dix, donc l'assertion passerait même si le widget ne triait pas du tout.
+    // inOrder échoue en revanche dès que le latest() du widget devient oldest().
+    Livewire::test(RecentUsersTable::class)
+        ->assertCanSeeTableRecords($users->take(10), inOrder: true);
+});
+
+it('affiche le nom, l’email et la dernière activité de chaque inscrit récent', function (): void {
+    $user = User::factory()->create([
+        'name' => 'Récente Recrue',
+        'email' => 'recente@example.com',
+        'last_workout_at' => Carbon::parse('2026-05-18 20:00:00'),
+    ]);
+
+    Livewire::test(RecentUsersTable::class)
+        ->assertCanSeeTableRecords([$user])
+        ->assertTableColumnStateSet('name', 'Récente Recrue', $user)
+        ->assertTableColumnStateSet('email', 'recente@example.com', $user)
+        ->assertTableColumnStateSet('last_workout_at', Carbon::parse('2026-05-18 20:00:00'), $user)
+        ->assertSee('recente@example.com');
+});

--- a/tests/Feature/Filament/ExerciseResourceTest.php
+++ b/tests/Feature/Filament/ExerciseResourceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ExerciseCategory;
+use App\Filament\Resources\Exercises\ExerciseResource;
+use App\Filament\Resources\Exercises\Pages\CreateExercise;
+use App\Filament\Resources\Exercises\Pages\EditExercise;
+use App\Filament\Resources\Exercises\Pages\ListExercises;
+use App\Models\Exercise;
+use App\Models\User;
+use Livewire\Livewire;
+use Tests\Support\FilamentAdminPanel;
+
+beforeEach(function (): void {
+    $this->actingAs(FilamentAdminPanel::admin(FilamentAdminPanel::crudPermissions('Exercise')), 'admin');
+});
+
+it('liste les exercices avec leur type, leur catégorie et leur propriétaire', function (): void {
+    $owner = User::factory()->create(['name' => 'Propriétaire Zoé']);
+    $userExercise = Exercise::factory()->create([
+        'name' => 'Squat bulgare',
+        'type' => 'strength',
+        'category' => 'Jambes',
+        'default_rest_time' => 150,
+        'user_id' => $owner->getKey(),
+    ]);
+    $systemExercise = Exercise::factory()->create([
+        'name' => 'Tapis de course',
+        'type' => 'cardio',
+        'category' => 'Cardio',
+        'user_id' => null,
+    ]);
+
+    Livewire::test(ListExercises::class)
+        ->assertCanSeeTableRecords([$userExercise, $systemExercise])
+        ->assertTableColumnStateSet('type', 'strength', $userExercise)
+        ->assertTableColumnStateSet('type', 'cardio', $systemExercise)
+        ->assertTableColumnStateSet('category', ExerciseCategory::Jambes, $userExercise)
+        ->assertTableColumnStateSet('default_rest_time', 150, $userExercise)
+        ->assertTableColumnStateSet('user.name', 'Propriétaire Zoé', $userExercise)
+        ->assertTableColumnStateSet('user.name', null, $systemExercise);
+});
+
+it('filtre les exercices par nom via la recherche', function (): void {
+    $wanted = Exercise::factory()->create(['name' => 'Développé militaire']);
+    $unwanted = Exercise::factory()->create(['name' => 'Rowing barre']);
+
+    Livewire::test(ListExercises::class)
+        ->searchTable('Développé militaire')
+        ->assertCanSeeTableRecords([$wanted])
+        ->assertCanNotSeeTableRecords([$unwanted]);
+});
+
+it('refuse un exercice sans nom et sans type', function (): void {
+    $before = Exercise::query()->count();
+
+    Livewire::test(CreateExercise::class)
+        ->fillForm(['name' => null, 'type' => null])
+        ->call('create')
+        ->assertHasFormErrors([
+            'name' => 'required',
+            'type' => 'required',
+        ]);
+
+    expect(Exercise::query()->count())->toBe($before);
+});
+
+it('refuse un type qui ne fait pas partie de la liste proposée', function (): void {
+    Livewire::test(CreateExercise::class)
+        ->fillForm(['name' => 'Exercice fantaisiste', 'type' => 'yoga'])
+        ->call('create')
+        ->assertHasFormErrors(['type']);
+
+    expect(Exercise::query()->where('name', 'Exercice fantaisiste')->exists())->toBeFalse();
+});
+
+it("charge l'exercice existant dans le formulaire d'édition", function (): void {
+    $owner = User::factory()->create();
+    $exercise = Exercise::factory()->create([
+        'name' => 'Soulevé de terre',
+        'type' => 'strength',
+        'category' => 'Dos',
+        'default_rest_time' => 210,
+        'user_id' => $owner->getKey(),
+    ]);
+
+    Livewire::test(EditExercise::class, ['record' => $exercise->getKey()])
+        ->assertFormFieldExists('name')
+        ->assertFormFieldExists('type')
+        ->assertFormFieldExists('category')
+        ->assertFormFieldExists('default_rest_time')
+        ->assertFormFieldExists('user_id')
+        ->assertFormSet([
+            'name' => 'Soulevé de terre',
+            'type' => 'strength',
+            'category' => 'Dos',
+            'default_rest_time' => '210',
+            'user_id' => (string) $owner->getKey(),
+        ]);
+});
+
+it('interdit la gestion des exercices à un admin sans les permissions Exercise', function (): void {
+    $exercise = Exercise::factory()->create();
+
+    $this->actingAs(FilamentAdminPanel::admin(['ViewAny:User']), 'admin');
+
+    expect(ExerciseResource::canViewAny())->toBeFalse()
+        ->and(ExerciseResource::canCreate())->toBeFalse()
+        ->and(ExerciseResource::canEdit($exercise))->toBeFalse()
+        ->and(ExerciseResource::canDelete($exercise))->toBeFalse();
+});

--- a/tests/Feature/Filament/GoalResourceTest.php
+++ b/tests/Feature/Filament/GoalResourceTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\GoalType;
+use App\Filament\Resources\Goals\GoalResource;
+use App\Filament\Resources\Goals\Pages\CreateGoal;
+use App\Filament\Resources\Goals\Pages\EditGoal;
+use App\Filament\Resources\Goals\Pages\ListGoals;
+use App\Models\Exercise;
+use App\Models\Goal;
+use App\Models\User;
+use Livewire\Livewire;
+use Tests\Support\FilamentAdminPanel;
+
+beforeEach(function (): void {
+    $this->actingAs(FilamentAdminPanel::admin(FilamentAdminPanel::crudPermissions('Goal')), 'admin');
+});
+
+it('liste les objectifs avec leur propriétaire, leur type et leurs valeurs', function (): void {
+    $owner = User::factory()->create(['name' => 'Objectif Owner']);
+    $exercise = Exercise::factory()->create(['name' => 'Squat']);
+    $goal = Goal::factory()->create([
+        'user_id' => $owner->getKey(),
+        'exercise_id' => $exercise->getKey(),
+        'title' => 'Atteindre 100 kg au squat',
+        'type' => 'weight',
+        'target_value' => 100,
+        'current_value' => 80,
+        'start_value' => 60,
+    ]);
+
+    Livewire::test(ListGoals::class)
+        ->assertCanSeeTableRecords([$goal])
+        ->assertTableColumnStateSet('user.name', 'Objectif Owner', $goal)
+        ->assertTableColumnStateSet('exercise.name', 'Squat', $goal)
+        ->assertTableColumnStateSet('title', 'Atteindre 100 kg au squat', $goal)
+        ->assertTableColumnStateSet('type', GoalType::Weight, $goal)
+        ->assertTableColumnStateSet('target_value', 100.0, $goal)
+        ->assertTableColumnStateSet('current_value', 80.0, $goal)
+        ->assertTableColumnStateSet('start_value', 60.0, $goal);
+});
+
+it('trie les objectifs par valeur cible', function (): void {
+    $small = Goal::factory()->create(['target_value' => 10]);
+    $big = Goal::factory()->create(['target_value' => 900]);
+    $mid = Goal::factory()->create(['target_value' => 400]);
+
+    Livewire::test(ListGoals::class)
+        ->sortTable('target_value', 'desc')
+        ->assertCanSeeTableRecords([$big, $mid, $small], inOrder: true);
+});
+
+it('cherche un objectif par son titre', function (): void {
+    $wanted = Goal::factory()->create(['title' => 'Perdre 5 kilos']);
+    $unwanted = Goal::factory()->create(['title' => 'Courir un semi-marathon']);
+
+    Livewire::test(ListGoals::class)
+        ->searchTable('Perdre 5 kilos')
+        ->assertCanSeeTableRecords([$wanted])
+        ->assertCanNotSeeTableRecords([$unwanted]);
+});
+
+it('refuse un objectif sans utilisateur, sans titre, sans type ni cible', function (): void {
+    $before = Goal::query()->count();
+
+    Livewire::test(CreateGoal::class)
+        ->fillForm([
+            'user_id' => null,
+            'title' => null,
+            'type' => null,
+            'target_value' => null,
+            'current_value' => 0,
+            'start_value' => 0,
+        ])
+        ->call('create')
+        ->assertHasFormErrors([
+            'user_id' => 'required',
+            'title' => 'required',
+            'type' => 'required',
+            'target_value' => 'required',
+        ]);
+
+    expect(Goal::query()->count())->toBe($before);
+});
+
+it("refuse un type d'objectif hors de la liste proposée", function (): void {
+    $owner = User::factory()->create();
+
+    Livewire::test(CreateGoal::class)
+        ->fillForm([
+            'user_id' => $owner->getKey(),
+            'title' => 'Objectif exotique',
+            'type' => 'astrologie',
+            'target_value' => 10,
+            'current_value' => 0,
+            'start_value' => 0,
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['type']);
+
+    expect(Goal::query()->where('title', 'Objectif exotique')->exists())->toBeFalse();
+});
+
+it("charge l'objectif existant dans le formulaire d'édition", function (): void {
+    $owner = User::factory()->create();
+    $exercise = Exercise::factory()->create();
+    $goal = Goal::factory()->create([
+        'user_id' => $owner->getKey(),
+        'exercise_id' => $exercise->getKey(),
+        'title' => 'Titre initial',
+        'type' => 'volume',
+        'target_value' => 12000,
+        'current_value' => 3000,
+        'start_value' => 1000,
+        'measurement_type' => 'tour_de_taille',
+    ]);
+
+    Livewire::test(EditGoal::class, ['record' => $goal->getKey()])
+        ->assertFormFieldExists('user_id')
+        ->assertFormFieldExists('title')
+        ->assertFormFieldExists('type')
+        ->assertFormFieldExists('exercise_id')
+        ->assertFormFieldExists('measurement_type')
+        ->assertFormFieldExists('deadline')
+        ->assertFormSet([
+            'user_id' => (string) $owner->getKey(),
+            'exercise_id' => (string) $exercise->getKey(),
+            'title' => 'Titre initial',
+            'type' => 'volume',
+            'measurement_type' => 'tour_de_taille',
+        ]);
+});
+
+it('interdit la gestion des objectifs à un admin sans les permissions Goal', function (): void {
+    $goal = Goal::factory()->create();
+
+    $this->actingAs(FilamentAdminPanel::admin(['ViewAny:User']), 'admin');
+
+    expect(GoalResource::canViewAny())->toBeFalse()
+        ->and(GoalResource::canCreate())->toBeFalse()
+        ->and(GoalResource::canEdit($goal))->toBeFalse()
+        ->and(GoalResource::canDelete($goal))->toBeFalse();
+});

--- a/tests/Feature/Filament/RoleResourceTest.php
+++ b/tests/Feature/Filament/RoleResourceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use BezhanSalleh\FilamentShield\Resources\Roles\Pages\CreateRole;
+use BezhanSalleh\FilamentShield\Resources\Roles\Pages\EditRole;
+use BezhanSalleh\FilamentShield\Resources\Roles\Pages\ListRoles;
+use BezhanSalleh\FilamentShield\Resources\Roles\RoleResource;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\Support\FilamentAdminPanel;
+
+beforeEach(function (): void {
+    $this->actingAs(FilamentAdminPanel::admin(FilamentAdminPanel::crudPermissions('Role')), 'admin');
+});
+
+it('liste les rôles existants avec leur nom et leur guard', function (): void {
+    $editor = Role::create(['name' => 'editeur_contenu', 'guard_name' => 'admin']);
+    $support = Role::create(['name' => 'support_client', 'guard_name' => 'admin']);
+
+    Livewire::test(ListRoles::class)
+        ->assertCanSeeTableRecords([$editor, $support])
+        ->assertTableColumnStateSet('name', 'editeur_contenu', $editor)
+        ->assertTableColumnStateSet('guard_name', 'admin', $editor)
+        // la colonne name est passée à Str::headline avant affichage
+        ->assertSee('Editeur Contenu');
+});
+
+it('compte les permissions attachées à chaque rôle', function (): void {
+    $role = Role::create(['name' => 'role_a_trois_permissions', 'guard_name' => 'admin']);
+    foreach (['ViewAny:Workout', 'View:Workout', 'Update:Workout'] as $name) {
+        $role->givePermissionTo(Permission::findOrCreate($name, 'admin'));
+    }
+    $empty = Role::create(['name' => 'role_vide', 'guard_name' => 'admin']);
+
+    Livewire::test(ListRoles::class)
+        ->assertTableColumnStateSet('permissions_count', 3, $role)
+        ->assertTableColumnStateSet('permissions_count', 0, $empty);
+});
+
+it('crée un rôle sur le guard admin depuis le formulaire', function (): void {
+    Livewire::test(CreateRole::class)
+        ->fillForm(['name' => 'moderateur', 'guard_name' => 'admin'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $created = Role::query()->where('name', 'moderateur')->sole();
+
+    expect($created->guard_name)->toBe('admin');
+});
+
+it('refuse un rôle sans nom', function (): void {
+    $before = Role::query()->count();
+
+    Livewire::test(CreateRole::class)
+        ->fillForm(['name' => null, 'guard_name' => 'admin'])
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'required']);
+
+    expect(Role::query()->count())->toBe($before);
+});
+
+it('refuse un rôle dont le nom est déjà pris sur le même guard', function (): void {
+    Role::create(['name' => 'deja_pris', 'guard_name' => 'admin']);
+
+    Livewire::test(CreateRole::class)
+        ->fillForm(['name' => 'deja_pris', 'guard_name' => 'admin'])
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'unique']);
+
+    expect(Role::query()->where('name', 'deja_pris')->count())->toBe(1);
+});
+
+it('charge le rôle existant dans le formulaire et enregistre son renommage', function (): void {
+    $role = Role::create(['name' => 'ancien_role', 'guard_name' => 'admin']);
+
+    Livewire::test(EditRole::class, ['record' => $role->getKey()])
+        ->assertFormFieldExists('name')
+        ->assertFormFieldExists('guard_name')
+        ->assertFormSet(['name' => 'ancien_role', 'guard_name' => 'admin'])
+        ->fillForm(['name' => 'role_renomme'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($role->fresh()->name)->toBe('role_renomme');
+});
+
+it('interdit la gestion des rôles à un admin sans les permissions Role', function (): void {
+    $role = Role::create(['name' => 'role_protege', 'guard_name' => 'admin']);
+
+    $this->actingAs(FilamentAdminPanel::admin(['ViewAny:User']), 'admin');
+
+    expect(RoleResource::canViewAny())->toBeFalse()
+        ->and(RoleResource::canCreate())->toBeFalse()
+        ->and(RoleResource::canEdit($role))->toBeFalse()
+        ->and(RoleResource::canDelete($role))->toBeFalse();
+});

--- a/tests/Feature/Filament/SupplementResourceTest.php
+++ b/tests/Feature/Filament/SupplementResourceTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\Supplements\Pages\CreateSupplement;
+use App\Filament\Resources\Supplements\Pages\EditSupplement;
+use App\Filament\Resources\Supplements\Pages\ListSupplements;
+use App\Filament\Resources\Supplements\SupplementResource;
+use App\Models\Supplement;
+use App\Models\User;
+use Livewire\Livewire;
+use Tests\Support\FilamentAdminPanel;
+
+beforeEach(function (): void {
+    $this->actingAs(FilamentAdminPanel::admin(FilamentAdminPanel::crudPermissions('Supplement')), 'admin');
+});
+
+it('liste les suppléments avec leur propriétaire et leur stock', function (): void {
+    $owner = User::factory()->create(['name' => 'Camille Consommatrice']);
+    $supplement = Supplement::factory()->create([
+        'user_id' => $owner->getKey(),
+        'name' => 'Créatine monohydrate',
+        'brand' => 'MarqueTest',
+        'dosage' => '5g',
+        'servings_remaining' => 42,
+        'low_stock_threshold' => 8,
+    ]);
+
+    Livewire::test(ListSupplements::class)
+        ->assertCanSeeTableRecords([$supplement])
+        ->assertTableColumnStateSet('user.name', 'Camille Consommatrice', $supplement)
+        ->assertTableColumnStateSet('name', 'Créatine monohydrate', $supplement)
+        ->assertTableColumnStateSet('brand', 'MarqueTest', $supplement)
+        ->assertTableColumnStateSet('servings_remaining', 42, $supplement)
+        ->assertTableColumnStateSet('low_stock_threshold', 8, $supplement);
+});
+
+it('trie les suppléments par stock restant', function (): void {
+    $empty = Supplement::factory()->create(['servings_remaining' => 1]);
+    $full = Supplement::factory()->create(['servings_remaining' => 500]);
+    $mid = Supplement::factory()->create(['servings_remaining' => 250]);
+
+    Livewire::test(ListSupplements::class)
+        ->sortTable('servings_remaining', 'desc')
+        ->assertCanSeeTableRecords([$full, $mid, $empty], inOrder: true);
+});
+
+it('crée un supplément rattaché au bon utilisateur', function (): void {
+    $owner = User::factory()->create();
+
+    Livewire::test(CreateSupplement::class)
+        ->fillForm([
+            'user_id' => $owner->getKey(),
+            'name' => 'Whey isolate',
+            'brand' => 'MarqueY',
+            'dosage' => '30g',
+            'servings_remaining' => 60,
+            'low_stock_threshold' => 7,
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $created = Supplement::query()->where('name', 'Whey isolate')->sole();
+
+    expect($created->user_id)->toBe($owner->getKey())
+        ->and($created->brand)->toBe('MarqueY')
+        ->and($created->dosage)->toBe('30g')
+        ->and($created->servings_remaining)->toBe(60)
+        ->and($created->low_stock_threshold)->toBe(7);
+});
+
+it('refuse un supplément sans utilisateur ni nom', function (): void {
+    $before = Supplement::query()->count();
+
+    Livewire::test(CreateSupplement::class)
+        ->fillForm([
+            'user_id' => null,
+            'name' => null,
+            'servings_remaining' => 10,
+            'low_stock_threshold' => 2,
+        ])
+        ->call('create')
+        ->assertHasFormErrors([
+            'user_id' => 'required',
+            'name' => 'required',
+        ]);
+
+    expect(Supplement::query()->count())->toBe($before);
+});
+
+it('refuse un stock non numérique', function (): void {
+    $owner = User::factory()->create();
+
+    Livewire::test(CreateSupplement::class)
+        ->fillForm([
+            'user_id' => $owner->getKey(),
+            'name' => 'Magnésium',
+            'servings_remaining' => 'beaucoup',
+            'low_stock_threshold' => 5,
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['servings_remaining' => 'numeric']);
+
+    expect(Supplement::query()->where('name', 'Magnésium')->exists())->toBeFalse();
+});
+
+it('charge le supplément existant dans le formulaire et enregistre la modification', function (): void {
+    $owner = User::factory()->create();
+    $supplement = Supplement::factory()->create([
+        'user_id' => $owner->getKey(),
+        'name' => 'Ancien nom',
+        'brand' => 'AncienneMarque',
+        'dosage' => '2g',
+        'servings_remaining' => 30,
+        'low_stock_threshold' => 5,
+    ]);
+
+    Livewire::test(EditSupplement::class, ['record' => $supplement->getKey()])
+        ->assertFormFieldExists('user_id')
+        ->assertFormFieldExists('name')
+        ->assertFormFieldExists('brand')
+        ->assertFormFieldExists('dosage')
+        ->assertFormFieldExists('servings_remaining')
+        ->assertFormFieldExists('low_stock_threshold')
+        ->assertFormSet([
+            'user_id' => (string) $owner->getKey(),
+            'name' => 'Ancien nom',
+            'brand' => 'AncienneMarque',
+            'dosage' => '2g',
+            'servings_remaining' => '30',
+            'low_stock_threshold' => '5',
+        ])
+        ->fillForm([
+            'name' => 'Nom corrigé',
+            'servings_remaining' => 12,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $supplement->refresh();
+
+    expect($supplement->name)->toBe('Nom corrigé')
+        ->and($supplement->servings_remaining)->toBe(12)
+        ->and($supplement->brand)->toBe('AncienneMarque');
+});
+
+it("réaffecte un supplément à un autre utilisateur depuis l'édition", function (): void {
+    $first = User::factory()->create();
+    $second = User::factory()->create();
+    $supplement = Supplement::factory()->create(['user_id' => $first->getKey()]);
+
+    Livewire::test(EditSupplement::class, ['record' => $supplement->getKey()])
+        ->fillForm(['user_id' => $second->getKey()])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($supplement->fresh()->user_id)->toBe($second->getKey());
+});
+
+it('interdit la gestion des suppléments à un admin sans les permissions Supplement', function (): void {
+    $supplement = Supplement::factory()->create();
+
+    $this->actingAs(FilamentAdminPanel::admin(['ViewAny:User']), 'admin');
+
+    expect(SupplementResource::canViewAny())->toBeFalse()
+        ->and(SupplementResource::canCreate())->toBeFalse()
+        ->and(SupplementResource::canEdit($supplement))->toBeFalse()
+        ->and(SupplementResource::canDelete($supplement))->toBeFalse();
+});

--- a/tests/Feature/Filament/UserResourceTest.php
+++ b/tests/Feature/Filament/UserResourceTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\Users\Pages\CreateUser;
+use App\Filament\Resources\Users\Pages\EditUser;
+use App\Filament\Resources\Users\Pages\ListUsers;
+use App\Filament\Resources\Users\UserResource;
+use App\Models\User;
+use Livewire\Livewire;
+use Tests\Support\FilamentAdminPanel;
+
+beforeEach(function (): void {
+    $this->actingAs(FilamentAdminPanel::admin(FilamentAdminPanel::crudPermissions('User')), 'admin');
+});
+
+it('liste les utilisateurs existants dans la table', function (): void {
+    $users = User::factory()->count(3)->create();
+
+    Livewire::test(ListUsers::class)
+        ->assertCanSeeTableRecords($users)
+        ->assertSee($users[0]->name)
+        ->assertSee($users[0]->email);
+});
+
+it('affiche les colonnes de streak avec la valeur réelle du modèle', function (): void {
+    $user = User::factory()->create([
+        'name' => 'Streaky McStreak',
+        'current_streak' => 12,
+        'longest_streak' => 34,
+        'default_rest_time' => 145,
+    ]);
+
+    Livewire::test(ListUsers::class)
+        ->assertCanSeeTableRecords([$user])
+        ->assertTableColumnStateSet('current_streak', 12, $user)
+        ->assertTableColumnStateSet('longest_streak', 34, $user)
+        ->assertTableColumnStateSet('default_rest_time', 145, $user);
+});
+
+it('ne montre que les utilisateurs correspondant à la recherche', function (): void {
+    $matching = User::factory()->create(['name' => 'Alphonse Recherchable']);
+    $other = User::factory()->create(['name' => 'Bertrand Invisible']);
+
+    Livewire::test(ListUsers::class)
+        ->searchTable('Alphonse Recherchable')
+        ->assertCanSeeTableRecords([$matching])
+        ->assertCanNotSeeTableRecords([$other]);
+});
+
+it('trie les utilisateurs par streak courant', function (): void {
+    $low = User::factory()->create(['current_streak' => 1]);
+    $high = User::factory()->create(['current_streak' => 99]);
+    $mid = User::factory()->create(['current_streak' => 50]);
+
+    Livewire::test(ListUsers::class)
+        ->sortTable('current_streak', 'desc')
+        ->assertCanSeeTableRecords([$high, $mid, $low], inOrder: true);
+});
+
+it("affiche les emails sur la page d'index à un admin porteur de ViewAny:User", function (): void {
+    User::factory()->create(['email' => 'confidentiel@example.com']);
+
+    $this->actingAs(FilamentAdminPanel::admin(['ViewAny:User']), 'admin')
+        ->get(UserResource::getUrl('index'))
+        ->assertOk()
+        ->assertSee('confidentiel@example.com');
+});
+
+it('ne laisse fuiter aucun email à un admin sans la permission ViewAny:User', function (): void {
+    User::factory()->create(['email' => 'confidentiel@example.com']);
+
+    $this->actingAs(FilamentAdminPanel::admin([]), 'admin')
+        ->get(UserResource::getUrl('index'))
+        ->assertDontSee('confidentiel@example.com')
+        ->assertForbidden();
+});
+
+it('refuse création, édition et suppression à un admin sans les permissions correspondantes', function (): void {
+    $admin = FilamentAdminPanel::admin(['ViewAny:User']);
+    $this->actingAs($admin, 'admin');
+
+    // La cible doit porter un id différent de celui de l'admin : UserPolicy
+    // compare les deux identifiants malgré les guards distincts (test dédié plus bas).
+    $target = User::factory()->create(['id' => $admin->getKey() + 1]);
+
+    expect(UserResource::canViewAny())->toBeTrue()
+        ->and(UserResource::canCreate())->toBeFalse()
+        ->and(UserResource::canEdit($target))->toBeFalse()
+        ->and(UserResource::canDelete($target))->toBeFalse();
+});
+
+it("sert le formulaire d'édition prérempli à un admin porteur de Update:User", function (): void {
+    $granted = FilamentAdminPanel::admin(FilamentAdminPanel::crudPermissions('User'));
+    $target = User::factory()->create([
+        'id' => $granted->getKey() + 1,
+        'email' => 'cible@example.com',
+    ]);
+
+    $this->actingAs($granted, 'admin')
+        ->get(UserResource::getUrl('edit', ['record' => $target]))
+        ->assertOk()
+        ->assertSee('cible@example.com');
+});
+
+it("cache le formulaire d'édition à un admin sans la permission Update:User", function (): void {
+    $denied = FilamentAdminPanel::admin(['ViewAny:User', 'View:User']);
+
+    // Id de la cible distinct de celui de l'admin, sinon UserPolicy laisse
+    // passer par simple collision d'identifiants entre les deux tables.
+    $target = User::factory()->create([
+        'id' => $denied->getKey() + 1,
+        'email' => 'cible@example.com',
+    ]);
+
+    $this->actingAs($denied, 'admin')
+        ->get(UserResource::getUrl('edit', ['record' => $target]))
+        ->assertDontSee('cible@example.com')
+        ->assertForbidden();
+});
+
+it("charge les valeurs de l'utilisateur dans le formulaire d'édition", function (): void {
+    $user = User::factory()->create([
+        'name' => 'Ancien Nom',
+        'email' => 'ancien@example.com',
+        'default_rest_time' => 75,
+        'current_streak' => 4,
+        'longest_streak' => 9,
+    ]);
+
+    Livewire::test(EditUser::class, ['record' => $user->getKey()])
+        ->assertFormFieldExists('name')
+        ->assertFormFieldExists('email')
+        ->assertFormFieldExists('default_rest_time')
+        ->assertFormFieldExists('current_streak')
+        ->assertFormFieldExists('longest_streak')
+        ->assertFormSet([
+            'name' => 'Ancien Nom',
+            'email' => 'ancien@example.com',
+            'default_rest_time' => '75',
+            'current_streak' => '4',
+            'longest_streak' => '9',
+        ]);
+});
+
+it('refuse la création sans nom et avec un email invalide', function (): void {
+    $before = User::query()->count();
+
+    Livewire::test(CreateUser::class)
+        ->fillForm([
+            'name' => null,
+            'email' => 'pas-un-email',
+            'default_rest_time' => 90,
+        ])
+        ->call('create')
+        ->assertHasFormErrors([
+            'name' => 'required',
+            'email' => 'email',
+        ]);
+
+    expect(User::query()->count())->toBe($before);
+});
+
+it('refuse la création sans temps de repos par défaut', function (): void {
+    Livewire::test(CreateUser::class)
+        ->fillForm([
+            'name' => 'Sans Repos',
+            'email' => 'sans-repos@example.com',
+            'default_rest_time' => null,
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['default_rest_time' => 'required']);
+
+    expect(User::query()->where('email', 'sans-repos@example.com')->exists())->toBeFalse();
+});

--- a/tests/Feature/Filament/WorkoutResourceTest.php
+++ b/tests/Feature/Filament/WorkoutResourceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\Workouts\Pages\CreateWorkout;
+use App\Filament\Resources\Workouts\Pages\EditWorkout;
+use App\Filament\Resources\Workouts\Pages\ListWorkouts;
+use App\Filament\Resources\Workouts\WorkoutResource;
+use App\Models\User;
+use App\Models\Workout;
+use Illuminate\Support\Carbon;
+use Livewire\Livewire;
+use Tests\Support\FilamentAdminPanel;
+
+beforeEach(function (): void {
+    $this->actingAs(FilamentAdminPanel::admin(FilamentAdminPanel::crudPermissions('Workout')), 'admin');
+});
+
+it('liste les séances avec leur propriétaire et leurs horaires', function (): void {
+    $owner = User::factory()->create(['name' => 'Sportive Sophie']);
+    $workout = Workout::factory()->create([
+        'user_id' => $owner->getKey(),
+        'name' => 'Séance du lundi',
+        'started_at' => Carbon::parse('2026-03-02 18:00:00'),
+        'ended_at' => Carbon::parse('2026-03-02 19:15:00'),
+    ]);
+
+    Livewire::test(ListWorkouts::class)
+        ->assertCanSeeTableRecords([$workout])
+        ->assertTableColumnStateSet('user.name', 'Sportive Sophie', $workout)
+        ->assertTableColumnStateSet('name', 'Séance du lundi', $workout)
+        ->assertTableColumnStateSet('started_at', Carbon::parse('2026-03-02 18:00:00'), $workout)
+        ->assertTableColumnStateSet('ended_at', Carbon::parse('2026-03-02 19:15:00'), $workout);
+});
+
+it('trie les séances de la plus récente à la plus ancienne', function (): void {
+    $oldest = Workout::factory()->create(['started_at' => Carbon::parse('2026-01-01 08:00:00')]);
+    $newest = Workout::factory()->create(['started_at' => Carbon::parse('2026-06-01 08:00:00')]);
+    $middle = Workout::factory()->create(['started_at' => Carbon::parse('2026-03-01 08:00:00')]);
+
+    Livewire::test(ListWorkouts::class)
+        ->sortTable('started_at', 'desc')
+        ->assertCanSeeTableRecords([$newest, $middle, $oldest], inOrder: true);
+});
+
+it('cherche une séance par le nom de son propriétaire', function (): void {
+    $wantedOwner = User::factory()->create(['name' => 'Gaspard Cherché']);
+    $wanted = Workout::factory()->create(['user_id' => $wantedOwner->getKey()]);
+    $unwanted = Workout::factory()->create();
+
+    Livewire::test(ListWorkouts::class)
+        ->searchTable('Gaspard Cherché')
+        ->assertCanSeeTableRecords([$wanted])
+        ->assertCanNotSeeTableRecords([$unwanted]);
+});
+
+it('refuse une séance sans utilisateur et sans date de début', function (): void {
+    $before = Workout::query()->count();
+
+    Livewire::test(CreateWorkout::class)
+        ->fillForm([
+            'user_id' => null,
+            'name' => 'Séance orpheline',
+            'started_at' => null,
+        ])
+        ->call('create')
+        ->assertHasFormErrors([
+            'user_id' => 'required',
+            'started_at' => 'required',
+        ]);
+
+    expect(Workout::query()->count())->toBe($before);
+});
+
+it("refuse une date de début qui n'est pas une date", function (): void {
+    $owner = User::factory()->create();
+
+    Livewire::test(CreateWorkout::class)
+        ->fillForm([
+            'user_id' => $owner->getKey(),
+            'name' => 'Séance mal datée',
+            'started_at' => 'un jour de pluie',
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['started_at']);
+
+    expect(Workout::query()->where('name', 'Séance mal datée')->exists())->toBeFalse();
+});
+
+it("charge la séance existante dans le formulaire d'édition", function (): void {
+    $owner = User::factory()->create();
+    $workout = Workout::factory()->create([
+        'user_id' => $owner->getKey(),
+        'name' => 'Nom initial',
+        'started_at' => Carbon::parse('2026-02-10 07:30:00'),
+        'ended_at' => Carbon::parse('2026-02-10 08:45:00'),
+        'notes' => 'Bonne séance.',
+    ]);
+
+    Livewire::test(EditWorkout::class, ['record' => $workout->getKey()])
+        ->assertFormFieldExists('user_id')
+        ->assertFormFieldExists('name')
+        ->assertFormFieldExists('started_at')
+        ->assertFormFieldExists('ended_at')
+        ->assertFormFieldExists('notes')
+        ->assertFormSet([
+            'user_id' => (string) $owner->getKey(),
+            'name' => 'Nom initial',
+            'started_at' => '2026-02-10 07:30:00',
+            'ended_at' => '2026-02-10 08:45:00',
+            'notes' => 'Bonne séance.',
+        ]);
+});
+
+it('interdit la gestion des séances à un admin sans les permissions Workout', function (): void {
+    $workout = Workout::factory()->create();
+
+    $this->actingAs(FilamentAdminPanel::admin(['ViewAny:User']), 'admin');
+
+    expect(WorkoutResource::canViewAny())->toBeFalse()
+        ->and(WorkoutResource::canCreate())->toBeFalse()
+        ->and(WorkoutResource::canEdit($workout))->toBeFalse()
+        ->and(WorkoutResource::canDelete($workout))->toBeFalse();
+});

--- a/tests/Feature/Notifications/DatabaseNotificationPayloadTest.php
+++ b/tests/Feature/Notifications/DatabaseNotificationPayloadTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PersonalRecordType;
+use App\Models\Achievement;
+use App\Models\Exercise;
+use App\Models\NotificationPreference;
+use App\Models\PersonalRecord;
+use App\Models\User;
+use App\Notifications\AchievementUnlocked;
+use App\Notifications\PersonalRecordAchieved;
+use App\Notifications\TrainingReminder;
+use Illuminate\Support\Carbon;
+
+/*
+ * toArray() is what lands in the `notifications` table and what the in-app bell
+ * renders. These tests assert the shape and the values, then send the
+ * notification for real (no Notification::fake) so the payload is proven to
+ * survive JSON encoding and the round trip back out of the database.
+ *
+ * "now" is frozen at a date distinct from every fixture date, so a regression
+ * that swaps a record's own timestamp for now() fails instead of coinciding.
+ */
+
+beforeEach(function (): void {
+    $this->travelTo(Carbon::parse('2026-08-12 18:00:00'));
+});
+
+describe('PersonalRecordAchieved::toArray', function (): void {
+    it('describes the record with its exercise, label and weight', function (): void {
+        $user = User::factory()->create();
+        $record = PersonalRecord::factory()->create([
+            'user_id' => $user->id,
+            'exercise_id' => Exercise::factory()->create(['name' => 'Développé Couché'])->id,
+            'type' => PersonalRecordType::MaxWeight,
+            'value' => 102.5,
+            'achieved_at' => Carbon::parse('2026-03-04 09:30:00'),
+        ])->fresh();
+
+        $data = new PersonalRecordAchieved($record)->toArray($user);
+
+        expect($data['type'])->toBe('personal_record')
+            ->and($data['title'])->toBe('Nouveau Record ! 🏆')
+            ->and($data['message'])->toBe(
+                "Félicitations ! Tu as battu ton record de Poids Maximum sur l'exercice Développé Couché avec 102.50kg."
+            )
+            ->and($data['exercise_id'])->toBe($record->exercise_id)
+            ->and($data['achieved_at'])->toBeInstanceOf(Carbon::class);
+
+        expect(array_keys($data))
+            ->toEqualCanonicalizing(['type', 'title', 'message', 'exercise_id', 'achieved_at']);
+    });
+
+    it('reports the moment the record was set, not the moment of sending', function (): void {
+        $user = User::factory()->create();
+        $record = PersonalRecord::factory()->create([
+            'user_id' => $user->id,
+            'achieved_at' => Carbon::parse('2026-03-04 09:30:00'),
+        ])->fresh();
+
+        $achievedAt = new PersonalRecordAchieved($record)->toArray($user)['achieved_at'];
+
+        expect($achievedAt->format('Y-m-d H:i:s'))->toBe('2026-03-04 09:30:00')
+            ->and($achievedAt->format('Y-m-d H:i:s'))->not->toBe(now()->format('Y-m-d H:i:s'));
+    });
+
+    it('survives a real round trip through the notifications table', function (): void {
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'personal_record',
+            'is_enabled' => true,
+            'is_push_enabled' => false,
+            'value' => null,
+        ]);
+        $record = PersonalRecord::factory()->create([
+            'user_id' => $user->id,
+            'exercise_id' => Exercise::factory()->create(['name' => 'Soulevé de Terre'])->id,
+            'type' => PersonalRecordType::Max1RM,
+            'value' => 187.25,
+            'achieved_at' => Carbon::parse('2026-03-04 09:30:00'),
+        ])->fresh();
+
+        $user->notify(new PersonalRecordAchieved($record));
+
+        $stored = $user->notifications()->sole();
+
+        expect($stored->type)->toBe(PersonalRecordAchieved::class)
+            ->and($stored->read_at)->toBeNull()
+            ->and($stored->notifiable_id)->toBe($user->id)
+            ->and($stored->data['type'])->toBe('personal_record')
+            ->and($stored->data['title'])->toBe('Nouveau Record ! 🏆')
+            ->and($stored->data['message'])->toBe(
+                "Félicitations ! Tu as battu ton record de 1RM Estimé sur l'exercice Soulevé de Terre avec 187.25kg."
+            )
+            ->and($stored->data['exercise_id'])->toBe($record->exercise_id);
+
+        // The JSON payload is serialised in UTC; read it back and compare the
+        // instant, so the assertion is not hostage to the app timezone.
+        expect(Carbon::parse($stored->data['achieved_at'])->setTimezone(config('app.timezone'))->toDateTimeString())
+            ->toBe('2026-03-04 09:30:00')
+            ->and(Carbon::parse($stored->data['achieved_at'])->toDateTimeString())
+            ->not->toBe(now()->utc()->toDateTimeString());
+
+        expect($user->unreadNotifications()->count())->toBe(1);
+    });
+});
+
+describe('AchievementUnlocked::toArray', function (): void {
+    it('describes the unlocked achievement', function (): void {
+        $user = User::factory()->create();
+        $achievement = Achievement::factory()->create(['name' => 'Marathonien du Fer']);
+
+        $data = new AchievementUnlocked($achievement)->toArray($user);
+
+        expect($data['type'])->toBe('achievement')
+            ->and($data['title'])->toBe('Succès Déverrouillé ! 🏆')
+            ->and($data['message'])->toBe('Félicitations ! Tu as déverrouillé le succès : Marathonien du Fer.')
+            ->and($data['achievement_id'])->toBe($achievement->id)
+            ->and($data['achieved_at']->format('Y-m-d H:i:s'))->toBe('2026-08-12 18:00:00');
+
+        expect(array_keys($data))
+            ->toEqualCanonicalizing(['type', 'title', 'message', 'achievement_id', 'achieved_at']);
+    });
+
+    it('survives a real round trip and is findable by the class the bell filters on', function (): void {
+        $user = User::factory()->create();
+        $achievement = Achievement::factory()->create(['name' => 'Première Séance']);
+
+        $user->notify(new AchievementUnlocked($achievement));
+
+        $stored = $user->unreadNotifications()
+            ->where('type', AchievementUnlocked::class)
+            ->sole();
+
+        expect($stored->data['type'])->toBe('achievement')
+            ->and($stored->data['title'])->toBe('Succès Déverrouillé ! 🏆')
+            ->and($stored->data['message'])->toBe('Félicitations ! Tu as déverrouillé le succès : Première Séance.')
+            ->and($stored->data['achievement_id'])->toBe($achievement->id);
+
+        expect(Carbon::parse($stored->data['achieved_at'])->setTimezone(config('app.timezone'))->toDateTimeString())
+            ->toBe('2026-08-12 18:00:00');
+    });
+});
+
+describe('TrainingReminder::toArray', function (): void {
+    it('uses the default message and the sending time', function (): void {
+        $user = User::factory()->create();
+
+        $data = new TrainingReminder()->toArray($user);
+
+        expect($data['type'])->toBe('training_reminder')
+            ->and($data['title'])->toBe("Rappel d'entraînement")
+            ->and($data['message'])->toBe("C'est le moment de s'entraîner ! 💪")
+            ->and($data['sent_at']->format('Y-m-d H:i:s'))->toBe('2026-08-12 18:00:00');
+
+        expect(array_keys($data))
+            ->toEqualCanonicalizing(['type', 'title', 'message', 'sent_at']);
+    });
+
+    it('keeps a custom message and does not overwrite it with the default', function (): void {
+        $user = User::factory()->create();
+
+        $data = new TrainingReminder('4 jours sans séance !')->toArray($user);
+
+        expect($data['message'])->toBe('4 jours sans séance !')
+            ->and($data['title'])->toBe("Rappel d'entraînement");
+    });
+
+    it('survives a real round trip through the notifications table', function (): void {
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'training_reminder',
+            'is_enabled' => true,
+            'is_push_enabled' => false,
+            'value' => null,
+        ]);
+
+        $user->notify(new TrainingReminder('4 jours sans séance !'));
+
+        $stored = $user->notifications()->sole();
+
+        expect($stored->type)->toBe(TrainingReminder::class)
+            ->and($stored->data['type'])->toBe('training_reminder')
+            ->and($stored->data['title'])->toBe("Rappel d'entraînement")
+            ->and($stored->data['message'])->toBe('4 jours sans séance !');
+
+        expect(Carbon::parse($stored->data['sent_at'])->setTimezone(config('app.timezone'))->toDateTimeString())
+            ->toBe('2026-08-12 18:00:00');
+    });
+});
+
+describe('the in-app notification is stored regardless of the push preference', function (): void {
+    it('stores exactly one database row when push is enabled but no subscription exists', function (): void {
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'training_reminder',
+            'is_enabled' => true,
+            'is_push_enabled' => true,
+            'value' => null,
+        ]);
+
+        $user->notify(new TrainingReminder('On y retourne !'));
+
+        expect($user->notifications()->count())->toBe(1)
+            ->and($user->notifications()->sole()->data['message'])->toBe('On y retourne !');
+    });
+});

--- a/tests/Feature/Notifications/NotificationChannelRoutingTest.php
+++ b/tests/Feature/Notifications/NotificationChannelRoutingTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PersonalRecordType;
+use App\Models\Achievement;
+use App\Models\Exercise;
+use App\Models\NotificationPreference;
+use App\Models\PersonalRecord;
+use App\Models\User;
+use App\Notifications\AchievementUnlocked;
+use App\Notifications\PersonalRecordAchieved;
+use App\Notifications\TrainingReminder;
+use NotificationChannels\WebPush\WebPushChannel;
+
+/*
+ * via() decides whether the user's phone buzzes. It is gated on the
+ * `is_push_enabled` column of the NotificationPreference row matching the
+ * notification's own type key. Both branches are asserted for each
+ * notification: a regression in either direction is silent — too few channels
+ * means no push ever, too many means pushing to users who opted out.
+ */
+
+describe('PersonalRecordAchieved::via', function (): void {
+    it('sends to the database only when the user has no preference row at all', function (): void {
+        $user = User::factory()->create();
+        $record = PersonalRecord::factory()->create(['user_id' => $user->id]);
+
+        $channels = new PersonalRecordAchieved($record)->via($user);
+
+        expect($channels)->toBe(['database'])
+            ->and($channels)->not->toContain(WebPushChannel::class);
+    });
+
+    it('adds the web push channel when push is enabled for personal records', function (): void {
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'personal_record',
+            'is_enabled' => true,
+            'is_push_enabled' => true,
+            'value' => null,
+        ]);
+        $record = PersonalRecord::factory()->create(['user_id' => $user->id]);
+
+        expect(new PersonalRecordAchieved($record)->via($user))
+            ->toBe(['database', WebPushChannel::class]);
+    });
+
+    it('withholds the web push channel when the in-app preference is on but push is off', function (): void {
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'personal_record',
+            'is_enabled' => true,
+            'is_push_enabled' => false,
+            'value' => null,
+        ]);
+        $record = PersonalRecord::factory()->create(['user_id' => $user->id]);
+
+        $channels = new PersonalRecordAchieved($record)->via($user);
+
+        expect($channels)->toBe(['database'])
+            ->and($channels)->not->toContain(WebPushChannel::class);
+    });
+
+    it('gates push on is_push_enabled alone, independently of the in-app preference', function (): void {
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'personal_record',
+            'is_enabled' => false,
+            'is_push_enabled' => true,
+            'value' => null,
+        ]);
+        $record = PersonalRecord::factory()->create(['user_id' => $user->id]);
+
+        expect(new PersonalRecordAchieved($record)->via($user))
+            ->toBe(['database', WebPushChannel::class]);
+    });
+
+    it('does not let another type\'s push opt-in turn on personal record push', function (): void {
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'training_reminder',
+            'is_enabled' => true,
+            'is_push_enabled' => true,
+            'value' => null,
+        ]);
+        $record = PersonalRecord::factory()->create(['user_id' => $user->id]);
+
+        expect(new PersonalRecordAchieved($record)->via($user))->toBe(['database']);
+    });
+
+    it('does not let another user\'s push opt-in turn on push for this user', function (): void {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $other->id,
+            'type' => 'personal_record',
+            'is_enabled' => true,
+            'is_push_enabled' => true,
+            'value' => null,
+        ]);
+        $record = PersonalRecord::factory()->create(['user_id' => $user->id]);
+
+        expect(new PersonalRecordAchieved($record)->via($user))->toBe(['database']);
+    });
+
+    it('reads an eager-loaded preference relation the same way it reads the database', function (): void {
+        // TrainingReminderCommand hydrates notificationPreferences to avoid an N+1,
+        // which takes the in-memory branch of User::isPushEnabled(). Both branches
+        // must agree or the scheduled command silently stops pushing.
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'personal_record',
+            'is_enabled' => true,
+            'is_push_enabled' => true,
+            'value' => null,
+        ]);
+        $record = PersonalRecord::factory()->create(['user_id' => $user->id]);
+
+        $hydrated = User::query()->with('notificationPreferences')->findOrFail($user->id);
+        expect($hydrated->relationLoaded('notificationPreferences'))->toBeTrue();
+
+        expect(new PersonalRecordAchieved($record)->via($hydrated))
+            ->toBe(['database', WebPushChannel::class]);
+    });
+
+    it('withholds push from an eager-loaded relation whose push flag is off', function (): void {
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'personal_record',
+            'is_enabled' => true,
+            'is_push_enabled' => false,
+            'value' => null,
+        ]);
+        $record = PersonalRecord::factory()->create(['user_id' => $user->id]);
+
+        $hydrated = User::query()->with('notificationPreferences')->findOrFail($user->id);
+
+        expect(new PersonalRecordAchieved($record)->via($hydrated))->toBe(['database']);
+    });
+});
+
+describe('TrainingReminder::via', function (): void {
+    it('sends to the database only when push is disabled', function (): void {
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'training_reminder',
+            'is_enabled' => true,
+            'is_push_enabled' => false,
+            'value' => null,
+        ]);
+
+        expect(new TrainingReminder()->via($user))->toBe(['database']);
+    });
+
+    it('adds the web push channel when push is enabled for training reminders', function (): void {
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'training_reminder',
+            'is_enabled' => true,
+            'is_push_enabled' => true,
+            'value' => null,
+        ]);
+
+        expect(new TrainingReminder()->via($user))->toBe(['database', WebPushChannel::class]);
+    });
+
+    it('reads an eager-loaded preference relation, as the reminder command hydrates it', function (): void {
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'training_reminder',
+            'is_enabled' => true,
+            'is_push_enabled' => true,
+            'value' => null,
+        ]);
+
+        $hydrated = User::query()->with('notificationPreferences')->findOrFail($user->id);
+
+        expect(new TrainingReminder()->via($hydrated))->toBe(['database', WebPushChannel::class]);
+    });
+});
+
+describe('AchievementUnlocked::via', function (): void {
+    it('sends to the database only when push is disabled', function (): void {
+        $user = User::factory()->create();
+        $achievement = Achievement::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'achievement',
+            'is_enabled' => true,
+            'is_push_enabled' => false,
+            'value' => null,
+        ]);
+
+        expect(new AchievementUnlocked($achievement)->via($user))->toBe(['database']);
+    });
+
+    it('adds the web push channel when push is enabled for achievements', function (): void {
+        $user = User::factory()->create();
+        $achievement = Achievement::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'achievement',
+            'is_enabled' => true,
+            'is_push_enabled' => true,
+            'value' => null,
+        ]);
+
+        expect(new AchievementUnlocked($achievement)->via($user))
+            ->toBe(['database', WebPushChannel::class]);
+    });
+
+    it('is gated on the "achievement" key, not the "achievement_unlocked" key the preferences form accepts', function (): void {
+        // Characterisation test for a real mismatch: UpdateNotificationPreferencesRequest
+        // whitelists "achievement_unlocked", while AchievementUnlocked::via() asks for
+        // "achievement". A row saved through the profile form therefore never turns
+        // achievement push on. Change the key on one side and this test tells you.
+        $user = User::factory()->create();
+        $achievement = Achievement::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'achievement_unlocked',
+            'is_enabled' => true,
+            'is_push_enabled' => true,
+            'value' => null,
+        ]);
+
+        expect(new AchievementUnlocked($achievement)->via($user))->toBe(['database']);
+    });
+});
+
+describe('the enum-typed record survives the round trip into via()', function (): void {
+    it('routes a max weight record exactly like any other type', function (): void {
+        $user = User::factory()->create();
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'personal_record',
+            'is_enabled' => true,
+            'is_push_enabled' => true,
+            'value' => null,
+        ]);
+        $record = PersonalRecord::factory()->create([
+            'user_id' => $user->id,
+            'exercise_id' => Exercise::factory()->create(['name' => 'Squat'])->id,
+            'type' => PersonalRecordType::MaxWeight,
+        ]);
+
+        expect($record->fresh()->type)->toBe(PersonalRecordType::MaxWeight)
+            ->and(new PersonalRecordAchieved($record)->via($user))
+            ->toBe(['database', WebPushChannel::class]);
+    });
+});

--- a/tests/Feature/Notifications/WebPushPayloadTest.php
+++ b/tests/Feature/Notifications/WebPushPayloadTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\PersonalRecordType;
+use App\Models\Achievement;
+use App\Models\Exercise;
+use App\Models\NotificationPreference;
+use App\Models\PersonalRecord;
+use App\Models\User;
+use App\Notifications\AchievementUnlocked;
+use App\Notifications\PersonalRecordAchieved;
+use App\Notifications\TrainingReminder;
+use Minishlink\WebPush\Subscription;
+use Minishlink\WebPush\WebPush;
+use NotificationChannels\WebPush\WebPushChannel;
+
+/*
+ * toWebPush() builds the payload the phone actually renders: title, body, icon
+ * and the action button. Nothing renders it in production before delivery, so a
+ * formatting regression (wrong label, wrong unit, wrong deep link) ships
+ * unnoticed. These tests build the payload from fixed fixtures and assert every
+ * key, then drive one payload end to end through the real WebPushChannel with
+ * only the HTTP transport (Minishlink\WebPush) faked.
+ */
+
+/**
+ * Builds a persisted personal record with fully known content.
+ */
+function makePersonalRecordFixture(PersonalRecordType $type, string $exerciseName, float $value): PersonalRecord
+{
+    $user = User::factory()->create();
+
+    return PersonalRecord::factory()->create([
+        'user_id' => $user->id,
+        'exercise_id' => Exercise::factory()->create(['name' => $exerciseName])->id,
+        'type' => $type,
+        'value' => $value,
+        'achieved_at' => Carbon\CarbonImmutable::parse('2026-03-04 09:30:00'),
+    ])->fresh();
+}
+
+describe('PersonalRecordAchieved::toWebPush', function (): void {
+    it('renders the full push payload from the record', function (): void {
+        $record = makePersonalRecordFixture(PersonalRecordType::MaxWeight, 'Développé Couché', 102.5);
+
+        $payload = new PersonalRecordAchieved($record)->toWebPush($record->user, null)->toArray();
+
+        expect($payload)->toEqual([
+            'title' => 'Nouveau Record ! 🏆',
+            'actions' => [
+                ['title' => 'Voir mes stats', 'action' => url('/stats')],
+            ],
+            'body' => "Félicitations ! Tu as battu ton record de Poids Maximum sur l'exercice Développé Couché avec 102.50kg.",
+            'icon' => '/logo.svg',
+        ]);
+    });
+
+    it('puts the exercise name, the weight and the two decimals in the body', function (): void {
+        $record = makePersonalRecordFixture(PersonalRecordType::MaxWeight, 'Soulevé de Terre', 187.25);
+
+        $body = new PersonalRecordAchieved($record)->toWebPush($record->user, null)->toArray()['body'];
+
+        expect($body)
+            ->toContain('Soulevé de Terre')
+            ->toContain('187.25kg')
+            ->not->toContain('187.3')
+            ->not->toContain('{');
+    });
+
+    it('labels every record type it knows about', function (PersonalRecordType $type, string $expectedLabel): void {
+        $record = makePersonalRecordFixture($type, 'Rowing Barre', 60.0);
+
+        $body = new PersonalRecordAchieved($record)->toWebPush($record->user, null)->toArray()['body'];
+
+        expect($body)->toBe(
+            "Félicitations ! Tu as battu ton record de {$expectedLabel} sur l'exercice Rowing Barre avec 60.00kg."
+        );
+    })->with([
+        'max weight' => [PersonalRecordType::MaxWeight, 'Poids Maximum'],
+        'estimated 1RM' => [PersonalRecordType::Max1RM, '1RM Estimé'],
+        'best set volume' => [PersonalRecordType::MaxVolumeSet, 'Volume par Série'],
+        'legacy strength falls back' => [PersonalRecordType::Strength, 'Record Personnel'],
+        'legacy 1RM falls back' => [PersonalRecordType::OneRM, 'Record Personnel'],
+        'legacy volume falls back' => [PersonalRecordType::Volume, 'Record Personnel'],
+    ]);
+
+    it('links the action to the stats page and nothing else', function (): void {
+        $record = makePersonalRecordFixture(PersonalRecordType::Max1RM, 'Squat', 140.0);
+
+        $actions = new PersonalRecordAchieved($record)->toWebPush($record->user, null)->toArray()['actions'];
+
+        expect($actions)->toHaveCount(1)
+            ->and($actions[0]['action'])->toBe(url('/stats'))
+            ->and($actions[0]['action'])->toEndWith('/stats')
+            ->and($actions[0]['title'])->toBe('Voir mes stats');
+    });
+});
+
+describe('AchievementUnlocked::toWebPush', function (): void {
+    it('renders the full push payload from the achievement', function (): void {
+        $user = User::factory()->create();
+        $achievement = Achievement::factory()->create(['name' => 'Marathonien du Fer']);
+
+        $payload = new AchievementUnlocked($achievement)->toWebPush($user, null)->toArray();
+
+        expect($payload)->toEqual([
+            'title' => 'Succès Déverrouillé ! 🏆',
+            'actions' => [
+                ['title' => 'Voir mes succès', 'action' => url('/achievements')],
+            ],
+            'body' => 'Félicitations ! Tu as déverrouillé le succès : Marathonien du Fer.',
+            'icon' => '/logo.svg',
+        ]);
+    });
+
+    it('carries the achievement name through to the body', function (): void {
+        $user = User::factory()->create();
+        $achievement = Achievement::factory()->create(['name' => 'Première Séance']);
+
+        $body = new AchievementUnlocked($achievement)->toWebPush($user, null)->toArray()['body'];
+
+        expect($body)->toBe('Félicitations ! Tu as déverrouillé le succès : Première Séance.')
+            ->and($body)->not->toContain('achievement');
+    });
+});
+
+describe('TrainingReminder::toWebPush', function (): void {
+    it('renders the default reminder payload', function (): void {
+        $user = User::factory()->create();
+
+        $payload = new TrainingReminder()->toWebPush($user, null)->toArray();
+
+        expect($payload)->toEqual([
+            'title' => 'Prêt pour ta séance ? 💪',
+            'actions' => [
+                ['title' => 'Ouvrir Gym Tracker', 'action' => url('/')],
+            ],
+            'body' => "C'est le moment de s'entraîner ! 💪",
+            'icon' => '/logo.svg',
+        ]);
+    });
+
+    it('uses the custom message as the body when one is given', function (): void {
+        $user = User::factory()->create();
+
+        $payload = new TrainingReminder('3 jours sans séance, on y retourne ?')->toWebPush($user, null)->toArray();
+
+        expect($payload['body'])->toBe('3 jours sans séance, on y retourne ?')
+            ->and($payload['title'])->toBe('Prêt pour ta séance ? 💪');
+    });
+
+    it('falls back to the default message when null is passed explicitly', function (): void {
+        $user = User::factory()->create();
+
+        expect(new TrainingReminder(null)->toWebPush($user, null)->toArray()['body'])
+            ->toBe("C'est le moment de s'entraîner ! 💪");
+    });
+});
+
+describe('end-to-end delivery through the real WebPushChannel', function (): void {
+    it('queues the rendered JSON payload against the user\'s subscription', function (): void {
+        $record = makePersonalRecordFixture(PersonalRecordType::MaxWeight, 'Développé Couché', 102.5);
+        $user = $record->user;
+
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'personal_record',
+            'is_enabled' => true,
+            'is_push_enabled' => true,
+            'value' => null,
+        ]);
+
+        $user->updatePushSubscription(
+            'https://fcm.googleapis.com/fcm/send/endpoint-e2e',
+            'p256dh-key',
+            'auth-token',
+        );
+
+        // Only the HTTP transport to the push service is faked; via(), the
+        // channel and toWebPush() all run for real.
+        $queued = [];
+        $transport = Mockery::mock(WebPush::class);
+        $transport->shouldReceive('queueNotification')
+            ->andReturnUsing(function (Subscription $subscription, ?string $payload = null) use (&$queued): void {
+                $queued[] = ['endpoint' => $subscription->getEndpoint(), 'payload' => $payload];
+            });
+        $transport->shouldReceive('flush')->andReturnUsing(function (): Generator {
+            yield from [];
+        });
+
+        app()->when(WebPushChannel::class)->needs(WebPush::class)->give(fn (): WebPush => $transport);
+
+        $user->notify(new PersonalRecordAchieved($record));
+
+        expect($queued)->toHaveCount(1)
+            ->and($queued[0]['endpoint'])->toBe('https://fcm.googleapis.com/fcm/send/endpoint-e2e');
+
+        $decoded = json_decode((string) $queued[0]['payload'], true, 512, JSON_THROW_ON_ERROR);
+
+        expect($decoded)->toEqual([
+            'title' => 'Nouveau Record ! 🏆',
+            'actions' => [
+                ['title' => 'Voir mes stats', 'action' => url('/stats')],
+            ],
+            'body' => "Félicitations ! Tu as battu ton record de Poids Maximum sur l'exercice Développé Couché avec 102.50kg.",
+            'icon' => '/logo.svg',
+        ]);
+    });
+
+    it('never reaches the push transport when the user turned push off', function (): void {
+        $record = makePersonalRecordFixture(PersonalRecordType::MaxWeight, 'Développé Couché', 102.5);
+        $user = $record->user;
+
+        NotificationPreference::factory()->create([
+            'user_id' => $user->id,
+            'type' => 'personal_record',
+            'is_enabled' => true,
+            'is_push_enabled' => false,
+            'value' => null,
+        ]);
+
+        $user->updatePushSubscription(
+            'https://fcm.googleapis.com/fcm/send/endpoint-optout',
+            'p256dh-key',
+            'auth-token',
+        );
+
+        $transport = Mockery::mock(WebPush::class);
+        $transport->shouldNotReceive('queueNotification');
+        $transport->shouldNotReceive('flush');
+
+        app()->when(WebPushChannel::class)->needs(WebPush::class)->give(fn (): WebPush => $transport);
+
+        $user->notify(new PersonalRecordAchieved($record));
+
+        // The in-app notification is still stored: only the push leg is skipped.
+        expect($user->notifications()->count())->toBe(1);
+    });
+});

--- a/tests/Feature/Policies/OwnershipBoundaryTest.php
+++ b/tests/Feature/Policies/OwnershipBoundaryTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\BodyMeasurement;
+use App\Models\BodyPartMeasurement;
+use App\Models\DailyJournal;
+use App\Models\Fast;
+use App\Models\Goal;
+use App\Models\Habit;
+use App\Models\HabitLog;
+use App\Models\IntervalTimer;
+use App\Models\MacroCalculation;
+use App\Models\NotificationPreference;
+use App\Models\PersonalRecord;
+use App\Models\Plate;
+use App\Models\Set;
+use App\Models\Supplement;
+use App\Models\SupplementLog;
+use App\Models\User;
+use App\Models\WaterLog;
+use App\Models\WilksScore;
+use App\Models\Workout;
+use App\Models\WorkoutLine;
+use App\Models\WorkoutTemplate;
+use App\Models\WorkoutTemplateLine;
+use App\Models\WorkoutTemplateSet;
+use App\Policies\BodyMeasurementPolicy;
+use App\Policies\BodyPartMeasurementPolicy;
+use App\Policies\DailyJournalPolicy;
+use App\Policies\FastPolicy;
+use App\Policies\GoalPolicy;
+use App\Policies\HabitLogPolicy;
+use App\Policies\HabitPolicy;
+use App\Policies\IntervalTimerPolicy;
+use App\Policies\MacroCalculationPolicy;
+use App\Policies\NotificationPreferencePolicy;
+use App\Policies\PersonalRecordPolicy;
+use App\Policies\PlatePolicy;
+use App\Policies\SetPolicy;
+use App\Policies\SupplementLogPolicy;
+use App\Policies\SupplementPolicy;
+use App\Policies\WarmupPreferencePolicy;
+use App\Policies\WaterLogPolicy;
+use App\Policies\WilksScorePolicy;
+use App\Policies\WorkoutLinePolicy;
+use App\Policies\WorkoutPolicy;
+use App\Policies\WorkoutTemplateLinePolicy;
+use App\Policies\WorkoutTemplatePolicy;
+use App\Policies\WorkoutTemplateSetPolicy;
+use Database\Factories\WarmupPreferenceFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Every record-scoped policy whose whole job is "this row belongs to this user",
+ * with a recipe that builds one such row for a given owner.
+ *
+ * Recipes live in a function rather than in the dataset itself so the dataset
+ * stays a flat list of names, which is what Pest prints on failure.
+ *
+ * @return array<string, array{0: class-string, 1: \Closure(User): Model}>
+ */
+function ownedRecordRecipes(): array
+{
+    return [
+        'body measurement' => [BodyMeasurementPolicy::class, fn (User $owner): Model => BodyMeasurement::factory()->create(['user_id' => $owner->id])],
+        'body part measurement' => [BodyPartMeasurementPolicy::class, fn (User $owner): Model => BodyPartMeasurement::factory()->create(['user_id' => $owner->id])],
+        'daily journal' => [DailyJournalPolicy::class, fn (User $owner): Model => DailyJournal::factory()->create(['user_id' => $owner->id])],
+        'fast' => [FastPolicy::class, fn (User $owner): Model => Fast::factory()->create(['user_id' => $owner->id])],
+        'goal' => [GoalPolicy::class, fn (User $owner): Model => Goal::factory()->create(['user_id' => $owner->id])],
+        'habit' => [HabitPolicy::class, fn (User $owner): Model => Habit::factory()->create(['user_id' => $owner->id])],
+        'habit log' => [HabitLogPolicy::class, fn (User $owner): Model => HabitLog::factory()
+            ->for(Habit::factory()->create(['user_id' => $owner->id]))
+            ->create()
+            ->load('habit')],
+        'interval timer' => [IntervalTimerPolicy::class, fn (User $owner): Model => IntervalTimer::factory()->create(['user_id' => $owner->id])],
+        'macro calculation' => [MacroCalculationPolicy::class, fn (User $owner): Model => MacroCalculation::factory()->create(['user_id' => $owner->id])],
+        'notification preference' => [NotificationPreferencePolicy::class, fn (User $owner): Model => NotificationPreference::factory()->create(['user_id' => $owner->id])],
+        'personal record' => [PersonalRecordPolicy::class, fn (User $owner): Model => PersonalRecord::factory()->create(['user_id' => $owner->id])],
+        'plate' => [PlatePolicy::class, fn (User $owner): Model => Plate::factory()->create(['user_id' => $owner->id])],
+        'set' => [SetPolicy::class, fn (User $owner): Model => Set::factory()
+            ->for(WorkoutLine::factory()->for(Workout::factory()->create(['user_id' => $owner->id]))->create())
+            ->create()
+            ->load('workoutLine.workout')],
+        'supplement' => [SupplementPolicy::class, fn (User $owner): Model => Supplement::factory()->create(['user_id' => $owner->id])],
+        'supplement log' => [SupplementLogPolicy::class, fn (User $owner): Model => SupplementLog::factory()->create(['user_id' => $owner->id])],
+        // App\Models\WarmupPreference does not use HasFactory, so the factory is reached directly.
+        'warmup preference' => [WarmupPreferencePolicy::class, fn (User $owner): Model => WarmupPreferenceFactory::new()->create(['user_id' => $owner->id])],
+        'water log' => [WaterLogPolicy::class, fn (User $owner): Model => WaterLog::factory()->create(['user_id' => $owner->id])],
+        'wilks score' => [WilksScorePolicy::class, fn (User $owner): Model => WilksScore::factory()->create(['user_id' => $owner->id])],
+        'workout' => [WorkoutPolicy::class, fn (User $owner): Model => Workout::factory()->create(['user_id' => $owner->id, 'ended_at' => null])],
+        'workout line' => [WorkoutLinePolicy::class, fn (User $owner): Model => WorkoutLine::factory()
+            ->for(Workout::factory()->create(['user_id' => $owner->id, 'ended_at' => null]))
+            ->create()
+            ->load('workout')],
+        'workout template' => [WorkoutTemplatePolicy::class, fn (User $owner): Model => WorkoutTemplate::factory()->create(['user_id' => $owner->id])],
+        'workout template line' => [WorkoutTemplateLinePolicy::class, fn (User $owner): Model => WorkoutTemplateLine::factory()
+            ->for(WorkoutTemplate::factory()->create(['user_id' => $owner->id]))
+            ->create()
+            ->load('workoutTemplate')],
+        'workout template set' => [WorkoutTemplateSetPolicy::class, fn (User $owner): Model => WorkoutTemplateSet::factory()
+            ->for(WorkoutTemplateLine::factory()->for(WorkoutTemplate::factory()->create(['user_id' => $owner->id]))->create())
+            ->create()
+            ->load('workoutTemplateLine.workoutTemplate')],
+    ];
+}
+
+/**
+ * Record-scoped policies deliberately left out of the uniform sweep, each with
+ * the reason it cannot obey "owner yes, everyone else no".
+ */
+const OWNERSHIP_SWEEP_EXCLUSIONS = [
+    // Permission driven, over the admin guard: tests/Feature/Policies/AdminPolicyTest.php
+    'AdminPolicy',
+    // Owner is nullable (a null owner is the shared catalogue): PolicyConditionBoundaryTest.php
+    'ExercisePolicy',
+    // Read-only by design, writes are always denied: PolicyConditionBoundaryTest.php
+    'UserAchievementPolicy',
+    // Self service plus admin permission, not row ownership: UserPolicyTest.php
+    'UserPolicy',
+];
+
+dataset('owned records', array_keys(ownedRecordRecipes()));
+
+it('lets the owner read their own record', function (string $recipe): void {
+    [$policyClass, $make] = ownedRecordRecipes()[$recipe];
+    $owner = User::factory()->create();
+    $record = $make($owner);
+    $policy = new $policyClass();
+
+    expect($policy->view($owner, $record))->toBeTrue();
+})->with('owned records');
+
+it('hides a record from every user but its owner', function (string $recipe): void {
+    [$policyClass, $make] = ownedRecordRecipes()[$recipe];
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $record = $make($owner);
+    $policy = new $policyClass();
+
+    expect($intruder->id)->not->toBe($owner->id)
+        ->and($policy->view($intruder, $record))->toBeFalse();
+})->with('owned records');
+
+it('lets the owner write to their own record', function (string $recipe): void {
+    [$policyClass, $make] = ownedRecordRecipes()[$recipe];
+    $owner = User::factory()->create();
+    $record = $make($owner);
+    $policy = new $policyClass();
+
+    expect($policy->update($owner, $record))->toBeTrue()
+        ->and($policy->delete($owner, $record))->toBeTrue();
+})->with('owned records');
+
+it('stops every user but the owner writing to or deleting a record', function (string $recipe): void {
+    [$policyClass, $make] = ownedRecordRecipes()[$recipe];
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $record = $make($owner);
+    $policy = new $policyClass();
+
+    expect($policy->update($intruder, $record))->toBeFalse()
+        ->and($policy->delete($intruder, $record))->toBeFalse();
+})->with('owned records');
+
+/**
+ * The sweep above is only worth as much as its list. This walks app/Policies and
+ * fails when a record-scoped policy is added without being swept or explicitly
+ * excused, so a new owned model cannot slip through uncovered.
+ */
+it('sweeps every record scoped policy in app/Policies', function (): void {
+    $recordScoped = collect(glob(app_path('Policies/*.php')))
+        ->map(fn (string $path): string => 'App\\Policies\\'.basename($path, '.php'))
+        ->filter(function (string $class): bool {
+            if (! method_exists($class, 'view')) {
+                return false;
+            }
+
+            $parameters = (new ReflectionMethod($class, 'view'))->getParameters();
+
+            if (count($parameters) !== 2) {
+                return false;
+            }
+
+            $type = $parameters[1]->getType();
+
+            return $type instanceof ReflectionNamedType && str_starts_with($type->getName(), 'App\\Models\\');
+        })
+        ->map(fn (string $class): string => class_basename($class))
+        ->sort()
+        ->values()
+        ->all();
+
+    $accountedFor = collect(ownedRecordRecipes())
+        ->map(fn (array $recipe): string => class_basename($recipe[0]))
+        ->merge(OWNERSHIP_SWEEP_EXCLUSIONS)
+        ->sort()
+        ->values()
+        ->all();
+
+    expect($recordScoped)->not->toBeEmpty()
+        ->and($recordScoped)->toBe($accountedFor);
+});

--- a/tests/Feature/Policies/PolicyConditionBoundaryTest.php
+++ b/tests/Feature/Policies/PolicyConditionBoundaryTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Achievement;
+use App\Models\Admin;
+use App\Models\Exercise;
+use App\Models\Habit;
+use App\Models\Set;
+use App\Models\User;
+use App\Models\UserAchievement;
+use App\Models\Workout;
+use App\Models\WorkoutLine;
+use App\Models\WorkoutTemplate;
+use App\Models\WorkoutTemplateLine;
+use App\Models\WorkoutTemplateSet;
+use App\Policies\AchievementPolicy;
+use App\Policies\ExercisePolicy;
+use App\Policies\HabitLogPolicy;
+use App\Policies\SetPolicy;
+use App\Policies\UserAchievementPolicy;
+use App\Policies\WorkoutPolicy;
+use App\Policies\WorkoutTemplateLinePolicy;
+use App\Policies\WorkoutTemplateSetPolicy;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+
+function adminGranted(array $abilities): Admin
+{
+    $admin = Admin::factory()->create();
+
+    foreach ($abilities as $ability) {
+        Permission::findOrCreate($ability, 'admin');
+    }
+
+    if ($abilities !== []) {
+        $admin->givePermissionTo($abilities);
+    }
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    return $admin->fresh();
+}
+
+describe('a finished workout is frozen', function (): void {
+    it('lets the owner edit a workout while it is still running', function (): void {
+        $owner = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $owner->id, 'ended_at' => null]);
+
+        expect((new WorkoutPolicy())->update($owner, $workout))->toBeTrue();
+    });
+
+    it('refuses to edit a workout once it has ended', function (): void {
+        $owner = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $owner->id, 'ended_at' => now()]);
+
+        expect((new WorkoutPolicy())->update($owner, $workout))->toBeFalse();
+    });
+
+    /**
+     * Deleting is deliberately not frozen: a finished session can still be
+     * thrown away. Asserted so the asymmetry survives anyone tidying up.
+     */
+    it('still lets the owner delete a workout that has ended', function (): void {
+        $owner = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $owner->id, 'ended_at' => now()]);
+
+        expect((new WorkoutPolicy())->delete($owner, $workout))->toBeTrue();
+    });
+
+    it('freezes the sets of a finished workout, and only those', function (): void {
+        $owner = User::factory()->create();
+        $open = Set::factory()
+            ->for(WorkoutLine::factory()->for(Workout::factory()->create(['user_id' => $owner->id, 'ended_at' => null]))->create())
+            ->create()
+            ->load('workoutLine.workout');
+        $ended = Set::factory()
+            ->for(WorkoutLine::factory()->for(Workout::factory()->create(['user_id' => $owner->id, 'ended_at' => now()]))->create())
+            ->create()
+            ->load('workoutLine.workout');
+        $policy = new SetPolicy();
+
+        expect($policy->update($owner, $open))->toBeTrue()
+            ->and($policy->delete($owner, $open))->toBeTrue()
+            ->and($policy->update($owner, $ended))->toBeFalse()
+            ->and($policy->delete($owner, $ended))->toBeFalse()
+            // Reading history stays allowed whatever the workout's state.
+            ->and($policy->view($owner, $ended))->toBeTrue();
+    });
+});
+
+describe('creating a child row against a parent', function (): void {
+    it('allows a set on the owner\'s running workout line only', function (): void {
+        $owner = User::factory()->create();
+        $intruder = User::factory()->create();
+        $open = WorkoutLine::factory()->for(Workout::factory()->create(['user_id' => $owner->id, 'ended_at' => null]))->create()->load('workout');
+        $ended = WorkoutLine::factory()->for(Workout::factory()->create(['user_id' => $owner->id, 'ended_at' => now()]))->create()->load('workout');
+        $policy = new SetPolicy();
+
+        expect($policy->create($owner, $open))->toBeTrue()
+            ->and($policy->create($owner, $ended))->toBeFalse()
+            ->and($policy->create($intruder, $open))->toBeFalse()
+            // No parent given: the form is being opened, nothing is being written yet.
+            ->and($policy->create($owner))->toBeTrue();
+    });
+
+    it('allows a habit log on the owner\'s habit only', function (): void {
+        $owner = User::factory()->create();
+        $intruder = User::factory()->create();
+        $habit = Habit::factory()->create(['user_id' => $owner->id]);
+        $policy = new HabitLogPolicy();
+
+        expect($policy->create($owner, $habit))->toBeTrue()
+            ->and($policy->create($intruder, $habit))->toBeFalse()
+            ->and($policy->create($owner))->toBeTrue();
+    });
+
+    it('allows a template line on the owner\'s template only', function (): void {
+        $owner = User::factory()->create();
+        $intruder = User::factory()->create();
+        $template = WorkoutTemplate::factory()->create(['user_id' => $owner->id]);
+        $policy = new WorkoutTemplateLinePolicy();
+
+        expect($policy->create($owner, $template))->toBeTrue()
+            ->and($policy->create($intruder, $template))->toBeFalse()
+            ->and($policy->create($owner))->toBeTrue();
+    });
+
+    it('allows a template set on the owner\'s template line only', function (): void {
+        $owner = User::factory()->create();
+        $intruder = User::factory()->create();
+        $line = WorkoutTemplateLine::factory()
+            ->for(WorkoutTemplate::factory()->create(['user_id' => $owner->id]))
+            ->create()
+            ->load('workoutTemplate');
+        $policy = new WorkoutTemplateSetPolicy();
+
+        expect($policy->create($owner, $line))->toBeTrue()
+            ->and($policy->create($intruder, $line))->toBeFalse()
+            ->and($policy->create($owner))->toBeTrue();
+    });
+
+    /**
+     * WorkoutTemplateSetPolicy walks the chain with `?->`. A broken chain must
+     * read as "no owner", i.e. denied, never as "owner matches null".
+     */
+    it('denies a template set whose chain up to the template is broken', function (): void {
+        $user = User::factory()->create();
+        $orphan = WorkoutTemplateSet::factory()->make();
+        $orphan->setRelation('workoutTemplateLine', null);
+        $policy = new WorkoutTemplateSetPolicy();
+
+        expect($policy->view($user, $orphan))->toBeFalse()
+            ->and($policy->update($user, $orphan))->toBeFalse()
+            ->and($policy->delete($user, $orphan))->toBeFalse();
+    });
+});
+
+describe('the shared exercise catalogue', function (): void {
+    it('shows a catalogue exercise to everyone but lets nobody edit it', function (): void {
+        $user = User::factory()->create();
+        $catalogue = Exercise::factory()->create(['user_id' => null]);
+        $policy = new ExercisePolicy();
+
+        expect($catalogue->user_id)->toBeNull()
+            ->and($policy->view($user, $catalogue))->toBeTrue()
+            ->and($policy->update($user, $catalogue))->toBeFalse()
+            ->and($policy->delete($user, $catalogue))->toBeFalse();
+    });
+
+    it('keeps a user\'s own exercise to themselves', function (): void {
+        $owner = User::factory()->create();
+        $intruder = User::factory()->create();
+        $exercise = Exercise::factory()->create(['user_id' => $owner->id]);
+        $policy = new ExercisePolicy();
+
+        expect($policy->view($owner, $exercise))->toBeTrue()
+            ->and($policy->update($owner, $exercise))->toBeTrue()
+            ->and($policy->delete($owner, $exercise))->toBeTrue()
+            ->and($policy->view($intruder, $exercise))->toBeFalse()
+            ->and($policy->update($intruder, $exercise))->toBeFalse()
+            ->and($policy->delete($intruder, $exercise))->toBeFalse();
+    });
+});
+
+describe('the admin branch bypasses ownership, not permissions', function (): void {
+    it('lets an admin holding View:Workout read a workout belonging to somebody else', function (): void {
+        $stranger = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $stranger->id]);
+        $policy = new WorkoutPolicy();
+
+        expect($policy->view(adminGranted(['View:Workout']), $workout))->toBeTrue()
+            ->and($policy->view(adminGranted(['Update:Workout', 'Delete:Workout']), $workout))->toBeFalse();
+    });
+
+    it('lets an admin holding Update:Workout edit a workout that has already ended', function (): void {
+        $stranger = User::factory()->create();
+        $workout = Workout::factory()->create(['user_id' => $stranger->id, 'ended_at' => now()]);
+        $policy = new WorkoutPolicy();
+
+        expect($policy->update(adminGranted(['Update:Workout']), $workout))->toBeTrue()
+            ->and($policy->update(adminGranted(['View:Workout']), $workout))->toBeFalse();
+    });
+
+    it('lets an admin holding View:Exercise read another user\'s private exercise', function (): void {
+        $stranger = User::factory()->create();
+        $exercise = Exercise::factory()->create(['user_id' => $stranger->id]);
+        $policy = new ExercisePolicy();
+
+        expect($policy->view(adminGranted(['View:Exercise']), $exercise))->toBeTrue()
+            ->and($policy->view(adminGranted([]), $exercise))->toBeFalse();
+    });
+
+    it('gives an application user free rein over the collection level abilities', function (): void {
+        $user = User::factory()->create();
+
+        expect((new WorkoutPolicy())->viewAny($user))->toBeTrue()
+            ->and((new WorkoutPolicy())->create($user))->toBeTrue()
+            ->and((new ExercisePolicy())->viewAny($user))->toBeTrue()
+            ->and((new ExercisePolicy())->create($user))->toBeTrue();
+    });
+});
+
+describe('achievements are read only for the people who earn them', function (): void {
+    it('lets an application user read achievements but never write them', function (): void {
+        $user = User::factory()->create();
+        $policy = new AchievementPolicy();
+
+        expect($policy->viewAny($user))->toBeTrue()
+            ->and($policy->view($user))->toBeTrue()
+            ->and($policy->update($user))->toBeFalse()
+            ->and($policy->delete($user))->toBeFalse()
+            // create() has no user branch at all, so it falls through to a gate nothing defines.
+            ->and($policy->create($user))->toBeFalse();
+    });
+
+    it('lets an admin holding the achievement abilities write them', function (): void {
+        $policy = new AchievementPolicy();
+
+        expect($policy->create(adminGranted(['Create:Achievement'])))->toBeTrue()
+            ->and($policy->update(adminGranted(['Update:Achievement'])))->toBeTrue()
+            ->and($policy->delete(adminGranted(['Delete:Achievement'])))->toBeTrue()
+            ->and($policy->create(adminGranted(['Update:Achievement', 'Delete:Achievement'])))->toBeFalse()
+            ->and($policy->update(adminGranted(['Create:Achievement', 'Delete:Achievement'])))->toBeFalse()
+            ->and($policy->delete(adminGranted(['Create:Achievement', 'Update:Achievement'])))->toBeFalse();
+    });
+
+    it('shows an earned achievement to its owner and to nobody else', function (): void {
+        $owner = User::factory()->create();
+        $intruder = User::factory()->create();
+        $earned = UserAchievement::create([
+            'user_id' => $owner->id,
+            'achievement_id' => Achievement::factory()->create()->id,
+            'achieved_at' => now(),
+        ]);
+        $policy = new UserAchievementPolicy();
+
+        expect($policy->view($owner, $earned))->toBeTrue()
+            ->and($policy->view($intruder, $earned))->toBeFalse();
+    });
+
+    it('never lets anyone hand themselves an achievement', function (): void {
+        $policy = new UserAchievementPolicy();
+
+        expect($policy->create())->toBeFalse()
+            ->and($policy->update())->toBeFalse()
+            ->and($policy->delete())->toBeFalse()
+            ->and($policy->viewAny())->toBeTrue();
+    });
+});

--- a/tests/Feature/Policies/RolePolicyTest.php
+++ b/tests/Feature/Policies/RolePolicyTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Admin;
+use App\Models\User;
+use App\Policies\RolePolicy;
+use Illuminate\Support\Facades\Gate;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * The abilities Shield actually generates for the Role resource, and that the
+ * admin panel actually reaches. Keys are the policy method, values the exact
+ * ability string the method must consult.
+ */
+const REACHABLE_ROLE_ABILITIES = [
+    'viewAny' => 'ViewAny:Role',
+    'view' => 'View:Role',
+    'create' => 'Create:Role',
+    'update' => 'Update:Role',
+    'delete' => 'Delete:Role',
+];
+
+function adminWithRoleAbilities(array $abilities): Admin
+{
+    $admin = Admin::factory()->create();
+
+    foreach ($abilities as $ability) {
+        Permission::findOrCreate($ability, 'admin');
+    }
+
+    $admin->givePermissionTo($abilities);
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    return $admin->fresh();
+}
+
+it('is the policy Laravel resolves for the configured role model', function (): void {
+    $roleModel = config('permission.models.role');
+
+    expect(Gate::getPolicyFor($roleModel))->toBeInstanceOf(RolePolicy::class);
+});
+
+it('grants an admin holding exactly the matching ability', function (string $method, string $ability): void {
+    $admin = adminWithRoleAbilities([$ability]);
+    $policy = new RolePolicy();
+
+    expect($policy->{$method}($admin))->toBeTrue();
+})->with(
+    collect(REACHABLE_ROLE_ABILITIES)
+        ->map(fn (string $ability, string $method): array => [$method, $ability])
+        ->all()
+);
+
+/**
+ * The mutation killer: the admin holds every other Role ability. A method that
+ * consults the wrong ability string (a copy/paste between methods) would still
+ * return true here, so this is what tells a correct policy from a cross-wired one.
+ */
+it('denies an admin holding every other role ability but not the matching one', function (string $method, string $ability): void {
+    $others = array_values(array_diff(array_values(REACHABLE_ROLE_ABILITIES), [$ability]));
+    $admin = adminWithRoleAbilities($others);
+    $policy = new RolePolicy();
+
+    expect($policy->{$method}($admin))->toBeFalse();
+})->with(
+    collect(REACHABLE_ROLE_ABILITIES)
+        ->map(fn (string $ability, string $method): array => [$method, $ability])
+        ->all()
+);
+
+/**
+ * Role management lives behind the admin guard. An application user has no
+ * roles table entry at all, so every method must fall through to a denied gate.
+ */
+it('denies an application user every reachable role ability', function (string $method): void {
+    $user = User::factory()->create();
+    $policy = new RolePolicy();
+
+    expect($policy->{$method}($user))->toBeFalse();
+})->with(array_keys(REACHABLE_ROLE_ABILITIES));
+
+/**
+ * Deny-by-default invariant over the whole class, scaffolding included: nothing
+ * a RolePolicy method can be asked returns true for a principal with no
+ * permission at all. Catches a `return true` slipped into any method.
+ */
+it('grants nothing at all to a principal with no permissions', function (string $principal): void {
+    $actor = $principal === 'admin' ? Admin::factory()->create() : User::factory()->create();
+    $policy = new RolePolicy();
+
+    $abilityMethods = collect((new ReflectionClass(RolePolicy::class))->getMethods(ReflectionMethod::IS_PUBLIC))
+        ->reject(fn (ReflectionMethod $method): bool => $method->isStatic() || $method->getNumberOfParameters() !== 1)
+        ->map(fn (ReflectionMethod $method): string => $method->getName())
+        ->values();
+
+    $granted = $abilityMethods
+        ->filter(fn (string $method): bool => $policy->{$method}($actor) === true)
+        ->values()
+        ->all();
+
+    expect($granted)->toBe([])
+        ->and($abilityMethods->all())->toBe([
+            'viewAny', 'view', 'create', 'update', 'delete', 'restore',
+            'forceDelete', 'forceDeleteAny', 'restoreAny', 'replicate', 'reorder',
+        ]);
+})->with(['admin', 'user']);

--- a/tests/Feature/Policies/UserPolicyTest.php
+++ b/tests/Feature/Policies/UserPolicyTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Admin;
+use App\Models\User;
+use App\Policies\UserPolicy;
+use Illuminate\Support\Facades\Gate;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * The abilities the admin panel's UserResource actually reaches. Keys are the
+ * policy method, values the exact ability string it must consult.
+ */
+const REACHABLE_USER_ABILITIES = [
+    'viewAny' => 'ViewAny:User',
+    'view' => 'View:User',
+    'create' => 'Create:User',
+    'update' => 'Update:User',
+    'delete' => 'Delete:User',
+];
+
+/** Methods that take the acted-upon user as a second argument. */
+const USER_ABILITIES_ON_A_RECORD = ['view', 'update', 'delete'];
+
+function adminWithUserAbilities(array $abilities): Admin
+{
+    $admin = Admin::factory()->create();
+
+    foreach ($abilities as $ability) {
+        Permission::findOrCreate($ability, 'admin');
+    }
+
+    if ($abilities !== []) {
+        $admin->givePermissionTo($abilities);
+    }
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    return $admin->fresh();
+}
+
+/**
+ * UserPolicy compares raw auth identifiers, so an admin and a user that happen
+ * to share an id are treated as the same principal. Tests about *permissions*
+ * must not accidentally land on that collision, hence this helper.
+ */
+function userWithIdOtherThan(Admin $admin): User
+{
+    do {
+        $user = User::factory()->create();
+    } while ($user->getAuthIdentifier() === $admin->getAuthIdentifier());
+
+    return $user;
+}
+
+it('is the policy Laravel resolves for the user model', function (): void {
+    expect(Gate::getPolicyFor(User::class))->toBeInstanceOf(UserPolicy::class);
+});
+
+describe('self service', function (): void {
+    it('lets a user act on their own account', function (string $method): void {
+        $user = User::factory()->create();
+        $policy = new UserPolicy();
+
+        expect($policy->{$method}($user, $user))->toBeTrue();
+    })->with(USER_ABILITIES_ON_A_RECORD);
+
+    it('stops a user acting on somebody else\'s account', function (string $method): void {
+        $actor = User::factory()->create();
+        $victim = User::factory()->create();
+        $policy = new UserPolicy();
+
+        expect($actor->getAuthIdentifier())->not->toBe($victim->getAuthIdentifier())
+            ->and($policy->{$method}($actor, $victim))->toBeFalse();
+    })->with(USER_ABILITIES_ON_A_RECORD);
+
+    it('stops a user listing or creating accounts, which is an admin panel affair', function (): void {
+        $user = User::factory()->create();
+        $policy = new UserPolicy();
+
+        expect($policy->viewAny($user))->toBeFalse()
+            ->and($policy->create($user))->toBeFalse();
+    });
+});
+
+describe('admin permissions', function (): void {
+    it('lets an admin holding the matching ability act on any account', function (string $method): void {
+        $admin = adminWithUserAbilities([REACHABLE_USER_ABILITIES[$method]]);
+        $victim = userWithIdOtherThan($admin);
+        $policy = new UserPolicy();
+
+        expect($policy->{$method}($admin, $victim))->toBeTrue();
+    })->with(USER_ABILITIES_ON_A_RECORD);
+
+    /**
+     * The admin holds every other User ability. A method wired to the wrong
+     * ability string would still pass a plain happy-path test; it cannot pass this.
+     */
+    it('denies an admin holding every other user ability but not the matching one', function (string $method): void {
+        $ability = REACHABLE_USER_ABILITIES[$method];
+        $others = array_values(array_diff(array_values(REACHABLE_USER_ABILITIES), [$ability]));
+        $admin = adminWithUserAbilities($others);
+        $victim = userWithIdOtherThan($admin);
+        $policy = new UserPolicy();
+
+        expect($policy->{$method}($admin, $victim))->toBeFalse();
+    })->with(USER_ABILITIES_ON_A_RECORD);
+
+    it('gates the collection level abilities on their own permission', function (string $method): void {
+        $ability = REACHABLE_USER_ABILITIES[$method];
+        $granted = adminWithUserAbilities([$ability]);
+        $others = array_values(array_diff(array_values(REACHABLE_USER_ABILITIES), [$ability]));
+        $denied = adminWithUserAbilities($others);
+        $policy = new UserPolicy();
+
+        expect($policy->{$method}($granted))->toBeTrue()
+            ->and($policy->{$method}($denied))->toBeFalse();
+    })->with(['viewAny', 'create']);
+});
+
+/**
+ * Deny-by-default invariant across the whole class, Shield scaffolding
+ * included: an admin with no permissions must be granted nothing on a user
+ * that is not itself. Catches a `return true` slipped into any method.
+ */
+it('grants a permission-less admin nothing over another account', function (): void {
+    $admin = Admin::factory()->create();
+    $victim = userWithIdOtherThan($admin);
+    $policy = new UserPolicy();
+
+    $methods = collect((new ReflectionClass(UserPolicy::class))->getMethods(ReflectionMethod::IS_PUBLIC))
+        ->reject(fn (ReflectionMethod $method): bool => $method->isStatic())
+        ->filter(fn (ReflectionMethod $method): bool => $method->getReturnType() instanceof ReflectionNamedType
+            && $method->getReturnType()->getName() === 'bool')
+        ->map(fn (ReflectionMethod $method): string => $method->getName())
+        ->values();
+
+    $granted = $methods
+        ->filter(function (string $method) use ($policy, $admin, $victim): bool {
+            $arity = (new ReflectionMethod(UserPolicy::class, $method))->getNumberOfParameters();
+
+            return ($arity === 2 ? $policy->{$method}($admin, $victim) : $policy->{$method}($admin)) === true;
+        })
+        ->values()
+        ->all();
+
+    expect($granted)->toBe([])
+        ->and($methods->all())->toBe([
+            'viewAny', 'view', 'create', 'update', 'delete', 'restore',
+            'forceDelete', 'forceDeleteAny', 'restoreAny', 'replicate', 'reorder',
+        ]);
+});

--- a/tests/Feature/Security/BackofficeAuthorizationTest.php
+++ b/tests/Feature/Security/BackofficeAuthorizationTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Exercise;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Route;
+use Tests\Support\FilamentAdminPanel;
+
+/**
+ * Every GET route of the 'admin' Filament panel (path 'backoffice'), keyed by route name,
+ * with the route parameters filled in so the URL can actually be requested.
+ *
+ * The list is read from the router at runtime, so a resource added tomorrow is covered by
+ * the boundary tests below without touching this file.
+ *
+ * Two routes are deliberately left out:
+ * - filament.admin.auth.login, the panel login page, public by design;
+ * - pulse, which only shares the URL prefix: it is a Laravel Pulse route with its own
+ *   middleware stack ('auth:admin,web' + the viewPulse gate, see config/pulse.php) and not
+ *   a Filament panel route. It has its own test below.
+ *
+ * @return array<string, string>
+ */
+function backofficeGuardedRoutes(): array
+{
+    $urls = [];
+
+    foreach (Route::getRoutes() as $route) {
+        $uri = $route->uri();
+
+        if ($uri !== 'backoffice' && ! str_starts_with($uri, 'backoffice/')) {
+            continue;
+        }
+
+        if (! in_array('GET', $route->methods(), true)) {
+            continue;
+        }
+
+        if (in_array($route->getName(), ['filament.admin.auth.login', 'pulse'], true)) {
+            continue;
+        }
+
+        $urls[$route->getName() ?? $uri] = '/'.preg_replace('/\{[^}]+\}/', '1', $uri);
+    }
+
+    ksort($urls);
+
+    return $urls;
+}
+
+/**
+ * The panel is behind a 30 requests/minute IP throttle (App\Http\Middleware\AdminRateLimiter).
+ * The boundary tests below walk every route in one test, so the throttle is reset between
+ * requests: what is under test here is authorization, not throttling.
+ */
+function forgetBackofficeThrottle(): void
+{
+    RateLimiter::clear('admin-panel:127.0.0.1');
+}
+
+it('connait toutes les routes GET du backoffice', function (): void {
+    $routes = backofficeGuardedRoutes();
+
+    expect($routes)->toHaveKeys([
+        'filament.admin.pages.dashboard',
+        'filament.admin.pages.backups',
+        'filament.admin.auth.profile',
+        'filament.admin.resources.users.index',
+        'filament.admin.resources.users.create',
+        'filament.admin.resources.users.edit',
+        'filament.admin.resources.exercises.index',
+        'filament.admin.resources.workouts.index',
+        'filament.admin.resources.goals.index',
+        'filament.admin.resources.supplements.index',
+        'filament.admin.resources.achievements.index',
+        'filament.admin.resources.shield.roles.index',
+    ]);
+
+    expect($routes['filament.admin.pages.dashboard'])->toBe('/backoffice')
+        ->and($routes['filament.admin.resources.users.edit'])->toBe('/backoffice/users/1/edit')
+        ->and($routes)->not->toHaveKey('filament.admin.auth.login')
+        ->and(count($routes))->toBeGreaterThanOrEqual(20);
+});
+
+it('renvoie un visiteur anonyme vers la connexion du panel sur chacune de ces routes', function (): void {
+    $login = route('filament.admin.auth.login');
+    $notRedirected = [];
+
+    foreach (backofficeGuardedRoutes() as $name => $url) {
+        forgetBackofficeThrottle();
+
+        $response = $this->get($url);
+
+        if ($response->headers->get('Location') !== $login) {
+            $notRedirected[$name] = $response->getStatusCode().' -> '.($response->headers->get('Location') ?? 'aucune redirection');
+        }
+    }
+
+    expect($notRedirected)->toBe([]);
+});
+
+it('ne divulgue aucune donnee au visiteur anonyme et le depose sur le formulaire de connexion', function (): void {
+    User::factory()->create(['name' => 'Victime Anonyme', 'email' => 'victime-anonyme@example.test']);
+
+    forgetBackofficeThrottle();
+    $this->get('/backoffice/users')
+        ->assertRedirect(route('filament.admin.auth.login'))
+        ->assertDontSee('victime-anonyme@example.test');
+
+    forgetBackofficeThrottle();
+    $this->get(route('filament.admin.auth.login'))
+        ->assertOk()
+        ->assertSee('wire:model="data.email"', escape: false)
+        ->assertSee('wire:model="data.password"', escape: false)
+        ->assertDontSee('victime-anonyme@example.test');
+});
+
+it("interdit a un utilisateur du guard web l'integralite des routes du backoffice", function (): void {
+    User::factory()->create(['name' => 'Victime Web', 'email' => 'victime-web@example.test']);
+    $intruder = User::factory()->create(['email' => 'intrus@example.test']);
+
+    $login = route('filament.admin.auth.login');
+    $reached = [];
+
+    foreach (backofficeGuardedRoutes() as $name => $url) {
+        forgetBackofficeThrottle();
+
+        $response = $this->actingAs($intruder, 'web')->get($url);
+
+        if ($response->headers->get('Location') !== $login) {
+            $reached[$name] = $response->getStatusCode().' -> '.($response->headers->get('Location') ?? 'aucune redirection');
+        }
+
+        $response->assertDontSee('victime-web@example.test');
+    }
+
+    expect($reached)->toBe([])
+        ->and(auth('admin')->check())->toBeFalse();
+});
+
+it('laisse un admin muni de la permission Shield afficher le contenu de la ressource', function (): void {
+    $admin = FilamentAdminPanel::admin(['ViewAny:User', 'ViewAny:Exercise']);
+
+    User::factory()->create(['name' => 'Utilisateur Visible', 'email' => 'visible@example.test']);
+    Exercise::factory()->create(['name' => 'Souleve De Terre Visible']);
+
+    forgetBackofficeThrottle();
+    $this->actingAs($admin, 'admin')->get('/backoffice/users')
+        ->assertOk()
+        ->assertSee('Utilisateur Visible')
+        ->assertSee('visible@example.test');
+
+    forgetBackofficeThrottle();
+    $this->actingAs($admin, 'admin')->get('/backoffice/exercises')
+        ->assertOk()
+        ->assertSee('Souleve De Terre Visible');
+});
+
+it("refuse a un admin la ressource dont il n'a pas la permission, tout en gardant celle qu'il a", function (): void {
+    $admin = FilamentAdminPanel::admin(['ViewAny:User']);
+
+    User::factory()->create(['name' => 'Utilisateur Autorise', 'email' => 'autorise@example.test']);
+    Exercise::factory()->create(['name' => 'Squat Interdit']);
+
+    forgetBackofficeThrottle();
+    $this->actingAs($admin, 'admin')->get('/backoffice/exercises')
+        ->assertForbidden()
+        ->assertDontSee('Squat Interdit');
+
+    forgetBackofficeThrottle();
+    $this->actingAs($admin, 'admin')->get('/backoffice/users')
+        ->assertOk()
+        ->assertSee('autorise@example.test');
+});
+
+it('cloisonne chaque page de ressource derriere sa propre permission Shield', function (): void {
+    $admin = FilamentAdminPanel::admin();
+
+    User::factory()->create(['name' => 'Utilisateur Cloisonne', 'email' => 'cloisonne@example.test']);
+    Exercise::factory()->create(['name' => 'Exercice Cloisonne']);
+
+    $pages = array_filter(
+        backofficeGuardedRoutes(),
+        fn (string $name): bool => str_starts_with($name, 'filament.admin.resources.')
+            && (str_ends_with($name, '.index') || str_ends_with($name, '.create')),
+        ARRAY_FILTER_USE_KEY
+    );
+
+    expect(count($pages))->toBeGreaterThanOrEqual(12);
+
+    $notForbidden = [];
+
+    foreach ($pages as $name => $url) {
+        forgetBackofficeThrottle();
+
+        $response = $this->actingAs($admin, 'admin')->get($url);
+
+        if ($response->getStatusCode() !== 403) {
+            $notForbidden[$name] = $response->getStatusCode();
+        }
+
+        $response->assertDontSee('cloisonne@example.test');
+        $response->assertDontSee('Exercice Cloisonne');
+    }
+
+    expect($notForbidden)->toBe([]);
+
+    forgetBackofficeThrottle();
+    $this->actingAs($admin, 'admin')->get('/backoffice')
+        ->assertOk()
+        ->assertSee('GymTracker');
+});

--- a/tests/Feature/Services/StatsChartPointsContractTest.php
+++ b/tests/Feature/Services/StatsChartPointsContractTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+use App\DTOs\Stats\BodyFatHistoryPoint;
+use App\DTOs\Stats\DailyVolumeTrendPoint;
+use App\DTOs\Stats\WeightHistoryPoint;
+use App\Models\BodyMeasurement;
+use App\Models\User;
+use App\Models\Workout;
+use App\Services\Stats\BodyStatsService;
+use App\Services\Stats\VolumeStatsService;
+use Carbon\Carbon;
+
+/**
+ * Ces trois DTO ne servent qu'à une chose : traverser Inertia et arriver dans
+ * un graphique Chart.js. Le contrat n'est donc pas la classe PHP, c'est le nom
+ * exact des clés du JSON. Renommer une propriété publique ne casse aucun test
+ * de type, ne lève aucune erreur côté serveur, et vide silencieusement la
+ * courbe côté navigateur :
+ *
+ *   WeightHistoryPoint   -> Components/Stats/WeightHistoryChart.vue lit .date et .weight
+ *   BodyFatHistoryPoint  -> Components/Stats/BodyFatChart.vue       lit .date et .body_fat
+ *   DailyVolumeTrendPoint-> Components/Stats/VolumeTrendChart.vue   lit .volume (+ .date en label)
+ *
+ * On construit donc chaque point par son vrai producteur (le service Stats sur
+ * des lignes réelles), puis on l'encode comme Inertia le fera.
+ */
+
+/**
+ * Le point tel que le navigateur le reçoit, clés comprises.
+ *
+ * @return array<string, mixed>
+ */
+function encodedStatsPoint(object $point): array
+{
+    /** @var array<string, mixed> $decoded */
+    $decoded = json_decode(json_encode($point, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+
+    return $decoded;
+}
+
+beforeEach(function (): void {
+    Carbon::setTestNow('2026-03-12 10:00:00');
+});
+
+afterEach(function (): void {
+    Carbon::setTestNow();
+});
+
+describe('WeightHistoryPoint', function (): void {
+    it('sort du service avec les clés que lit WeightHistoryChart.vue', function (): void {
+        $user = User::factory()->create();
+        BodyMeasurement::factory()->create([
+            'user_id' => $user->id,
+            'weight' => 81.40,
+            'measured_at' => '2026-03-09',
+        ]);
+        BodyMeasurement::factory()->create([
+            'user_id' => $user->id,
+            'weight' => 80.90,
+            'measured_at' => '2026-03-11',
+        ]);
+        // Hors de la fenêtre de 90 jours : ne doit pas apparaître.
+        BodyMeasurement::factory()->create([
+            'user_id' => $user->id,
+            'weight' => 95.00,
+            'measured_at' => '2025-01-01',
+        ]);
+
+        $history = app(BodyStatsService::class)->getWeightHistory($user, 90);
+
+        expect($history)->toHaveCount(2)
+            ->and($history[0])->toBeInstanceOf(WeightHistoryPoint::class);
+
+        expect(encodedStatsPoint($history[0]))->toBe([
+            'date' => '09/03',
+            'full_date' => '2026-03-09',
+            'weight' => 81.4,
+        ]);
+
+        expect(encodedStatsPoint($history[1]))->toBe([
+            'date' => '11/03',
+            'full_date' => '2026-03-11',
+            'weight' => 80.9,
+        ]);
+    });
+});
+
+describe('BodyFatHistoryPoint', function (): void {
+    it('sort du service avec les clés que lit BodyFatChart.vue', function (): void {
+        $user = User::factory()->create();
+        BodyMeasurement::factory()->create([
+            'user_id' => $user->id,
+            'weight' => 81.40,
+            'body_fat' => 17.20,
+            'measured_at' => '2026-03-09',
+        ]);
+        // Pesée sans mesure de masse grasse : absente de la courbe.
+        BodyMeasurement::factory()->create([
+            'user_id' => $user->id,
+            'weight' => 80.90,
+            'body_fat' => null,
+            'measured_at' => '2026-03-11',
+        ]);
+
+        $history = app(BodyStatsService::class)->getBodyFatHistory($user, 90);
+
+        expect($history)->toHaveCount(1)
+            ->and($history[0])->toBeInstanceOf(BodyFatHistoryPoint::class);
+
+        expect(encodedStatsPoint($history[0]))->toBe([
+            'date' => '09/03',
+            'full_date' => '2026-03-09',
+            'body_fat' => 17.2,
+        ]);
+    });
+});
+
+describe('DailyVolumeTrendPoint', function (): void {
+    it('sort du service avec les clés que lit VolumeTrendChart.vue', function (): void {
+        $user = User::factory()->create();
+
+        // Deux séances le même jour : le point porte leur somme.
+        Workout::factory()->create([
+            'user_id' => $user->id,
+            'started_at' => '2026-03-09 18:00:00',
+            'workout_volume' => 1200.00,
+        ]);
+        Workout::factory()->create([
+            'user_id' => $user->id,
+            'started_at' => '2026-03-09 20:00:00',
+            'workout_volume' => 300.50,
+        ]);
+        Workout::factory()->create([
+            'user_id' => $user->id,
+            'started_at' => '2026-03-12 07:00:00',
+            'workout_volume' => 800.25,
+        ]);
+        // Antérieure à la fenêtre de 7 jours : ignorée.
+        Workout::factory()->create([
+            'user_id' => $user->id,
+            'started_at' => '2026-03-01 09:00:00',
+            'workout_volume' => 9999.00,
+        ]);
+
+        $trend = app(VolumeStatsService::class)->getDailyVolumeTrend($user, 7);
+
+        expect($trend)->toHaveCount(7)
+            ->and($trend[0])->toBeInstanceOf(DailyVolumeTrendPoint::class);
+
+        // Les sept jours sont présents même sans séance : la courbe ne saute pas de jour.
+        expect(array_map(fn (array $point): mixed => $point['date'], array_map(encodedStatsPoint(...), $trend)))
+            ->toBe(['06/03', '07/03', '08/03', '09/03', '10/03', '11/03', '12/03']);
+
+        expect(array_map(fn (DailyVolumeTrendPoint $point): float => $point->volume, $trend))
+            ->toBe([0.0, 0.0, 0.0, 1500.5, 0.0, 0.0, 800.25]);
+
+        // day_name est le libellé de l'axe : il est traduit, pas laissé en anglais.
+        expect(array_map(fn (array $point): mixed => $point['day_name'], array_map(encodedStatsPoint(...), $trend)))
+            ->toBe(['ven.', 'sam.', 'dim.', 'lun.', 'mar.', 'mer.', 'jeu.']);
+
+        expect(encodedStatsPoint($trend[3]))->toBe([
+            'date' => '09/03',
+            'day_name' => 'lun.',
+            'volume' => 1500.5,
+        ]);
+    });
+});
+
+/**
+ * Le chemin réellement emprunté en production : BodyMeasurementController
+ * expose getBodyProgressOverview() en prop différée « bodyStats », et
+ * Pages/Measurements/Index.vue lit bodyStats.weightHistory / .bodyFatHistory.
+ * Ce test verrouille toute la chaîne, y compris les deux clés du tableau.
+ */
+describe('la prop différée bodyStats de Measurements/Index', function (): void {
+    it('livre les deux séries avec leurs clés de graphique', function (): void {
+        $user = User::factory()->create();
+        BodyMeasurement::factory()->create([
+            'user_id' => $user->id,
+            'weight' => 81.40,
+            'body_fat' => 17.20,
+            'measured_at' => '2026-03-09',
+        ]);
+        BodyMeasurement::factory()->create([
+            'user_id' => $user->id,
+            'weight' => 80.90,
+            'body_fat' => null,
+            'measured_at' => '2026-03-11',
+        ]);
+
+        // La version d'asset est calculée pendant la requête (hash du manifest
+        // Vite) : on la lit sur une première visite plutôt que de la deviner,
+        // sinon Inertia répond 409 au rechargement partiel.
+        $version = (string) $this->actingAs($user)
+            ->withHeader('X-Inertia', 'true')
+            ->get(route('body-measurements.index'))
+            ->headers->get('X-Inertia-Version');
+
+        expect($version)->not->toBe('');
+
+        $response = $this->actingAs($user)
+            ->withHeaders([
+                'X-Inertia' => 'true',
+                'X-Inertia-Version' => $version,
+                'X-Inertia-Partial-Component' => 'Measurements/Index',
+                'X-Inertia-Partial-Data' => 'bodyStats',
+            ])
+            ->get(route('body-measurements.index'));
+
+        $response->assertJsonPath('props.bodyStats.weightHistory', [
+            ['date' => '09/03', 'full_date' => '2026-03-09', 'weight' => 81.4],
+            ['date' => '11/03', 'full_date' => '2026-03-11', 'weight' => 80.9],
+        ]);
+
+        $response->assertJsonPath('props.bodyStats.bodyFatHistory', [
+            ['date' => '09/03', 'full_date' => '2026-03-09', 'body_fat' => 17.2],
+        ]);
+    });
+});

--- a/tests/Support/FilamentAdminPanel.php
+++ b/tests/Support/FilamentAdminPanel.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use App\Models\Admin;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * Scaffolding shared by every Filament panel test.
+ *
+ * Three things are needed before a Filament page can be mounted through
+ * Livewire::test() in this application:
+ *
+ * 1. an Admin authenticated on the 'admin' guard (the panel's authGuard),
+ * 2. the Shield permissions the resource policies check — the super_admin role
+ *    is NOT a gate bypass here (config/filament-shield.php has
+ *    super_admin.define_via_gate = false), so the permissions must really exist
+ *    on the 'admin' guard and be granted,
+ * 3. the 'admin' panel set as the current panel, because no panel middleware
+ *    runs when a page component is mounted directly.
+ */
+final class FilamentAdminPanel
+{
+    /**
+     * Create an Admin holding the given Shield permissions on the 'admin' guard
+     * and make the 'admin' panel current.
+     *
+     * @param  array<int, string>  $permissions  e.g. ['ViewAny:User', 'Create:User']
+     */
+    public static function admin(array $permissions = []): Admin
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $admin = Admin::factory()->create();
+
+        foreach ($permissions as $permission) {
+            Permission::findOrCreate($permission, 'admin');
+        }
+
+        if ($permissions !== []) {
+            $admin->givePermissionTo($permissions);
+        }
+
+        Filament::setCurrentPanel('admin');
+
+        return $admin;
+    }
+
+    /**
+     * The full CRUD permission set Shield generates for a resource model.
+     *
+     * @return array<int, string>
+     */
+    public static function crudPermissions(string $model): array
+    {
+        return [
+            "ViewAny:{$model}",
+            "View:{$model}",
+            "Create:{$model}",
+            "Update:{$model}",
+            "Delete:{$model}",
+            "DeleteAny:{$model}",
+        ];
+    }
+}


### PR DESCRIPTION
Répond à #1346 et donne à #1339 quelque chose à verrouiller.

**Couverture backend : 84,0 % → 94,3 %.** 1522 → 1856 tests, 5500 → 6648 assertions.

## Par zone

| Dossier | Avant | Après | Fichiers à 0 % |
|---|---|---|---|
| `app/Enums` | 0,0 % | **100,0 %** | 3 → **0** |
| `app/Filament` | 26,9 % | **99,1 %** | 27 → **0** |
| `app/Notifications` | 34,3 % | **100,0 %** | 0 |
| `app/DTOs` | 76,9 % | **100,0 %** | 3 → **0** |
| `app/Policies` | 81,4 % | **91,1 %** | 0 |
| `app/Actions` | 86,2 % | **95,9 %** | 6 → 1 |

Le fichier restant à 0 % dans `Actions` est `FetchGoalsIndexAction` — **code mort**, jamais référencé par un contrôleur ni une route. Il n'est délibérément pas couvert : le bon traitement est la suppression, pas la couverture (relevé dans #1341).

## Ce qui est réellement testé

Pas des appels de page renvoyant 200. Quelques exemples :

- **`Enums`** — la valeur *stockée* de chaque cas est assertée explicitement. Renommer une valeur persistée est une migration de données silencieuse ; ce test la transforme en échec. Plus l'aller-retour par le cast du modèle, qui prouve que le cast est câblé.
- **`Notifications`** — `toWebPush()` était à 0 % : c'est le contenu affiché sur le téléphone. Le payload est asserté champ par champ, et `via()` est testé dans ses deux branches selon les préférences.
- **`DTOs/Stats`** — les clés exactes du JSON envoyé aux graphiques Vue. Une clé renommée casse un graphique en silence.
- **`Filament`** — la frontière d'autorisation d'abord : un `User` du guard `web` ne doit atteindre **aucune** des routes `backoffice/*`, en itérant sur la liste réelle des routes plutôt que sur une URL en dur, pour qu'une ressource ajoutée demain soit couverte d'office.
- **`Policies`** — la frontière de propriété, sur les deux versants systématiquement : une policy testée seulement sur son cas passant ne détecte pas une condition inversée.

## Méthode : chaque test a été vu échouer

Pour chaque comportement, le code de production a été cassé volontairement (condition inversée, retour anticipé, constante modifiée), l'échec du test constaté, puis le code restauré. **Un test qu'on n'a pas vu échouer ne prouve rien.**

Aucun fichier hors `tests/` n'est modifié par cette PR — le diff le montre.

## Onze tests écrits puis supprimés

Un audit adverse a relu chaque zone en cherchant les tests qui ne prouvent rien. Il en a rejeté onze, tous retirés ici :

- **9 tests** assertaient qu'une création Filament **échoue** avec une `MassAssignmentException`. Ils figeaient le défaut de #1352 comme contrat : ils passaient au vert *parce que* la fonctionnalité est cassée, et deviendraient rouges le jour du correctif. Exactement l'inverse de ce qu'un test doit faire.
- **1 test** figeait la faille d'autorisation corrigée par #1353.
- **1 test** vérifiait un gate qu'il **définissait lui-même** deux lignes plus haut.

Une assertion a par ailleurs été remplacée plutôt que supprimée : sur le widget des inscrits récents, `assertCanNotSeeTableRecords` sur les plus anciens était satisfaite par la **pagination par défaut de Filament**, pas par le tri du widget. Elle passerait même si le widget ne triait pas du tout. Remplacée par une assertion d'ordre, qui échoue dès que le `latest()` devient `oldest()`.

## Ce que l'écriture a révélé

Deux bugs, sortis en PR/issue séparées plutôt que noyés ici :

- **#1353** *(corrigé)* — `UserPolicy` comparait les identités sans vérifier le type, donc un admin sans permission avait six droits sur l'utilisateur portant son id.
- **#1352** *(à arbitrer)* — 4 ressources Filament exposent des champs hors `$fillable` ; en production les saisies admin sont silencieusement perdues.

Une conclusion moins visible, sur `app/Actions/Fortify` (5 fichiers à 0 %) : `FortifyServiceProvider` appelle `Fortify::ignoreRoutes()`, donc ces actions ne sont **atteignables par aucune route HTTP** — toute l'auth passe par les contrôleurs Breeze, qui réimplémentent leur propre validation. Deux sources de vérité pour la même politique de mot de passe. C'est la cause du 0 %, et ça mériterait son issue.

## Aucune dépendance ajoutée

`pestphp/pest-plugin-livewire` n'est pas installé et ne l'a pas été : `Livewire::test()` suffit à piloter les pages Filament, le plugin n'apporte qu'un helper.

## Suite

#1339 pose le cliquet à `--min=84` (PR #1351). Une fois cette PR mergée, **il doit passer à 94** — sinon les 10 points gagnés ne sont pas verrouillés et peuvent repartir sans que rien ne bronche.

## Vérifications

| | |
|---|---|
| Suite complète | **1856 passés** (6648 assertions), 35 s en parallèle |
| Couverture | 94,3 % |
| Fichiers de production modifiés | **aucun** |
| Pint / PHPStan | verts |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
